### PR TITLE
Don't test on hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 sudo: false
 


### PR DESCRIPTION
Don't test on hhvm sense  `ARRAY_FILTER_USE_BOTH` constant is not present. 

Or allow it to fail tests maybe?