### PR TITLE
explicitly set user_id as the field name for relations

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -18,7 +18,7 @@ trait HasApiTokens
      */
     public function clients()
     {
-        return $this->hasMany(Client::class);
+        return $this->hasMany(Client::class, 'user_id');
     }
 
     /**
@@ -26,7 +26,7 @@ trait HasApiTokens
      */
     public function tokens()
     {
-        return $this->hasMany(Token::class)->orderBy('created_at', 'desc');
+        return $this->hasMany(Token::class, 'user_id')->orderBy('created_at', 'desc');
     }
 
     /**


### PR DESCRIPTION
If your model is named something other than Users it tries to use that name for the relation. 

For instance mine is called `App\Contact\Person` and it's trying to use `person_id` for queries instead of the `user_id` that is in the schema.