### PR TITLE
Fetch token cookie name from config

### DIFF
--- a/src/ApiTokenCookieFactory.php
+++ b/src/ApiTokenCookieFactory.php
@@ -51,7 +51,7 @@ class ApiTokenCookieFactory
         $expiration = Carbon::now()->addMinutes($config['lifetime']);
 
         return new Cookie(
-            'laravel_token',
+            $this->config->get('session.token_cookie', 'laravel_token'),
             $this->createToken($userId, $csrfToken, $expiration),
             $expiration,
             $config['path'],

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -5,9 +5,17 @@ namespace Laravel\Passport\Http\Middleware;
 use Closure;
 use Illuminate\Http\Response;
 use Laravel\Passport\ApiTokenCookieFactory;
+use Illuminate\Contracts\Config\Repository as Config;
 
 class CreateFreshApiToken
 {
+    /**
+     * The configuration repository implementation.
+     *
+     * @var Config
+     */
+    protected $config;
+
     /**
      * The API token cookie factory instance.
      *
@@ -18,11 +26,13 @@ class CreateFreshApiToken
     /**
      * Create a new middleware instance.
      *
+     * @param  Config  $config
      * @param  ApiTokenCookieFactory  $cookieFactory
      * @return void
      */
-    public function __construct(ApiTokenCookieFactory $cookieFactory)
+    public function __construct(Config $config, ApiTokenCookieFactory $cookieFactory)
     {
+        $this->config = $config;
         $this->cookieFactory = $cookieFactory;
     }
 
@@ -93,7 +103,7 @@ class CreateFreshApiToken
     protected function alreadyContainsToken($response)
     {
         foreach ($response->headers->getCookies() as $cookie) {
-            if ($cookie->getName() === 'laravel_token') {
+            if ($cookie->getName() === $this->config->get('session.token_cookie', 'laravel_token')) {
                 return true;
             }
         }

--- a/tests/ApiTokenCookieFactoryTest.php
+++ b/tests/ApiTokenCookieFactoryTest.php
@@ -19,11 +19,34 @@ class ApiTokenCookieFactoryTest extends PHPUnit_Framework_TestCase
             'domain' => null,
             'secure' => true,
         ]);
+        $config->shouldReceive('get')->with('session.token_cookie', 'laravel_token')->andReturn(
+            'laravel_token'
+        );
         $encrypter = new Encrypter(str_repeat('a', 16));
         $factory = new ApiTokenCookieFactory($config, $encrypter);
 
         $cookie = $factory->make(1, 'token');
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Cookie', $cookie);
+    }
+
+    public function test_cookie_can_be_renamed()
+    {
+        $config = Mockery::mock('Illuminate\Contracts\Config\Repository');
+        $config->shouldReceive('get')->with('session')->andReturn([
+            'lifetime' => 120,
+            'path' => '/',
+            'domain' => null,
+            'secure' => true,
+        ]);
+        $config->shouldReceive('get')->with('session.token_cookie', 'laravel_token')->andReturn(
+            'renamed_cookie'
+        );
+        $encrypter = new Encrypter(str_repeat('a', 16));
+        $factory = new ApiTokenCookieFactory($config, $encrypter);
+
+        $cookie = $factory->make(1, 'token');
+
+        $this->assertTrue($cookie->getName() === 'renamed_cookie');
     }
 }

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -15,13 +15,14 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
 
     public function test_user_can_be_pulled_via_bearer_token()
     {
+        $config = Mockery::mock('Illuminate\Contracts\Config\Repository');
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
         $encrypter = Mockery::mock('Illuminate\Contracts\Encryption\Encrypter');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+        $guard = new TokenGuard($config, $resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -47,13 +48,14 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
         $container->instance('Illuminate\Contracts\Debug\ExceptionHandler', $handler = Mockery::mock());
         $handler->shouldReceive('report')->once()->with(Mockery::type('League\OAuth2\Server\Exception\OAuthServerException'));
 
+        $config = Mockery::mock('Illuminate\Contracts\Config\Repository');
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
         $encrypter = Mockery::mock('Illuminate\Contracts\Encryption\Encrypter');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+        $guard = new TokenGuard($config, $resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -67,13 +69,14 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
 
     public function test_null_is_returned_if_no_user_is_found()
     {
+        $config = Mockery::mock('Illuminate\Contracts\Config\Repository');
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
         $encrypter = Mockery::mock('Illuminate\Contracts\Encryption\Encrypter');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+        $guard = new TokenGuard($config, $resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -87,13 +90,14 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
 
     public function test_users_may_be_retrieved_from_cookies()
     {
+        $config = Mockery::mock('Illuminate\Contracts\Config\Repository');
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
         $encrypter = new Illuminate\Encryption\Encrypter(str_repeat('a', 16));
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+        $guard = new TokenGuard($config, $resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
         $request = Request::create('/');
         $request->headers->set('X-CSRF-TOKEN', 'token');
@@ -104,6 +108,9 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
             ], str_repeat('a', 16)))
         );
 
+        $config->shouldReceive('get')->with('session.token_cookie', 'laravel_token')->andReturn(
+            'laravel_token'
+        );
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
 
         $user = $guard->user($request);
@@ -113,13 +120,14 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
 
     public function test_cookie_xsrf_is_verified_against_header()
     {
+        $config = Mockery::mock('Illuminate\Contracts\Config\Repository');
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
         $encrypter = new Illuminate\Encryption\Encrypter(str_repeat('a', 16));
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+        $guard = new TokenGuard($config, $resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
         $request = Request::create('/');
         $request->headers->set('X-CSRF-TOKEN', 'wrong_token');
@@ -130,6 +138,9 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
             ], str_repeat('a', 16)))
         );
 
+        $config->shouldReceive('get')->with('session.token_cookie', 'laravel_token')->andReturn(
+            'laravel_token'
+        );
         $userProvider->shouldReceive('retrieveById')->never();
 
         $this->assertNull($guard->user($request));
@@ -137,13 +148,14 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
 
     public function test_expired_cookies_may_not_be_used()
     {
+        $config = Mockery::mock('Illuminate\Contracts\Config\Repository');
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
         $encrypter = new Illuminate\Encryption\Encrypter(str_repeat('a', 16));
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+        $guard = new TokenGuard($config, $resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
         $request = Request::create('/');
         $request->headers->set('X-CSRF-TOKEN', 'token');
@@ -154,6 +166,9 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
             ], str_repeat('a', 16)))
         );
 
+        $config->shouldReceive('get')->with('session.token_cookie', 'laravel_token')->andReturn(
+            'laravel_token'
+        );
         $userProvider->shouldReceive('retrieveById')->never();
 
         $this->assertNull($guard->user($request));


### PR DESCRIPTION
Fetch the token cookie name from the config instead of hardcoding it.

Updated tests since the `TokenGuard` constructor has been changed.

Added test to confirm the cookie name can be changed.