### PR TITLE
Enable client credentials grant type

### DIFF
--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Laravel\Passport\Http\Middleware;
+
+use Closure;
+use League\OAuth2\Server\ResourceServer;
+use Illuminate\Auth\AuthenticationException;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+
+class CheckClientCredentials
+{
+    /**
+     * The Resource Server instance.
+     *
+     * @var ResourceServer
+     */
+    private $server;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  ResourceServer  $server
+     * @return void
+     */
+    public function __construct(ResourceServer $server)
+    {
+        $this->server = $server;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $psr = (new DiactorosFactory)->createRequest($request);
+
+        try{
+            $this->server->validateAuthenticatedRequest($psr);
+        } catch (OAuthServerException $e) {
+            throw new AuthenticationException;
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -34,6 +34,8 @@ class CheckClientCredentials
      * @param  \Illuminate\Http\Request $request
      * @param  \Closure $next
      * @return mixed
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
      */
     public function handle($request, Closure $next)
     {

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -14,6 +14,7 @@ use League\OAuth2\Server\Grant\PasswordGrant;
 use Laravel\Passport\Bridge\PersonalAccessGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use Laravel\Passport\Bridge\RefreshTokenRepository;
+use League\OAuth2\Server\Grant\ClientCredentialsGrant;
 
 class PassportServiceProvider extends ServiceProvider
 {
@@ -82,6 +83,10 @@ class PassportServiceProvider extends ServiceProvider
 
                 $server->enableGrantType(
                     new PersonalAccessGrant, new DateInterval('P100Y')
+                );
+
+                $server->enableGrantType(
+                    new ClientCredentialsGrant(), Passport::tokensExpireIn()
                 );
             });
         });


### PR DESCRIPTION
This grant type is useful to allow clients to access data that's not owned by a certain user, for example: searching tweets, listing supported countries, etc...

The PR implements a middleware that can be used to check for client credentials.