### PR TITLE
Add index name to fix compatibility with oracle.

### DIFF
--- a/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -15,7 +15,7 @@ class CreateOauthPersonalAccessClientsTable extends Migration
     {
         Schema::create('oauth_personal_access_clients', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('client_id')->index();
+            $table->integer('client_id')->index('oauth_personal_clients_index');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
In oracle, database object names are limited to 30chars. Having a long table name causes dynamic constraint names to be duplicated. This PR will address that issue when using passport with Oracle like the issue below:

```php
[Yajra\Pdo\Oci8\Exceptions\Oci8Exception]
  Error Code    : 955
  Error Message : ORA-00955: name is already used by an existing object
  Position      : 13
  Statement     : create table oauth_personal_access_clients ( id number(10,0) not null, client_id number(10,0) not null, created_at timestamp null, updated_at timestamp null, constraint oauth_personal_access_clients_ primary key (
  id ) )
  Bindings      : []
```

Thanks!