### PR TITLE
Change identifier of user id by return of method getAuthIdentifier()

### DIFF
--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -46,6 +46,6 @@ class UserRepository implements UserRepositoryInterface
             return;
         }
 
-        return new User($user->id);
+        return new User($user->getAuthIdentifier());
     }
 }


### PR DESCRIPTION
Problem with primary key distinct to "id". Dont save user_id on oauth_access_tokens.