### PR TITLE
fix for #52

### DIFF
--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -68,7 +68,7 @@ class CreateFreshApiToken
      */
     protected function requestShouldReceiveFreshToken($request)
     {
-        return $request->isMethod('GET') && $request->user();
+        return ($request->isMethod('GET') || $request->ajax()) && $request->user();
     }
 
     /**


### PR DESCRIPTION
If the login to the application is performed with ajax and single page application, then it should generate api token cookie, so single page application can consider a successful login.

based on discussion at #52 