### PR TITLE
Allow disallowing star scopes

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -17,6 +17,13 @@ class Passport
     public static $pruneRevokedTokens = false;
 
     /**
+     * Indicates if * scope is allowed.
+     *
+     * @var bool
+     */
+    public static $allowStarScope = true;
+
+    /**
      * The personal access token client ID.
      *
      * @var int
@@ -80,6 +87,18 @@ class Passport
     }
 
     /**
+     * Instruct Passport to disallow the use of * scope.
+     *
+     * @return static
+     */
+    public static function disallowStarScope()
+    {
+        static::$allowStarScope = false;
+
+        return new static;
+    }
+
+    /**
      * Set the client ID that should be used to issue personal access tokens.
      *
      * @param  int  $clientId
@@ -110,7 +129,8 @@ class Passport
      */
     public static function hasScope($id)
     {
-        return $id === '*' || array_key_exists($id, static::$scopes);
+        return (static::$allowStarScope && $id === '*') ||
+               array_key_exists($id, static::$scopes);
     }
 
     /**

--- a/src/Token.php
+++ b/src/Token.php
@@ -71,7 +71,7 @@ class Token extends Model
      */
     public function can($scope)
     {
-        return in_array('*', $this->scopes) ||
+        return (Passport::$allowStarScope && in_array('*', $this->scopes)) ||
                array_key_exists($scope, array_flip($this->scopes));
     }
 

--- a/tests/PassportTest.php
+++ b/tests/PassportTest.php
@@ -14,4 +14,18 @@ class PassportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['user'], Passport::scopeIds());
         $this->assertEquals('user', Passport::scopes()[0]->id);
     }
+
+    public function test_scopes_can_have_star()
+    {
+        $this->assertTrue(Passport::hasScope('*'));
+    }
+
+    public function test_scopes_cannot_have_star_when_disallowed()
+    {
+        Passport::disallowStarScope();
+
+        $this->assertFalse(Passport::hasScope('*'));
+
+        Passport::$allowStarScope = true;
+    }
 }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Laravel\Passport\Passport;
+
 class TokenTest extends PHPUnit_Framework_TestCase
 {
     public function test_token_can_determine_if_it_has_scopes()
@@ -14,5 +16,22 @@ class TokenTest extends PHPUnit_Framework_TestCase
         $token = new Laravel\Passport\Token(['scopes' => ['*']]);
         $this->assertTrue($token->can('user'));
         $this->assertTrue($token->can('something'));
+    }
+
+    public function test_token_cannot_use_star_scopes_if_disallowed()
+    {
+        Passport::disallowStarScope();
+
+        $token = new Laravel\Passport\Token(['scopes' => ['*']]);
+        $this->assertFalse($token->can('user'));
+        $this->assertFalse($token->can('something'));
+        $this->assertTrue($token->cant('something'));
+
+        $token = new Laravel\Passport\Token(['scopes' => ['*', 'user']]);
+        $this->assertTrue($token->can('user'));
+        $this->assertFalse($token->can('something'));
+        $this->assertTrue($token->cant('something'));
+
+        Passport::$allowStarScope = true;
     }
 }


### PR DESCRIPTION
This allows disabling/disallowing the use of star (*) scope.

Some applications may not want to allow the use of issuing tokens with a cover all scope such as the star (*) scope.

In this case those applications can disallow it's use by adding a line into the boot method of their `AuthServiceProvider` as per below:

```php
    /**
     * Register any authentication / authorization services.
     *
     * @return void
     */
    public function boot()
    {
        $this->registerPolicies();

        Passport::disallowStarScope();
    }
```

By default star scope will be allowed and it must be explicitly disallowed.

When disallowed any existing tokens with star scope will no longer work, and any attempts to authorize with a star scope when disallowed will throw a **The requested scope is invalid, unknown, or malformed** error message.