### PR TITLE
Use phpseclib for generating keys

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         "illuminate/http": "~5.3",
         "illuminate/support": "~5.3",
         "league/oauth2-server": "~5.0",
-        "symfony/process": "~3.1",
         "symfony/psr-http-message-bridge": "^0.3.0",
-        "zendframework/zend-diactoros": "~1.0"
+        "zendframework/zend-diactoros": "~1.0",
+        "phpseclib/phpseclib": "^2.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Passport\Console;
 
+use phpseclib\Crypt\RSA;
 use Illuminate\Console\Command;
-use Symfony\Component\Process\Process;
 
 class KeysCommand extends Command
 {
@@ -24,16 +24,15 @@ class KeysCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  RSA  $rsa
      * @return mixed
      */
-    public function handle()
+    public function handle(RSA $rsa)
     {
-        $callback = function ($type, $line) {
-            $this->output->write($line);
-        };
+        $keys = $rsa->createKey(4096);
 
-        (new Process('openssl genrsa -out oauth-private.key 4096', storage_path()))->run($callback);
-        (new Process('openssl rsa -in oauth-private.key -pubout -out oauth-public.key', storage_path()))->run($callback);
+        file_put_contents(storage_path('oauth-private.key'), array_get($keys, 'privatekey'));
+        file_put_contents(storage_path('oauth-public.key'), array_get($keys, 'publickey'));
 
         $this->info('Encryption keys generated successfully.');
     }

--- a/tests/KeysCommandTest.php
+++ b/tests/KeysCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+function storage_path($file = null)
+{
+    return __DIR__ . DIRECTORY_SEPARATOR . $file;
+}
+
+class KeysCommandTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+
+        @unlink(storage_path('oauth-private.key'));
+        @unlink(storage_path('oauth-public.key'));
+    }
+
+    public function testPrivateAndPublicKeysAreGenerated()
+    {
+        $command = Mockery::mock(Laravel\Passport\Console\KeysCommand::class)
+            ->makePartial()
+            ->shouldReceive('info')
+            ->with('Encryption keys generated successfully.')
+            ->getMock();
+
+        $rsa = new phpseclib\Crypt\RSA();
+
+        $command->handle($rsa);
+
+        $this->assertFileExists(storage_path('oauth-private.key'));
+        $this->assertFileExists(storage_path('oauth-public.key'));
+    }
+}


### PR DESCRIPTION
Sometimes the 'openssl' cli utility may not me available, especially on windows this may require some ceremony.

Updated this command to leverage phpseclib instead.