### PR TITLE
Fix first scope checkbox

### DIFF
--- a/resources/assets/js/components/PersonalAccessTokens.vue
+++ b/resources/assets/js/components/PersonalAccessTokens.vue
@@ -258,7 +258,7 @@
              * Determine if the given scope has been assigned to the token.
              */
             scopeIsAssigned(scope) {
-                return _.indexOf(this.form.scopes, scope) > 0;
+                return _.indexOf(this.form.scopes, scope) >= 0;
             },
 
             /**


### PR DESCRIPTION
The first checkbox in the Personal Access Token component can’t be checked.
`_.indexOf()` returns -1, not 0, if it wasn’t found.

My first PR, please tell me if I did something wrong 😳