### PR TITLE
Introduce PassportServiceProvider::$migrate property to allow fallback to publishing migration.

### DIFF
--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -19,6 +19,13 @@ use League\OAuth2\Server\Grant\ClientCredentialsGrant;
 class PassportServiceProvider extends ServiceProvider
 {
     /**
+     * Indicates if migration should be executed (default as `true`) or published.
+     *
+     * @var bool
+     */
+    protected $migrate = true;
+
+    /**
      * Bootstrap the application services.
      *
      * @return void
@@ -28,7 +35,13 @@ class PassportServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'passport');
 
         if ($this->app->runningInConsole()) {
-            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+            if ($this->migrate === true) {
+                $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+            } else {
+                $this->publishes([
+                    __DIR__.'/../database/migrations' => database_path('migrations'),
+                ], 'migrations');
+            }
 
             $this->publishes([
                 __DIR__.'/../resources/views' => base_path('resources/views/vendor/passport'),


### PR DESCRIPTION
By default all packages' Service Provider should be able to load custom migration paths, however the developer of each application
should be able to override this by extending the original service provider. As example:

```php
<?php

namespace App\Providers;

class PassportServiceProvider extends \Laravel\Passport\PassportServiceProvider
{
    protected $migrate = false;
}
```

Signed-off-by: crynobone <crynobone@gmail.com>