### PR TITLE
Use Token model/repository when working with AccessTokenRepository

### DIFF
--- a/src/Bridge/AccessTokenRepository.php
+++ b/src/Bridge/AccessTokenRepository.php
@@ -3,7 +3,7 @@
 namespace Laravel\Passport\Bridge;
 
 use DateTime;
-use Illuminate\Database\Connection;
+use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
@@ -17,7 +17,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      *
      * @var \Illuminate\Database\Connection
      */
-    protected $database;
+    protected $tokenRepository;
 
     /**
      * Create a new repository instance.
@@ -25,9 +25,9 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      * @param  \Illuminate\Database\Connection  $database
      * @return void
      */
-    public function __construct(Connection $database)
+    public function __construct(TokenRepository $tokenRepository)
     {
-        $this->database = $database;
+        $this->tokenRepository = $tokenRepository;
     }
 
     /**
@@ -43,7 +43,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      */
     public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity)
     {
-        $this->database->table('oauth_access_tokens')->insert([
+        $this->tokenRepository->create([
             'id' => $accessTokenEntity->getIdentifier(),
             'user_id' => $accessTokenEntity->getUserIdentifier(),
             'client_id' => $accessTokenEntity->getClient()->getIdentifier(),
@@ -60,8 +60,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      */
     public function revokeAccessToken($tokenId)
     {
-        $this->database->table('oauth_access_tokens')
-                    ->where('id', $tokenId)->update(['revoked' => true]);
+        $this->tokenRepository->revokeAccessToken($tokenId);
     }
 
     /**
@@ -69,7 +68,6 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      */
     public function isAccessTokenRevoked($tokenId)
     {
-        return $this->database->table('oauth_access_tokens')
-                    ->where('id', $tokenId)->where('revoked', 1)->exists();
+        return $this->tokenRepository->isAccessTokenRevoked($tokenId);
     }
 }

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -5,6 +5,17 @@ namespace Laravel\Passport;
 class TokenRepository
 {
     /**
+     * Creates a new Access Token
+     *
+     * @param  array  $attributes
+     * @return Token
+     */
+    public function create($attributes)
+    {
+        return Token::create($attributes);
+    }
+
+    /**
      * Get a token by the given ID.
      *
      * @param  string  $id
@@ -21,9 +32,31 @@ class TokenRepository
      * @param  Token  $token
      * @return void
      */
-    public function save($token)
+    public function save(Token $token)
     {
         $token->save();
+    }
+
+    /**
+     * Revoke an access token.
+     *
+     * @param string $id
+     */
+    public function revokeAccessToken($id)
+    {
+        return $this->find($id)->update(['revoked' => true]);
+    }
+
+    /**
+     * Check if the access token has been revoked.
+     *
+     * @param string $id
+     *
+     * @return bool Return true if this token has been revoked
+     */
+    public function isAccessTokenRevoked($id)
+    {
+        return Token::where('id', $id)->where('revoked', 1)->exists();
     }
 
     /**

--- a/tests/BridgeAccessTokenRepositoryTest.php
+++ b/tests/BridgeAccessTokenRepositoryTest.php
@@ -13,9 +13,9 @@ class BridgeAccessTokenRepositoryTest extends PHPUnit_Framework_TestCase
     {
         $expiration = Carbon::now();
 
-        $database = Mockery::mock('Illuminate\Database\Connection');
+        $tokenRepository = Mockery::mock('Laravel\Passport\TokenRepository');
 
-        $database->shouldReceive('table->insert')->once()->andReturnUsing(function ($array) use ($expiration) {
+        $tokenRepository->shouldReceive('create')->once()->andReturnUsing(function ($array) use ($expiration) {
             $this->assertEquals(1, $array['id']);
             $this->assertEquals(2, $array['user_id']);
             $this->assertEquals('client-id', $array['client_id']);
@@ -31,7 +31,7 @@ class BridgeAccessTokenRepositoryTest extends PHPUnit_Framework_TestCase
         $accessToken->setExpiryDateTime($expiration);
         $accessToken->setClient(new Laravel\Passport\Bridge\Client('client-id', 'name', 'redirect'));
 
-        $repository = new Laravel\Passport\Bridge\AccessTokenRepository($database);
+        $repository = new Laravel\Passport\Bridge\AccessTokenRepository($tokenRepository);
 
         $repository->persistNewAccessToken($accessToken);
     }

--- a/tests/PersonalAccessTokenFactoryTest.php
+++ b/tests/PersonalAccessTokenFactoryTest.php
@@ -39,7 +39,7 @@ class PersonalAccessTokenFactoryTestClientStub
     public $secret = 'something';
 }
 
-class PersonalAccessTokenFactoryTestModelStub extends Illuminate\Database\Eloquent\Model
+class PersonalAccessTokenFactoryTestModelStub extends Laravel\Passport\Token
 {
     public $id = 1;
     public $secret = 'something';


### PR DESCRIPTION
This replaces the usage of using the Database Connection in favor of TokenRepository which then calls `Token` directly.

A big benefit of this is so that Model events can be observed when creating Access Tokens.

I believe this would cover at least part of [Issue #77](https://github.com/laravel/passport/issues/77).