### PR TITLE
Ability to load keys from a custom location

### DIFF
--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Console;
 
 use phpseclib\Crypt\RSA;
+use Laravel\Passport\Passport;
 use Illuminate\Console\Command;
 
 class KeysCommand extends Command
@@ -31,8 +32,8 @@ class KeysCommand extends Command
     {
         $keys = $rsa->createKey(4096);
 
-        file_put_contents(storage_path('oauth-private.key'), array_get($keys, 'privatekey'));
-        file_put_contents(storage_path('oauth-public.key'), array_get($keys, 'publickey'));
+        file_put_contents(Passport::keysPath('oauth-private.key'), array_get($keys, 'privatekey'));
+        file_put_contents(Passport::keysPath('oauth-public.key'), array_get($keys, 'publickey'));
 
         $this->info('Encryption keys generated successfully.');
     }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -47,6 +47,13 @@ class Passport
     public static $refreshTokensExpireAt;
 
     /**
+     * The location of the encryption keys.
+     *
+     * @var bool
+     */
+    public static $keysLocation;
+
+    /**
      * Get a Passport route registrar.
      *
      * @param  array  $options
@@ -189,5 +196,31 @@ class Passport
         }
 
         return new static;
+    }
+
+    /**
+     * Set the location of the encryption keys.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public static function loadKeysFrom($path)
+    {
+        static::$keysLocation = $path;
+    }
+
+    /**
+     * The location of the encryption keys.
+     *
+     * @param $file
+     * @return string
+     */
+    public static function keysPath($file)
+    {
+        $file = ltrim($file, "/\\");
+
+        return static::$keysLocation
+            ? rtrim(static::$keysLocation, "/\\").DIRECTORY_SEPARATOR.$file
+            : storage_path($file);
     }
 }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -160,8 +160,8 @@ class PassportServiceProvider extends ServiceProvider
             $this->app->make(Bridge\ClientRepository::class),
             $this->app->make(Bridge\AccessTokenRepository::class),
             $this->app->make(Bridge\ScopeRepository::class),
-            'file://'.storage_path('oauth-private.key'),
-            'file://'.storage_path('oauth-public.key')
+            'file://'.Passport::keysPath('oauth-private.key'),
+            'file://'.Passport::keysPath('oauth-public.key')
         );
     }
 
@@ -175,7 +175,7 @@ class PassportServiceProvider extends ServiceProvider
         $this->app->singleton(ResourceServer::class, function () {
             return new ResourceServer(
                 $this->app->make(Bridge\AccessTokenRepository::class),
-                'file://'.storage_path('oauth-public.key')
+                'file://'.Passport::keysPath('oauth-public.key')
             );
         });
     }

--- a/tests/KeysCommandTest.php
+++ b/tests/KeysCommandTest.php
@@ -5,6 +5,11 @@ function storage_path($file = null)
     return __DIR__ . DIRECTORY_SEPARATOR . $file;
 }
 
+function custom_path($file = null)
+{
+    return __DIR__.DIRECTORY_SEPARATOR.'files'.DIRECTORY_SEPARATOR.$file;
+}
+
 class KeysCommandTest extends PHPUnit_Framework_TestCase
 {
     public function tearDown()
@@ -13,6 +18,8 @@ class KeysCommandTest extends PHPUnit_Framework_TestCase
 
         @unlink(storage_path('oauth-private.key'));
         @unlink(storage_path('oauth-public.key'));
+        @unlink(custom_path('oauth-private.key'));
+        @unlink(custom_path('oauth-public.key'));
     }
 
     public function testPrivateAndPublicKeysAreGenerated()
@@ -29,5 +36,23 @@ class KeysCommandTest extends PHPUnit_Framework_TestCase
 
         $this->assertFileExists(storage_path('oauth-private.key'));
         $this->assertFileExists(storage_path('oauth-public.key'));
+    }
+
+    public function testPrivateAndPublicKeysAreGeneratedInCustomPath()
+    {
+        \Laravel\Passport\Passport::loadKeysFrom(custom_path());
+
+        $command = Mockery::mock(Laravel\Passport\Console\KeysCommand::class)
+            ->makePartial()
+            ->shouldReceive('info')
+            ->with('Encryption keys generated successfully.')
+            ->getMock();
+
+        $rsa = new phpseclib\Crypt\RSA();
+
+        $command->handle($rsa);
+
+        $this->assertFileExists(custom_path('oauth-private.key'));
+        $this->assertFileExists(custom_path('oauth-public.key'));
     }
 }

--- a/tests/files/.gitignore
+++ b/tests/files/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Adding the ability to load keys from a custom location:

```
Passport::loadKeysFrom('/var/http/path/to/files');
```

If not set, Passport will look for the keys inside `storage_path()` by default.