### PR TITLE
Replace connection instance with repositories and add support to change the database connection name

### DIFF
--- a/src/AuthCodeRepository.php
+++ b/src/AuthCodeRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Laravel\Passport;
+
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+
+class AuthCodeRepository
+{
+    /**
+     * Get a auth code by the given ID.
+     *
+     * @param  int  $id
+     * @return AuthCode|null
+     */
+    public function find($id)
+    {
+        return AuthCode::on(Passport::$connectionName)->find($id);
+    }
+
+    /**
+     * Store a new auth code.
+     *
+     * @param  array  $attributes
+     * @return AuthCode
+     */
+    public function create(array $attributes)
+    {
+        $authCode = (new AuthCode)->on(Passport::$connectionName)
+            ->forceFill($attributes)
+            ->save();
+
+        return $authCode;
+    }
+
+    /**
+     * Revoke an auth code.
+     *
+     * @param  string  $id
+     * @return bool|int
+     */
+    public function revoke($id)
+    {
+        return $this->find($id)->update(['revoked' => true]);
+    }
+
+    /**
+     * Determine if the given auth code is revoked.
+     *
+     * @param  int  $id
+     * @return bool
+     */
+    public function revoked($id)
+    {
+        return AuthCode::on(Passport::$connectionName)
+            ->where('id', $id)
+            ->where('revoked', true)
+            ->exists();
+    }
+}

--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
-use Illuminate\Database\Connection;
+use Laravel\Passport\AuthCodeRepository as AuthCodeModelRepository;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 
@@ -11,21 +11,21 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
     use FormatsScopesForStorage;
 
     /**
-     * The database connection.
+     * The auth code model repository.
      *
-     * @var \Illuminate\Database\Connection
+     * @var \Laravel\Passport\AuthCodeRepository
      */
-    protected $database;
+    protected $authCodes;
 
     /**
      * Create a new repository instance.
      *
-     * @param  \Illuminate\Database\Connection  $database
+     * @param  \Laravel\Passport\AuthCodeRepository  $authCodes
      * @return void
      */
-    public function __construct(Connection $database)
+    public function __construct(AuthCodeModelRepository $authCodes)
     {
-        $this->database = $database;
+        $this->authCodes = $authCodes;
     }
 
     /**
@@ -41,7 +41,7 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity)
     {
-        $this->database->table('oauth_auth_codes')->insert([
+        $this->authCodes->create([
             'id' => $authCodeEntity->getIdentifier(),
             'user_id' => $authCodeEntity->getUserIdentifier(),
             'client_id' => $authCodeEntity->getClient()->getIdentifier(),
@@ -56,8 +56,7 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function revokeAuthCode($codeId)
     {
-        $this->database->table('oauth_auth_codes')
-                    ->where('id', $codeId)->update(['revoked' => true]);
+        $this->authCodes->revoke($codeId);
     }
 
     /**
@@ -65,7 +64,6 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function isAuthCodeRevoked($codeId)
     {
-        return $this->database->table('oauth_auth_codes')
-                    ->where('id', $codeId)->where('revoked', 1)->exists();
+        return $this->authCodes->revoked($codeId);
     }
 }

--- a/src/Bridge/RefreshTokenRepository.php
+++ b/src/Bridge/RefreshTokenRepository.php
@@ -2,28 +2,28 @@
 
 namespace Laravel\Passport\Bridge;
 
-use Illuminate\Database\Connection;
+use Laravel\Passport\RefreshTokenRepository as RefreshTokenModelRepository;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 
 class RefreshTokenRepository implements RefreshTokenRepositoryInterface
 {
     /**
-     * The database connection.
+     * The refresh token model repository.
      *
-     * @var \Illuminate\Database\Connection
+     * @var \Laravel\Passport\RefreshTokenRepository
      */
-    protected $database;
+    protected $refreshTokens;
 
     /**
      * Create a new repository instance.
      *
-     * @param  \Illuminate\Database\Connection  $database
+     * @param  \Laravel\Passport\RefreshTokenRepository  $refreshTokens
      * @return void
      */
-    public function __construct(Connection $database)
+    public function __construct(RefreshTokenModelRepository $refreshTokens)
     {
-        $this->database = $database;
+        $this->refreshTokens = $refreshTokens;
     }
 
     /**
@@ -39,7 +39,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
      */
     public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity)
     {
-        $this->database->table('oauth_refresh_tokens')->insert([
+        $this->refreshTokens->create([
             'id' => $refreshTokenEntity->getIdentifier(),
             'access_token_id' => $refreshTokenEntity->getAccessToken()->getIdentifier(),
             'revoked' => false,
@@ -52,8 +52,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
      */
     public function revokeRefreshToken($tokenId)
     {
-        $this->database->table('oauth_refresh_tokens')
-                    ->where('id', $tokenId)->update(['revoked' => true]);
+        $this->refreshTokens->revoke($tokenId);
     }
 
     /**
@@ -61,7 +60,6 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
      */
     public function isRefreshTokenRevoked($tokenId)
     {
-        return $this->database->table('oauth_refresh_tokens')
-                    ->where('id', $tokenId)->where('revoked', 1)->exists();
+        return $this->refreshTokens->revoked($tokenId);
     }
 }

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -12,7 +12,8 @@ class ClientRepository
      */
     public function find($id)
     {
-        return Client::find($id);
+        return Client::on(Passport::$connectionName)
+                        ->find($id);
     }
 
     /**
@@ -36,8 +37,10 @@ class ClientRepository
      */
     public function forUser($userId)
     {
-        return Client::where('user_id', $userId)
-                        ->orderBy('name', 'desc')->get();
+        return Client::on(Passport::$connectionName)
+                        ->where('user_id', $userId)
+                        ->orderBy('name', 'desc')
+                        ->get();
     }
 
     /**
@@ -61,9 +64,11 @@ class ClientRepository
     public function personalAccessClient()
     {
         if (Passport::$personalAccessClient) {
-            return Client::find(Passport::$personalAccessClient);
+            return Client::on(Passport::$connectionName)
+                            ->find(Passport::$personalAccessClient);
         } else {
-            return PersonalAccessClient::orderBy('id', 'desc')->first()->client;
+            return PersonalAccessClient::on(Passport::$connectionName)
+                            ->orderBy('id', 'desc')->first()->client;
         }
     }
 
@@ -79,7 +84,7 @@ class ClientRepository
      */
     public function create($userId, $name, $redirect, $personalAccess = false, $password = false)
     {
-        $client = (new Client)->forceFill([
+        $client = (new Client)->on(Passport::$connectionName)->forceFill([
             'user_id' => $userId,
             'name' => $name,
             'secret' => str_random(40),
@@ -160,7 +165,8 @@ class ClientRepository
      */
     public function revoked($id)
     {
-        return Client::where('id', $id)
+        return Client::on(Passport::$connectionName)
+                ->where('id', $id)
                 ->where('revoked', true)->exists();
     }
 

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -47,6 +47,13 @@ class Passport
     public static $refreshTokensExpireAt;
 
     /**
+     * The connection name used during queries.
+     *
+     * @var string
+     */
+    public static $connectionName;
+
+    /**
      * Get a Passport route registrar.
      *
      * @param  array  $options
@@ -187,6 +194,29 @@ class Passport
         } else {
             static::$refreshTokensExpireAt = $date;
         }
+
+        return new static;
+    }
+
+    /**
+     * Get the connection name used during queries.
+     *
+     * @return null|string
+     */
+    public static function getConnectionName()
+    {
+        return static::$connectionName;
+    }
+
+    /**
+     * Set the connection name used during queries.
+     *
+     * @param  null|string  $connectionName
+     * @return static
+     */
+    public static function setConnectionName($connectionName)
+    {
+        static::$connectionName = $connectionName;
 
         return new static;
     }

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Passport;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RefreshToken extends Model
+{
+    /**
+     * The database table used by the model.
+     *
+     * @var string
+     */
+    protected $table = 'oauth_refresh_tokens';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The guarded attributes on the model.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'revoked' => 'bool',
+    ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'expires_at',
+    ];
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * Get the access token that the refresh token belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function accessToken()
+    {
+        return $this->belongsTo(Token::class);
+    }
+
+    /**
+     * Revoke the token instance.
+     *
+     * @return void
+     */
+    public function revoke()
+    {
+        $this->forceFill(['revoked' => true])->save();
+    }
+
+    /**
+     * Determine if the token is a transient JWT token.
+     *
+     * @return bool
+     */
+    public function transient()
+    {
+        return false;
+    }
+}

--- a/src/RefreshTokenRepository.php
+++ b/src/RefreshTokenRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Laravel\Passport;
+
+class RefreshTokenRepository
+{
+    /**
+     * Get a token by the given ID.
+     *
+     * @param  string  $id
+     * @return RefreshToken
+     */
+    public function find($id)
+    {
+        return RefreshToken::on(Passport::$connectionName)->find($id);
+    }
+
+    /**
+     * Creates a new Access Token
+     *
+     * @param  array  $attributes
+     * @return RefreshToken
+     */
+    public function create(array $attributes)
+    {
+        $authCode = (new RefreshToken)->on(Passport::$connectionName)
+            ->forceFill($attributes)
+            ->save();
+
+        return $authCode;
+    }
+
+    /**
+     * Revoke a refresh token.
+     *
+     * @param  string  $id
+     * @return bool|int
+     */
+    public function revoke($id)
+    {
+        return $this->find($id)->update(['revoked' => true]);
+    }
+
+    /**
+     * Check if the given refresh token has been revoked.
+     *
+     * @param  string  $id
+     * @return bool
+     */
+    public function revoked($id)
+    {
+        return RefreshToken::on(Passport::$connectionName)
+            ->where('id', $id)
+            ->where('revoked', 1)
+            ->exists();
+    }
+}

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -12,7 +12,7 @@ class TokenRepository
      */
     public function create($attributes)
     {
-        return Token::create($attributes);
+        return Token::on(Passport::$connectionName)->create($attributes);
     }
 
     /**
@@ -23,7 +23,7 @@ class TokenRepository
      */
     public function find($id)
     {
-        return Token::find($id);
+        return Token::on(Passport::$connectionName)->find($id);
     }
 
     /**
@@ -56,7 +56,10 @@ class TokenRepository
      */
     public function isAccessTokenRevoked($id)
     {
-        return Token::where('id', $id)->where('revoked', 1)->exists();
+        return Token::on(Passport::$connectionName)
+            ->where('id', $id)
+            ->where('revoked', 1)
+            ->exists();
     }
 
     /**
@@ -69,8 +72,9 @@ class TokenRepository
      */
     public function revokeOtherAccessTokens($clientId, $userId, $except = null, $prune = false)
     {
-        $query = Token::where('user_id', $userId)
-                      ->where('client_id', $clientId);
+        $query = Token::on(Passport::$connectionName)
+            ->where('user_id', $userId)
+            ->where('client_id', $clientId);
 
         if ($except) {
             $query->where('id', '<>', $except);


### PR DESCRIPTION
This replaces the usage of Database Connection instances for the auth codes and refresh tokens in favor of repositories, similar to: laravel/passport:#90

And this adds the ability to change the connection name used during queries using `Passport::setConnectionName('name-here')`.
_This somewhat resolves my issue mentioned here: laravel/framework#15597_