### PR TITLE
Added support for custom primary key names on user models, resolves: #106

### DIFF
--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -2,11 +2,12 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
-use Laravel\Passport\Client;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
-use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 
 class ClientController
 {
@@ -46,7 +47,9 @@ class ClientController
      */
     public function forUser(Request $request)
     {
-        return $this->clients->activeForUser($request->user()->id)->makeVisible('secret');
+        $userId = $request->user() instanceof Model ? $request->user()->getKey() : $request->user()->id;
+
+        return $this->clients->activeForUser($userId)->makeVisible('secret');
     }
 
     /**
@@ -62,8 +65,10 @@ class ClientController
             'redirect' => 'required|url',
         ])->validate();
 
+        $userId = $request->user() instanceof Model ? $request->user()->getKey() : $request->user()->id;
+
         return $this->clients->create(
-            $request->user()->id, $request->name, $request->redirect
+            $userId, $request->name, $request->redirect
         )->makeVisible('secret');
     }
 

--- a/src/Http/Controllers/RetrievesAuthRequestFromSession.php
+++ b/src/Http/Controllers/RetrievesAuthRequestFromSession.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Http\Controllers;
 
 use Exception;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Laravel\Passport\Bridge\User;
 
@@ -21,7 +22,9 @@ trait RetrievesAuthRequestFromSession
                 throw new Exception('Authorization request was not present in the session.');
             }
 
-            $authRequest->setUser(new User($request->user()->id));
+            $userId = $request->user() instanceof Model ? $request->user()->getKey() : $request->user()->id;
+
+            $authRequest->setUser(new User($userId));
 
             $authRequest->setAuthorizationApproved(true);
         });


### PR DESCRIPTION
As discussed in #106, using `$request->user()->id` wont work when using a different primary key name instead of the default `id`.

Since Eloquent models have support for custom key names, we can simply check if we are dealing with an Eloquent model and use the `getKey()` helper instead.
Because we can change the user model using the `auth.php` config and thereby potentially also change the type, ie. not an Eloquent instance, we fallback on using `->id` to directly fetch the preferred default value.

@taylorotwell As requested on #107 now with a longer description.