### PR TITLE
Replaced Database Connection instances and added the ability to easily swap models

### DIFF
--- a/src/AuthCode.php
+++ b/src/AuthCode.php
@@ -39,12 +39,42 @@ class AuthCode extends Model
     ];
 
     /**
+     * The client relation model.
+     *
+     * @var string
+     */
+    protected static $clientModel = Client::class;
+
+    /**
      * Get the client that owns the authentication code.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function client()
     {
-        return $this->hasMany(Client::class);
+        return $this->hasMany(static::$clientModel);
+    }
+
+    /**
+     * Get the client model.
+     *
+     * @return mixed
+     */
+    public static function getClientModel()
+    {
+        return static::$clientModel;
+    }
+
+    /**
+     * Set the client model.
+     *
+     * @param  mixed  $clientModel
+     * @return static
+     */
+    public static function setClientModel($clientModel)
+    {
+        static::$clientModel = $clientModel;
+
+        return new static;
     }
 }

--- a/src/AuthCodeRepository.php
+++ b/src/AuthCodeRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Laravel\Passport;
+
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+
+class AuthCodeRepository
+{
+    /**
+     * Get a auth code by the given ID.
+     *
+     * @param  int  $id
+     * @return AuthCode|null
+     */
+    public function find($id)
+    {
+        return AuthCode::find($id);
+    }
+
+    /**
+     * Store a new auth code.
+     *
+     * @param  array  $attributes
+     * @return AuthCode
+     */
+    public function create(array $attributes)
+    {
+        $authCode = (new AuthCode)->forceFill($attributes);
+
+        $authCode->save();
+
+        return $authCode;
+    }
+
+    /**
+     * Revoke an auth code.
+     *
+     * @param  string  $id
+     * @return bool|int
+     */
+    public function revoke($id)
+    {
+        return $this->find($id)->update(['revoked' => true]);
+    }
+
+    /**
+     * Determine if the given auth code is revoked.
+     *
+     * @param  int  $id
+     * @return bool
+     */
+    public function revoked($id)
+    {
+        return AuthCode::where('id', $id)->where('revoked', true)->exists();
+    }
+}

--- a/src/AuthCodeRepository.php
+++ b/src/AuthCodeRepository.php
@@ -6,6 +6,15 @@ use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 
 class AuthCodeRepository
 {
+    use RepositoryHelper;
+
+    /**
+     * The auth code model.
+     *
+     * @var string
+     */
+    protected static $model = AuthCode::class;
+
     /**
      * Get a auth code by the given ID.
      *
@@ -14,7 +23,7 @@ class AuthCodeRepository
      */
     public function find($id)
     {
-        return AuthCode::find($id);
+        return $this->createModel()->find($id);
     }
 
     /**
@@ -25,7 +34,7 @@ class AuthCodeRepository
      */
     public function create(array $attributes)
     {
-        $authCode = (new AuthCode)->forceFill($attributes);
+        $authCode = $this->createModel()->forceFill($attributes);
 
         $authCode->save();
 
@@ -51,6 +60,27 @@ class AuthCodeRepository
      */
     public function revoked($id)
     {
-        return AuthCode::where('id', $id)->where('revoked', true)->exists();
+        return $this->createModel()
+            ->where('id', $id)
+            ->where('revoked', true)
+            ->exists();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getModel()
+    {
+        return static::$model;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setModel($model)
+    {
+        static::$model = $model;
+
+        return new static;
     }
 }

--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
-use Illuminate\Database\Connection;
+use Laravel\Passport\AuthCodeRepository as AuthCodeModelRepository;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 
@@ -11,21 +11,21 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
     use FormatsScopesForStorage;
 
     /**
-     * The database connection.
+     * The auth code model repository.
      *
-     * @var \Illuminate\Database\Connection
+     * @var \Laravel\Passport\AuthCodeRepository
      */
-    protected $database;
+    protected $authCodes;
 
     /**
      * Create a new repository instance.
      *
-     * @param  \Illuminate\Database\Connection  $database
+     * @param  \Laravel\Passport\AuthCodeRepository  $authCodes
      * @return void
      */
-    public function __construct(Connection $database)
+    public function __construct(AuthCodeModelRepository $authCodes)
     {
-        $this->database = $database;
+        $this->authCodes = $authCodes;
     }
 
     /**
@@ -41,7 +41,7 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity)
     {
-        $this->database->table('oauth_auth_codes')->insert([
+        $this->authCodes->create([
             'id' => $authCodeEntity->getIdentifier(),
             'user_id' => $authCodeEntity->getUserIdentifier(),
             'client_id' => $authCodeEntity->getClient()->getIdentifier(),
@@ -56,8 +56,7 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function revokeAuthCode($codeId)
     {
-        $this->database->table('oauth_auth_codes')
-                    ->where('id', $codeId)->update(['revoked' => true]);
+        $this->authCodes->revoke($codeId);
     }
 
     /**
@@ -65,7 +64,6 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function isAuthCodeRevoked($codeId)
     {
-        return $this->database->table('oauth_auth_codes')
-                    ->where('id', $codeId)->where('revoked', 1)->exists();
+        return $this->authCodes->revoked($codeId);
     }
 }

--- a/src/Bridge/RefreshTokenRepository.php
+++ b/src/Bridge/RefreshTokenRepository.php
@@ -2,28 +2,28 @@
 
 namespace Laravel\Passport\Bridge;
 
-use Illuminate\Database\Connection;
+use Laravel\Passport\RefreshTokenRepository as RefreshTokenModelRepository;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 
 class RefreshTokenRepository implements RefreshTokenRepositoryInterface
 {
     /**
-     * The database connection.
+     * The refresh token model repository.
      *
-     * @var \Illuminate\Database\Connection
+     * @var \Laravel\Passport\RefreshTokenRepository
      */
-    protected $database;
+    protected $refreshTokens;
 
     /**
      * Create a new repository instance.
      *
-     * @param  \Illuminate\Database\Connection  $database
+     * @param  \Laravel\Passport\RefreshTokenRepository  $refreshTokens
      * @return void
      */
-    public function __construct(Connection $database)
+    public function __construct(RefreshTokenModelRepository $refreshTokens)
     {
-        $this->database = $database;
+        $this->refreshTokens = $refreshTokens;
     }
 
     /**
@@ -39,7 +39,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
      */
     public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity)
     {
-        $this->database->table('oauth_refresh_tokens')->insert([
+        $this->refreshTokens->create([
             'id' => $refreshTokenEntity->getIdentifier(),
             'access_token_id' => $refreshTokenEntity->getAccessToken()->getIdentifier(),
             'revoked' => false,
@@ -52,8 +52,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
      */
     public function revokeRefreshToken($tokenId)
     {
-        $this->database->table('oauth_refresh_tokens')
-                    ->where('id', $tokenId)->update(['revoked' => true]);
+        $this->refreshTokens->revoke($tokenId);
     }
 
     /**
@@ -61,7 +60,6 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
      */
     public function isRefreshTokenRevoked($tokenId)
     {
-        return $this->database->table('oauth_refresh_tokens')
-                    ->where('id', $tokenId)->where('revoked', 1)->exists();
+        return $this->refreshTokens->revoked($tokenId);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -41,13 +41,27 @@ class Client extends Model
     ];
 
     /**
+     * The auth code relation model.
+     *
+     * @var string
+     */
+    protected static $authCodeModel = AuthCode::class;
+
+    /**
+     * The access token relation model.
+     *
+     * @var string
+     */
+    protected static $tokenModel = Token::class;
+
+    /**
      * Get all of the authentication codes for the client.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function authCodes()
     {
-        return $this->hasMany(AuthCode::class);
+        return $this->hasMany(static::$authCodeModel);
     }
 
     /**
@@ -57,7 +71,7 @@ class Client extends Model
      */
     public function tokens()
     {
-        return $this->hasMany(Token::class);
+        return $this->hasMany(static::$tokenModel);
     }
 
     /**
@@ -68,5 +82,51 @@ class Client extends Model
     public function firstParty()
     {
         return $this->personal_access_client || $this->password_client;
+    }
+
+    /**
+     * Get the auth code model.
+     *
+     * @return mixed
+     */
+    public static function getAuthCodeModel()
+    {
+        return static::$authCodeModel;
+    }
+
+    /**
+     * Set the auth code model.
+     *
+     * @param  mixed  $authCodeModel
+     * @return static
+     */
+    public static function setAuthCodeModel($authCodeModel)
+    {
+        static::$authCodeModel = $authCodeModel;
+
+        return new static;
+    }
+
+    /**
+     * Get the token model.
+     *
+     * @return mixed
+     */
+    public static function getTokenModel()
+    {
+        return static::$tokenModel;
+    }
+
+    /**
+     * Set the token model.
+     *
+     * @param  mixed  $tokenModel
+     * @return static
+     */
+    public static function setTokenModel($tokenModel)
+    {
+        static::$tokenModel = $tokenModel;
+
+        return new static;
     }
 }

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -4,6 +4,22 @@ namespace Laravel\Passport;
 
 class ClientRepository
 {
+    use RepositoryHelper;
+
+    /**
+     * The client model.
+     *
+     * @var string
+     */
+    protected static $model = Client::class;
+
+    /**
+     * The personal access client model.
+     *
+     * @var mixed
+     */
+    protected static $personalAccessClientModel = PersonalAccessClient::class;
+
     /**
      * Get a client by the given ID.
      *
@@ -12,7 +28,7 @@ class ClientRepository
      */
     public function find($id)
     {
-        return Client::find($id);
+        return $this->createModel()->find($id);
     }
 
     /**
@@ -36,8 +52,10 @@ class ClientRepository
      */
     public function forUser($userId)
     {
-        return Client::where('user_id', $userId)
-                        ->orderBy('name', 'desc')->get();
+        return $this->createModel()
+            ->where('user_id', $userId)
+            ->orderBy('name', 'desc')
+            ->get();
     }
 
     /**
@@ -61,9 +79,9 @@ class ClientRepository
     public function personalAccessClient()
     {
         if (Passport::$personalAccessClient) {
-            return Client::find(Passport::$personalAccessClient);
+            return $this->find(Passport::$personalAccessClient);
         } else {
-            return PersonalAccessClient::orderBy('id', 'desc')->first()->client;
+            return $this->createPersonalAccessClientModel()->orderBy('id', 'desc')->first()->client;
         }
     }
 
@@ -79,7 +97,7 @@ class ClientRepository
      */
     public function create($userId, $name, $redirect, $personalAccess = false, $password = false)
     {
-        $client = (new Client)->forceFill([
+        $client = $this->createModel()->forceFill([
             'user_id' => $userId,
             'name' => $name,
             'secret' => str_random(40),
@@ -160,8 +178,10 @@ class ClientRepository
      */
     public function revoked($id)
     {
-        return Client::where('id', $id)
-                ->where('revoked', true)->exists();
+        return $this->createModel()
+            ->where('id', $id)
+            ->where('revoked', true)
+            ->exists();
     }
 
     /**
@@ -175,5 +195,65 @@ class ClientRepository
         $client->tokens()->update(['revoked' => true]);
 
         $client->forceFill(['revoked' => true])->save();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getModel()
+    {
+        return static::$model;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setModel($model)
+    {
+        static::$model = $model;
+
+        return new static;
+    }
+
+    /**
+     * Get the personal access client model.
+     *
+     * @return mixed
+     */
+    public static function getPersonalAccessClientModel()
+    {
+        return static::$personalAccessClientModel;
+    }
+
+    /**
+     * Set the personal access client model.
+     *
+     * @param  mixed  $personalAccessClientModel
+     * @return static
+     */
+    public static function setPersonalAccessClientModel($personalAccessClientModel)
+    {
+        static::$personalAccessClientModel = $personalAccessClientModel;
+
+        return new static;
+    }
+
+    /**
+     * Create a new personal access client model instance.
+     *
+     * @param  array  $attributes  Optional array of model attributes.
+     * @return mixed
+     */
+    public function createPersonalAccessClientModel(array $attributes = [])
+    {
+        if (is_string($model = $this->getPersonalAccessClientModel())) {
+            if (! class_exists($class = '\\'.ltrim($model, '\\'))) {
+                throw new RuntimeException("Class {$model} does not exist!");
+            }
+
+            $model = new $model($attributes);
+        }
+
+        return $model;
     }
 }

--- a/src/PersonalAccessClient.php
+++ b/src/PersonalAccessClient.php
@@ -21,12 +21,42 @@ class PersonalAccessClient extends Model
     protected $guarded = [];
 
     /**
+     * The client relation model.
+     *
+     * @var string
+     */
+    protected static $clientModel = Client::class;
+
+    /**
      * Get all of the authentication codes for the client.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function client()
     {
-        return $this->belongsTo(Client::class);
+        return $this->belongsTo(static::$clientModel);
+    }
+
+    /**
+     * Get the client model.
+     *
+     * @return mixed
+     */
+    public static function getClientModel()
+    {
+        return static::$clientModel;
+    }
+
+    /**
+     * Set the client model.
+     *
+     * @param  mixed  $clientModel
+     * @return static
+     */
+    public static function setClientModel($clientModel)
+    {
+        static::$clientModel = $clientModel;
+
+        return new static;
     }
 }

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -53,13 +53,20 @@ class RefreshToken extends Model
     public $timestamps = false;
 
     /**
+     * The access token relation model.
+     *
+     * @var string
+     */
+    protected static $tokenModel = Token::class;
+
+    /**
      * Get the access token that the refresh token belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function accessToken()
     {
-        return $this->belongsTo(Token::class);
+        return $this->belongsTo(static::$tokenModel);
     }
 
     /**
@@ -80,5 +87,28 @@ class RefreshToken extends Model
     public function transient()
     {
         return false;
+    }
+
+    /**
+     * Get the token model.
+     *
+     * @return mixed
+     */
+    public static function getTokenModel()
+    {
+        return static::$tokenModel;
+    }
+
+    /**
+     * Set the token model.
+     *
+     * @param  mixed  $tokenModel
+     * @return static
+     */
+    public static function setTokenModel($tokenModel)
+    {
+        static::$tokenModel = $tokenModel;
+
+        return new static;
     }
 }

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Passport;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RefreshToken extends Model
+{
+    /**
+     * The database table used by the model.
+     *
+     * @var string
+     */
+    protected $table = 'oauth_refresh_tokens';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The guarded attributes on the model.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'revoked' => 'bool',
+    ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'expires_at',
+    ];
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * Get the access token that the refresh token belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function accessToken()
+    {
+        return $this->belongsTo(Token::class);
+    }
+
+    /**
+     * Revoke the token instance.
+     *
+     * @return void
+     */
+    public function revoke()
+    {
+        $this->forceFill(['revoked' => true])->save();
+    }
+
+    /**
+     * Determine if the token is a transient JWT token.
+     *
+     * @return bool
+     */
+    public function transient()
+    {
+        return false;
+    }
+}

--- a/src/RefreshTokenRepository.php
+++ b/src/RefreshTokenRepository.php
@@ -4,6 +4,15 @@ namespace Laravel\Passport;
 
 class RefreshTokenRepository
 {
+    use RepositoryHelper;
+
+    /**
+     * The refresh token model.
+     *
+     * @var string
+     */
+    protected static $model = RefreshToken::class;
+
     /**
      * Get a token by the given ID.
      *
@@ -12,7 +21,7 @@ class RefreshTokenRepository
      */
     public function find($id)
     {
-        return RefreshToken::find($id);
+        return $this->createModel()->find($id);
     }
 
     /**
@@ -23,7 +32,8 @@ class RefreshTokenRepository
      */
     public function create(array $attributes)
     {
-        $authCode = (new RefreshToken)->forceFill($attributes)
+        $authCode = $this->createModel()
+            ->forceFill($attributes)
             ->save();
 
         return $authCode;
@@ -48,6 +58,27 @@ class RefreshTokenRepository
      */
     public function revoked($id)
     {
-        return RefreshToken::where('id', $id)->where('revoked', 1)->exists();
+        return $this->createModel()
+            ->where('id', $id)
+            ->where('revoked', 1)
+            ->exists();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getModel()
+    {
+        return static::$model;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setModel($model)
+    {
+        static::$model = $model;
+
+        return new static;
     }
 }

--- a/src/RefreshTokenRepository.php
+++ b/src/RefreshTokenRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Laravel\Passport;
+
+class RefreshTokenRepository
+{
+    /**
+     * Get a token by the given ID.
+     *
+     * @param  string  $id
+     * @return RefreshToken
+     */
+    public function find($id)
+    {
+        return RefreshToken::find($id);
+    }
+
+    /**
+     * Creates a new Access Token
+     *
+     * @param  array  $attributes
+     * @return RefreshToken
+     */
+    public function create(array $attributes)
+    {
+        $authCode = (new RefreshToken)->forceFill($attributes)
+            ->save();
+
+        return $authCode;
+    }
+
+    /**
+     * Revoke a refresh token.
+     *
+     * @param  string  $id
+     * @return bool|int
+     */
+    public function revoke($id)
+    {
+        return $this->find($id)->update(['revoked' => true]);
+    }
+
+    /**
+     * Check if the given refresh token has been revoked.
+     *
+     * @param  string  $id
+     * @return bool
+     */
+    public function revoked($id)
+    {
+        return RefreshToken::where('id', $id)->where('revoked', 1)->exists();
+    }
+}

--- a/src/RepositoryHelper.php
+++ b/src/RepositoryHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Passport;
+
+use RuntimeException;
+
+trait RepositoryHelper
+{
+    /**
+     * Create a new model instance.
+     *
+     * @param  array  $attributes  Optional array of model attributes.
+     * @return mixed
+     */
+    public function createModel(array $attributes = [])
+    {
+        if (is_string($model = $this->getModel())) {
+            if (! class_exists($class = '\\'.ltrim($model, '\\'))) {
+                throw new RuntimeException("Class {$model} does not exist!");
+            }
+
+            $model = new $model($attributes);
+        }
+
+        return $model;
+    }
+}

--- a/src/Token.php
+++ b/src/Token.php
@@ -54,13 +54,20 @@ class Token extends Model
     public $timestamps = false;
 
     /**
+     * The client relation model.
+     *
+     * @var string
+     */
+    protected static $clientModel = Client::class;
+
+    /**
      * Get the client that the token belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function client()
     {
-        return $this->belongsTo(Client::class);
+        return $this->belongsTo(static::$clientModel);
     }
 
     /**
@@ -104,5 +111,28 @@ class Token extends Model
     public function transient()
     {
         return false;
+    }
+
+    /**
+     * Get the client model.
+     *
+     * @return mixed
+     */
+    public static function getClientModel()
+    {
+        return static::$clientModel;
+    }
+
+    /**
+     * Set the client model.
+     *
+     * @param  mixed  $clientModel
+     * @return static
+     */
+    public static function setClientModel($clientModel)
+    {
+        static::$clientModel = $clientModel;
+
+        return new static;
     }
 }

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -4,6 +4,15 @@ namespace Laravel\Passport;
 
 class TokenRepository
 {
+    use RepositoryHelper;
+
+    /**
+     * The access token model.
+     *
+     * @var string
+     */
+    protected static $model = Token::class;
+
     /**
      * Creates a new Access Token
      *
@@ -12,7 +21,7 @@ class TokenRepository
      */
     public function create($attributes)
     {
-        return Token::create($attributes);
+        return $this->createModel()->create($attributes);
     }
 
     /**
@@ -23,7 +32,7 @@ class TokenRepository
      */
     public function find($id)
     {
-        return Token::find($id);
+        return $this->createModel()->find($id);
     }
 
     /**
@@ -56,7 +65,7 @@ class TokenRepository
      */
     public function isAccessTokenRevoked($id)
     {
-        return Token::where('id', $id)->where('revoked', 1)->exists();
+        return $this->createModel()->where('id', $id)->where('revoked', 1)->exists();
     }
 
     /**
@@ -69,8 +78,9 @@ class TokenRepository
      */
     public function revokeOtherAccessTokens($clientId, $userId, $except = null, $prune = false)
     {
-        $query = Token::where('user_id', $userId)
-                      ->where('client_id', $clientId);
+        $query = $this->createModel()
+            ->where('user_id', $userId)
+            ->where('client_id', $clientId);
 
         if ($except) {
             $query->where('id', '<>', $except);
@@ -81,5 +91,23 @@ class TokenRepository
         } else {
             $query->update(['revoked' => true]);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getModel()
+    {
+        return static::$model;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setModel($model)
+    {
+        static::$model = $model;
+
+        return new static;
     }
 }


### PR DESCRIPTION
Replaced Database Connection instances in favor of repositories, comparable to: #90 

Added support to swap models, possible solution for: #58
```PHP
// On repositories
AuthCodeRepository::setModel(SomeOtherModel::class);
ClientRepository::setModel(SomeOtherModel::class);
RefreshTokenRepository::setModel(SomeOtherModel::class);
TokenRepository::setModel(SomeOtherModel::class);

// On models
Client::setTokenModel(SomeOtherModel::class);
```

Fixed an issue with a previously issued PR (#111) regarding the RepositoryTrait.