### PR TITLE
Throw AuthorizationException if user doesn't have scope

### DIFF
--- a/src/Http/Middleware/CheckScopes.php
+++ b/src/Http/Middleware/CheckScopes.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class CheckScopes
 {
@@ -22,7 +23,7 @@ class CheckScopes
 
         foreach ($scopes as $scope) {
             if (! $request->user()->tokenCan($scope)) {
-                throw new AuthenticationException;
+                throw new AuthorizationException;
             }
         }
 

--- a/tests/CheckScopesTest.php
+++ b/tests/CheckScopesTest.php
@@ -26,7 +26,7 @@ class CheckScopesTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Illuminate\Auth\AuthenticationException
+     * @expectedException \Illuminate\Auth\Access\AuthorizationException
      */
     public function test_exception_is_thrown_if_token_doesnt_have_scope()
     {


### PR DESCRIPTION
Should this not throw AuthorizationException when the user doesn't have the required scopes as the user is authenticated but doesn't have the scope to access the route?