### PR TITLE
Added guard handling to CreateFreshApiToken

### DIFF
--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -16,6 +16,13 @@ class CreateFreshApiToken
     protected $cookieFactory;
 
     /**
+     * Authentication guard
+     *
+     * @var \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
+     */
+    protected $guard;
+
+    /**
      * Create a new middleware instance.
      *
      * @param  ApiTokenCookieFactory  $cookieFactory
@@ -36,6 +43,7 @@ class CreateFreshApiToken
      */
     public function handle($request, Closure $next, $guard = null)
     {
+        $this->guard = $guard;
         $response = $next($request);
 
         if ($this->shouldReceiveFreshToken($request, $response)) {
@@ -68,7 +76,7 @@ class CreateFreshApiToken
      */
     protected function requestShouldReceiveFreshToken($request)
     {
-        return $request->isMethod('GET') && $request->user();
+        return $request->isMethod('GET') && $request->user($this->guard);
     }
 
     /**


### PR DESCRIPTION
For using the CreateFreshApiToken middleware with multiple auth providers, the guards must set when it looks for the user.