### PR TITLE
Fix the --name option on the ClientCommand

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -18,7 +18,7 @@ class ClientCommand extends Command
     protected $signature = 'passport:client
             {--personal : Create a personal access token client}
             {--password : Create a password grant client}
-            {--name : The name of the client}';
+            {--name= : The name of the client}';
 
     /**
      * The console command description.


### PR DESCRIPTION
This fix adds the '=' to the name option of command signature to able to call it like:

```
    php artisan passport:client --name="My Client Name"
```

Currently it throws the following exception:

```
[Symfony\Component\Console\Exception\RuntimeException]
  The "--name" option does not accept a value.
```