### PR TITLE
Allow to configure ApiTokenCookie name

### DIFF
--- a/src/ApiTokenCookieFactory.php
+++ b/src/ApiTokenCookieFactory.php
@@ -51,7 +51,7 @@ class ApiTokenCookieFactory
         $expiration = Carbon::now()->addMinutes($config['lifetime']);
 
         return new Cookie(
-            'laravel_token',
+            array_key_exists('passport_cookie', $config) ? $config['passport_cookie'] : 'laravel_token',
             $this->createToken($userId, $csrfToken, $expiration),
             $expiration,
             $config['path'],

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -3,11 +3,19 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
+use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Http\Response;
 use Laravel\Passport\ApiTokenCookieFactory;
 
 class CreateFreshApiToken
 {
+    /**
+     * The configuration repository implementation.
+     *
+     * @var Config
+     */
+    protected $config;
+
     /**
      * The API token cookie factory instance.
      *
@@ -26,11 +34,13 @@ class CreateFreshApiToken
      * Create a new middleware instance.
      *
      * @param  ApiTokenCookieFactory  $cookieFactory
+     * @param  Config  $config
      * @return void
      */
-    public function __construct(ApiTokenCookieFactory $cookieFactory)
+    public function __construct(ApiTokenCookieFactory $cookieFactory, Config $config)
     {
         $this->cookieFactory = $cookieFactory;
+        $this->config = $config;
     }
 
     /**
@@ -102,8 +112,9 @@ class CreateFreshApiToken
      */
     protected function alreadyContainsToken($response)
     {
+        $cookie_name = $this->config->get('session.passport_cookie', 'laravel_token');
         foreach ($response->headers->getCookies() as $cookie) {
-            if ($cookie->getName() === 'laravel_token') {
+            if ($cookie->getName() === $cookie_name) {
                 return true;
             }
         }

--- a/tests/ApiTokenCookieFactoryTest.php
+++ b/tests/ApiTokenCookieFactoryTest.php
@@ -25,5 +25,26 @@ class ApiTokenCookieFactoryTest extends PHPUnit_Framework_TestCase
         $cookie = $factory->make(1, 'token');
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Cookie', $cookie);
+        $this->assertEquals('laravel_token', $cookie->getName());
+    }
+
+    public function test_cookie_can_be_successfully_created_with_custom_name()
+    {
+        $custom_cookie_name = 'my_custom_cookie_name';
+        $config = Mockery::mock('Illuminate\Contracts\Config\Repository');
+        $config->shouldReceive('get')->with('session')->andReturn([
+            'passport_cookie' => $custom_cookie_name,
+            'lifetime' => 120,
+            'path' => '/',
+            'domain' => null,
+            'secure' => true,
+        ]);
+        $encrypter = new Encrypter(str_repeat('a', 16));
+        $factory = new ApiTokenCookieFactory($config, $encrypter);
+
+        $cookie = $factory->make(1, 'token');
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Cookie', $cookie);
+        $this->assertEquals($custom_cookie_name, $cookie->getName());
     }
 }


### PR DESCRIPTION
This can be useful if you have two Laravel apps on the same domain and do not want to restrict cookies to a specific path.