### PR TITLE
Allow to configure ApiTokenCookie name (2)

### DIFF
--- a/src/ApiTokenCookieFactory.php
+++ b/src/ApiTokenCookieFactory.php
@@ -51,7 +51,7 @@ class ApiTokenCookieFactory
         $expiration = Carbon::now()->addMinutes($config['lifetime']);
 
         return new Cookie(
-            'laravel_token',
+            Passport::cookie(),
             $this->createToken($userId, $csrfToken, $expiration),
             $expiration,
             $config['path'],

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -4,6 +4,7 @@ namespace Laravel\Passport\Guards;
 
 use Exception;
 use Firebase\JWT\JWT;
+use Laravel\Passport\Passport;
 use Laravel\Passport\Token;
 use Illuminate\Http\Request;
 use Laravel\Passport\TransientToken;
@@ -87,7 +88,7 @@ class TokenGuard
     {
         if ($request->bearerToken()) {
             return $this->authenticateViaBearerToken($request);
-        } elseif ($request->cookie('laravel_token')) {
+        } elseif ($request->cookie(Passport::cookie())) {
             return $this->authenticateViaCookie($request);
         }
     }
@@ -185,7 +186,7 @@ class TokenGuard
     protected function decodeJwtTokenCookie($request)
     {
         return (array) JWT::decode(
-            $this->encrypter->decrypt($request->cookie('laravel_token')),
+            $this->encrypter->decrypt($request->cookie(Passport::cookie())),
             $this->encrypter->getKey(), ['HS256']
         );
     }

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport\Http\Middleware;
 use Closure;
 use Illuminate\Http\Response;
 use Laravel\Passport\ApiTokenCookieFactory;
+use Laravel\Passport\Passport;
 
 class CreateFreshApiToken
 {
@@ -103,7 +104,7 @@ class CreateFreshApiToken
     protected function alreadyContainsToken($response)
     {
         foreach ($response->headers->getCookies() as $cookie) {
-            if ($cookie->getName() === 'laravel_token') {
+            if ($cookie->getName() === Passport::cookie()) {
                 return true;
             }
         }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -47,6 +47,13 @@ class Passport
     public static $refreshTokensExpireAt;
 
     /**
+     * The name for API token cookies.
+     *
+     * @var string
+     */
+    public static $cookie = 'laravel_token';
+
+    /**
      * The storage location of the encryption keys.
      *
      * @var string
@@ -200,6 +207,23 @@ class Passport
                             : new DateInterval('P100Y');
         } else {
             static::$refreshTokensExpireAt = $date;
+        }
+
+        return new static;
+    }
+
+    /**
+     * Get or set the name for API token cookies.
+     *
+     * @param  string|null  $cookie
+     * @return string|static
+     */
+    public static function cookie($cookie = null)
+    {
+        if (is_null($cookie)) {
+            return static::$cookie;
+        } else {
+            static::$cookie = $cookie;
         }
 
         return new static;


### PR DESCRIPTION
Revised version of #139

As requested by @taylorotwell, I use `Passport::cookie()` instead of a configuration option to set the cookie name.
I would love to add some test cases, but calling `Passport::cookie('foo')` in one test also affects the cookie name for all later tests (even for other classes). Is there any good workaround for that problem, i.e. how to reset the `Passport` class static state after a test?