### PR TITLE
Change revoked field to be searched by boolean

### DIFF
--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -56,7 +56,7 @@ class TokenRepository
      */
     public function isAccessTokenRevoked($id)
     {
-        return Token::where('id', $id)->where('revoked', 1)->exists();
+        return Token::where('id', $id)->where('revoked', true)->exists();
     }
 
     /**


### PR DESCRIPTION
`revoked` attribute is saved in boolean but searched by integer here. It breaks working with mongodb.

So replaced to boolean.