### PR TITLE
Shows the client secret and id in the console

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -68,6 +68,8 @@ class ClientCommand extends Command
         $accessClient->save();
 
         $this->info('Personal access client created successfully.');
+        $this->line('<comment>Client ID:</comment> '.$client->id);
+        $this->line('<comment>Client secret:</comment> '.$client->secret);
     }
 
     /**
@@ -83,11 +85,13 @@ class ClientCommand extends Command
             config('app.name').' Password Grant Client'
         );
 
-        $clients->createPasswordGrantClient(
+        $client = $clients->createPasswordGrantClient(
             null, $name, 'http://localhost'
         );
 
         $this->info('Password grant client created successfully.');
+        $this->line('<comment>Client ID:</comment> '.$client->id);
+        $this->line('<comment>Client secret:</comment> '.$client->secret);
     }
 
     /**


### PR DESCRIPTION
## What does it do?
When firing `php artisan passport:client --password` or `php artisan passport:client --personal`, the `client_id` and `client_secret` are now visible in the console.
This way you don't need to manually lookup the `id` and `secret` from the database.