### PR TITLE
Fixes scopes error in issue #148

### DIFF
--- a/src/Bridge/AccessTokenRepository.php
+++ b/src/Bridge/AccessTokenRepository.php
@@ -47,7 +47,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
             'id' => $accessTokenEntity->getIdentifier(),
             'user_id' => $accessTokenEntity->getUserIdentifier(),
             'client_id' => $accessTokenEntity->getClient()->getIdentifier(),
-            'scopes' => $this->formatScopesForStorage($accessTokenEntity->getScopes()),
+            'scopes' => $this->scopesToArray($accessTokenEntity->getScopes()),
             'revoked' => false,
             'created_at' => new DateTime,
             'updated_at' => new DateTime,

--- a/src/Bridge/FormatsScopesForStorage.php
+++ b/src/Bridge/FormatsScopesForStorage.php
@@ -12,8 +12,19 @@ trait FormatsScopesForStorage
      */
     public function formatScopesForStorage(array $scopes)
     {
-        return json_encode(array_map(function ($scope) {
+        return json_encode($this->scopesToArray($scopes));
+    }
+
+    /**
+     * Get an array of scope identifiers for storage.
+     *
+     * @param array $scopes
+     * @return array
+     */
+    public function scopesToArray(array $scopes)
+    {
+        return array_map(function ($scope) {
             return $scope->getIdentifier();
-        }, $scopes));
+        }, $scopes);
     }
 }

--- a/tests/BridgeAccessTokenRepositoryTest.php
+++ b/tests/BridgeAccessTokenRepositoryTest.php
@@ -19,7 +19,7 @@ class BridgeAccessTokenRepositoryTest extends PHPUnit_Framework_TestCase
             $this->assertEquals(1, $array['id']);
             $this->assertEquals(2, $array['user_id']);
             $this->assertEquals('client-id', $array['client_id']);
-            $this->assertEquals(json_encode(['scopes']), $array['scopes']);
+            $this->assertEquals(['scopes'], $array['scopes']);
             $this->assertEquals(false, $array['revoked']);
             $this->assertInstanceOf('DateTime', $array['created_at']);
             $this->assertInstanceOf('DateTime', $array['updated_at']);


### PR DESCRIPTION
This makes scopes work again on the Master branch. See issue #148.

The problem was introduced by PR#90.

Because the Token model is casting scopes automatically they do not need encoding in the bridge. Doing so breaks scopes when using an access token created with a scope.

The fix simply sends the array of scopes rather then a json encoded array to the new TokenRepository.
