### PR TITLE
add UUID support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "league/oauth2-server": "~5.0",
         "symfony/psr-http-message-bridge": "^0.3.0",
         "zendframework/zend-diactoros": "~1.0",
-        "phpseclib/phpseclib": "^2.0"
+        "phpseclib/phpseclib": "^2.0",
+        "webpatser/laravel-uuid": "2.*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -17,6 +17,7 @@ class CreateOauthClientsTable extends Migration
             $table->increments('id');
             $table->integer('user_id')->index()->nullable();
             $table->string('name');
+            $table->char('uuid', 36);
             $table->string('secret', 100);
             $table->text('redirect');
             $table->boolean('personal_access_client');

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -2,28 +2,30 @@
 
 namespace Laravel\Passport;
 
+use Webpatser\Uuid\Uuid as UUID;
+
 class ClientRepository
 {
     /**
      * Get a client by the given ID.
      *
-     * @param  int  $id
+     * @param  string  $uuid
      * @return Client|null
      */
-    public function find($id)
+    public function find($uuid)
     {
-        return Client::find($id);
+        return Client::where('uuid', $uuid)->firstOrFail();
     }
 
     /**
      * Get an active client by the given ID.
      *
-     * @param  int  $id
+     * @param  string  $id
      * @return Client|null
      */
-    public function findActive($id)
+    public function findActive($uuid)
     {
-        $client = $this->find($id);
+        $client = $this->find($uuid);
 
         return $client && ! $client->revoked ? $client : null;
     }
@@ -82,6 +84,7 @@ class ClientRepository
         $client = (new Client)->forceFill([
             'user_id' => $userId,
             'name' => $name,
+            'uuid' => UUID::generate(4)->string,
             'secret' => str_random(40),
             'redirect' => $redirect,
             'personal_access_client' => $personalAccess,


### PR DESCRIPTION
In this pull request we still use the original `id` as the primary key in the `oauth_clients` table.  However, we've added a `char(36)` column called `uuid` right before the `secret` column.

The only difference here is that instead of using the value of `oauth_clients.id` to pass in as the `client_id` for authentication, we instead pass in the value found in the `oauth_clients.uuid` column.

Thus, we can make a request like so:
```
curl -X POST \
    www.my-app.com/oauth/token \
    -d grant_type=password \
    -d client_id=e961c6dc-3761-4d6f-bd7b-681c3e264deb \
    -d client_secret=uWmHeqsjhMPgNXt7rYTnfDhxdGdOKNKK5gRvK9PC \
    -d username=user@email.com \
    -d password=myreallysecurepassword
```
... and it will pass client authentication.

**CAVEAT:**
I added another dependency (which ideally we'd avoid altogether): `webpatser/laravel-uuid` that is used to generate the version 4 UUID when a new client is generated.  If anyone has something simpler, please chime in.

**How to introduce this without making breaking changes?**
We will need to add in a configuration like `Passport::useClientUuids()` that will enable or disable these features.  I'm not sure how to do this without making what I've modified more complicated (yet), so if anyone's got any ideas let's hear'em.
