### PR TITLE
'passport:client --password --name=asdf throws RuntimeException

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -17,7 +17,7 @@ class ClientCommand extends Command
     protected $signature = 'passport:client
             {--personal : Create a personal access token client}
             {--password : Create a password grant client}
-            {--name : The name of the client}';
+            {--name= : The name of the client}';
 
     /**
      * The console command description.


### PR DESCRIPTION
missing the equals sign