### PR TITLE
Modifying UserRepository so it has another option if the User's class password isn't a standard hashed password.

### DIFF
--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Bridge;
 
 use RuntimeException;
+use Illuminate\Support\Facades\App;
 use Illuminate\Contracts\Hashing\Hasher;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
@@ -42,7 +43,12 @@ class UserRepository implements UserRepositoryInterface
             $user = (new $model)->where('email', $username)->first();
         }
 
-        if (! $user || ! $this->hasher->check($password, $user->password)) {
+
+        if (! $user ) {
+            return;
+        } else if (method_exists($user, 'validateForPassportPasswordGrant') && ! $user->validateForPassportPasswordGrant($password) ) {            
+            return;
+        } else if (! $this->hasher->check($password, $user->password)) {
             return;
         }
 

--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -3,7 +3,6 @@
 namespace Laravel\Passport\Bridge;
 
 use RuntimeException;
-use Illuminate\Support\Facades\App;
 use Illuminate\Contracts\Hashing\Hasher;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;


### PR DESCRIPTION
An issue with the Password Grant is it assumes
that you are using a user model with a hashed password.

This may not be true depending on a number of use cases.

This pull request offers an option similar to what was done with findForPassport earlier in getUserEntityByUserCredentials.

If the code sees a method 'validateForPassportPasswordGrant' in the user class it calls that and lets
the class validate the password sent into the password grant.

First time submitting to a laravel project so if something is wrong in terms of formatting, naming, or something else please let me know so I can fix it.