### PR TITLE
re-enable revoking access tokens

### DIFF
--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -70,7 +70,7 @@ class AccessTokenController
         $payload = json_decode($response->getBody()->__toString(), true);
 
         if (isset($payload['access_token'])) {
-            // $this->revokeOtherAccessTokens($payload);
+             $this->revokeOtherAccessTokens($payload);
         }
 
         return $response;


### PR DESCRIPTION

Having this line commented out creates 2 problems: the datastore can potentially fill up with many live tokens, and it breaks pruning revoked tokens.

To reproduce (before including this patch):

- [ ] in AuthServiceProvider.php

```php
 Passport::routes();
 Passport::pruneRevokedTokens();
```

- [ ] now, make a call to `/oauth/token`
- [ ] verify that tokens are not getting pruned from the db
- [ ] manually change a token to `revoked=1` in the db. Call `/oauth/token` again and confirm that  the revoked token did not get pruned

closing https://github.com/laravel/passport/issues/166 in lieu of this PR