### PR TITLE
Fix csrf validation

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -200,8 +200,14 @@ class TokenGuard
      */
     protected function validCsrf($token, $request)
     {
+    	$reqToken = $request->input('_token') ?: $request->header('X-CSRF-TOKEN');
+
+        if (! $reqToken && $header = $request->header('X-XSRF-TOKEN')) {
+            $reqToken = $this->encrypter->decrypt($header);
+        }
+    	
         return isset($token['csrf']) && hash_equals(
-            $token['csrf'], (string) $request->header('X-CSRF-TOKEN')
+            $token['csrf'], (string) $reqToken
         );
     }
 }


### PR DESCRIPTION
Allow request `_token` input and `X-XSRF-TOKEN` header. The same as in the [VerifyCsrfToken::tokensMatch](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php#L108) method.

This allow us instead of using (the only valid method now):
```JavaScript
Vue.http.interceptors.push((request, next) => {
    request.headers.set('X-CSRF-TOKEN', Laravel.csrfToken);

    next();
});
```

To use below method (my favourite one):
```JavaScript
Vue.http.interceptors.push((request, next) => {
    request.headers.set('X-XSRF-TOKEN', getCookie("XSRF-TOKEN")); // where getCookie returns encrypted X-XSRF-TOKEN cookie

    next();
});
```
... or of course the `_token` input.