### PR TITLE
Expire in 1 year by default

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -204,7 +204,7 @@ class Passport
         if (is_null($date)) {
             return static::$tokensExpireAt
                             ? Carbon::now()->diff(static::$tokensExpireAt)
-                            : new DateInterval('P100Y');
+                            : new DateInterval('P1Y');
         } else {
             static::$tokensExpireAt = $date;
         }
@@ -223,7 +223,7 @@ class Passport
         if (is_null($date)) {
             return static::$refreshTokensExpireAt
                             ? Carbon::now()->diff(static::$refreshTokensExpireAt)
-                            : new DateInterval('P100Y');
+                            : new DateInterval('P1Y');
         } else {
             static::$refreshTokensExpireAt = $date;
         }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -104,7 +104,7 @@ class PassportServiceProvider extends ServiceProvider
                 );
 
                 $server->enableGrantType(
-                    new PersonalAccessGrant, new DateInterval('P100Y')
+                    new PersonalAccessGrant, new DateInterval('P1Y')
                 );
 
                 $server->enableGrantType(


### PR DESCRIPTION
In reference to https://github.com/laravel/passport/issues/162 and https://github.com/laravel/passport/issues/47

100 years seems to be too long for some environments, maybe 1 year is enough?