### PR TITLE
fixing the validateForPassportPasswordGrant() method bug

### DIFF
--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -45,9 +45,10 @@ class UserRepository implements UserRepositoryInterface
 
         if (! $user ) {
             return;
-        } elseif (method_exists($user, 'validateForPassportPasswordGrant') &&
-                ! $user->validateForPassportPasswordGrant($password) ) {
-            return;
+        } elseif (method_exists($user, 'validateForPassportPasswordGrant')) {
+            if (!$user->validateForPassportPasswordGrant($password)) {
+                return;
+            }
         } elseif (! $this->hasher->check($password, $user->password)) {
             return;
         }


### PR DESCRIPTION
The question came to me when I used Laravel's Passport package to authenticate a different password column on reaching 'oauth/token'

If I want to authenticate from a different 'username' column, it can be done with the following code:
```
 public function findForPassport($username) {
        return $this->where('id', $username)->first();
    }
```
It will take Id, as the 'username' column. What if I want to use a different 'password' column. A column in the table with a different name such as 'uid_token'.

As I went to the `validateForPassportPasswordGrant()` method and called it in my model and expect it to work like the `findForPassport()` it did not work. To see the if condition was causing the problem. But once you write it in this way it worked.

```
       if (! $user ) {
            return;
        } elseif (method_exists($user, 'validateForPassportPasswordGrant')) {
            if (!$user->validateForPassportPasswordGrant($password)) {
                return;
            }
        } elseif (! $this->hasher->check($password, $user->password)) {
            return;
        }
```

replacing the old code:

```
       if (! $user ) {
            return;
        } elseif (method_exists($user, 'validateForPassportPasswordGrant') &&
                ! $user->validateForPassportPasswordGrant($password) ) {
            return;
        } elseif (! $this->hasher->check($password, $user->password)) {
            return;
        }`
```