### PR TITLE
Adds middleware to attach client credentials

### DIFF
--- a/src/Http/Middleware/AttachesPasswordGrantCredentials.php
+++ b/src/Http/Middleware/AttachesPasswordGrantCredentials.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Laravel\Passport\Http\Middleware;
+
+use Closure;
+use Laravel\Passport\Client;
+use Laravel\Passport\ClientRepository;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class AttachesPasswordGrantCredentials
+{
+    /**
+     * The Client Repository instance.
+     *
+     * @var \Laravel\Passport\ClientRepository
+     */
+    private $clients;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param \Laravel\Passport\ClientRepository $clients
+     * @return void
+     */
+    public function __construct(ClientRepository $clients)
+    {
+        $this->clients = $clients;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @return mixed
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function handle($request, Closure $next)
+    {
+        if ($request->grant_type === 'password') {
+            $client = $this->clients->find($request->client_id);
+
+            if ($client === null) {
+                throw (new ModelNotFoundException)->setModel(Client::class);
+            }
+
+            $request->request->add([
+                'client_secret' => $client->secret,
+            ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/tests/AttachesPasswordGrantCredentialsTest.php
+++ b/tests/AttachesPasswordGrantCredentialsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Http\Request;
+use Laravel\Passport\Client;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Laravel\Passport\Http\Middleware\AttachesPasswordGrantCredentials;
+
+class AttachesPasswordGrantCredentialsTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function test_request_is_passed_along_if_client_id_is_valid()
+    {
+        $clientRepository = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clientRepository->shouldReceive('find')->andReturn($client = Mockery::mock('Laravel\Passport\Client'));
+        $client->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $client->shouldReceive('getAttribute')->with('secret')->andReturn('secret');
+
+        $middleware = new AttachesPasswordGrantCredentials($clientRepository);
+
+        $request = Request::create('/', 'POST', ['grant_type' => 'password', 'client_id' => 1]);
+
+        $response = $middleware->handle($request, function () {
+            return 'response';
+        });
+
+        $this->assertEquals('response', $response);
+        $this->assertEquals('secret', $request->client_secret);
+    }
+
+    /**
+     * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function test_exception_is_thrown_if_client_id_is_invalid()
+    {
+        $clientRepository = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clientRepository->shouldReceive('find')->andReturnUsing(function () {
+            throw (new ModelNotFoundException())->setModel(Client::class);
+        });
+
+        $middleware = new AttachesPasswordGrantCredentials($clientRepository);
+
+        $request = Request::create('/', 'POST', ['grant_type' => 'password']);
+
+        $middleware->handle($request, function () {
+            return 'response';
+        });
+    }
+}


### PR DESCRIPTION
In reference to #165. I imagine this will work by adding this middleware before your `auth:api` call in your main application's routes. Basically you can make a POST request with the following parameters.

```js
{
  grant_type: 'password',
  client_id: 1,
  scope: '',
  username: 'email@example.com',
  password: 'secret'
}
```

The middleware will then attempt to find the client in it's database, otherwise a `ModelNotFoundException` will be thrown. If it finds the client, it will attach the client secret to the request. This will allow Passport's `TokenGuard` to continue with handling authentication assuming the username and password were correct.