### PR TITLE
Add in implicit grant type

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -54,6 +54,13 @@ class Passport
     public static $refreshTokensExpireAt;
 
     /**
+     * If implicit flow grant type is enabled.
+     *
+     * @var boolean|null
+     */
+    public static $enableImplicitFlow;
+
+    /**
      * The name for API token cookies.
      *
      * @var string
@@ -282,6 +289,18 @@ class Passport
     public static function ignoreMigrations()
     {
         static::$runsMigrations = false;
+
+        return new static;
+    }
+
+    /**
+     * Enable implicit flow grant type.
+     *
+     * @return static
+     */
+    public static function enableImplicitFlow()
+    {
+        static::$enableImplicitFlow = true;
 
         return new static;
     }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -14,6 +14,7 @@ use Illuminate\Support\ServiceProvider;
 use League\OAuth2\Server\ResourceServer;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
+use League\OAuth2\Server\Grant\ImplicitGrant;
 use League\OAuth2\Server\Grant\PasswordGrant;
 use Laravel\Passport\Bridge\PersonalAccessGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
@@ -95,6 +96,12 @@ class PassportServiceProvider extends ServiceProvider
                     $this->makeAuthCodeGrant(), Passport::tokensExpireIn()
                 );
 
+                if (Passport::$enableImplicitFlow) {
+                    $server->enableGrantType(
+                        $this->makeImplicitGrant(), Passport::tokensExpireIn()
+                    );
+                }
+
                 $server->enableGrantType(
                     $this->makeRefreshTokenGrant(), Passport::tokensExpireIn()
                 );
@@ -137,6 +144,28 @@ class PassportServiceProvider extends ServiceProvider
             $this->app->make(Bridge\AuthCodeRepository::class),
             $this->app->make(Bridge\RefreshTokenRepository::class),
             new DateInterval('PT10M')
+        );
+    }
+
+    /**
+     * Create and configure an instance of the Implicit grant.
+     *
+     * @return ImplicitGrant
+     */
+    protected function makeImplicitGrant()
+    {
+        return $this->buildImplicitGrant();
+    }
+
+    /**
+     * Build the Implicit grant instance.
+     *
+     * @return ImplicitGrant
+     */
+    protected function buildImplicitGrant()
+    {
+        return new ImplicitGrant(
+            Passport::tokensExpireIn()
         );
     }
 


### PR DESCRIPTION
Copy from https://github.com/laravel/passport/pull/63

----

This adds in the implicit grant type.

Same process as the AuthCode grant type except the `response_type` url attribute is set to `token` rather than `code`.

Once a user authorises the request they will be redirected back to the redirect url with the `access_token` directly in the url hash.

Useful for client side JavaScript applications that need to be able to generate an access token but don't have a server side component to retrieve the access token from a code authorization.

This is by default disabled due to many applications possibly not needing or wanting this type of grant. To enable it is as simple as defining a static call in the boot method of `AuthServiceProvider` as you do for pruning of auth tokens:

``` php
    /**
     * Register any authentication / authorization services.
     *
     * @return void
     */
    public function boot()
    {
        $this->registerPolicies();

        Passport::pruneRevokedTokens();

        Passport::enableImplicitFlow();
    }
```
