### PR TITLE
Bypass auth screen if we already have a token

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Laravel\Passport\Passport;

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -2,6 +2,9 @@
 
 namespace Laravel\Passport;
 
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+
 class TokenRepository
 {
     /**
@@ -24,6 +27,22 @@ class TokenRepository
     public function save($token)
     {
         $token->save();
+    }
+
+    /**
+     * Store the given token instance.
+     *
+     * @param  Model  $userId
+     * @param  Client  $client
+     * @return Token|null
+     */
+    public function getValidToken($user, $client)
+    {
+        return $client->tokens()
+                      ->whereUserId($user->id)
+                      ->whereRevoked(0)
+                      ->where('expires_at', '>', Carbon::now()->toDateTimeString())
+                      ->first();
     }
 
     /**

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -41,7 +41,7 @@ class TokenRepository
         return $client->tokens()
                       ->whereUserId($user->id)
                       ->whereRevoked(0)
-                      ->where('expires_at', '>', Carbon::now()->toDateTimeString())
+                      ->where('expires_at', '>', Carbon::now())
                       ->first();
     }
 

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -43,8 +43,11 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
         $clients->shouldReceive('find')->with(1)->andReturn('client');
 
+        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
+        $tokens->shouldReceive('getValidToken')->with('user', 'client')->andReturnNull();
+
         $this->assertEquals('view', $controller->authorize(
-            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients
+            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
         ));
     }
 
@@ -64,8 +67,46 @@ class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
 
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
 
+        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
+
         $this->assertEquals('whoops', $controller->authorize(
-            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients
+            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
         )->getOriginalContent());
+    }
+
+    public function test_request_is_approved_if_valid_token_exists()
+    {
+        Laravel\Passport\Passport::tokensCan([
+            'scope-1' => 'description',
+        ]);
+
+        $server = Mockery::mock(AuthorizationServer::class);
+        $response = Mockery::mock(ResponseFactory::class);
+
+        $controller = new Laravel\Passport\Http\Controllers\AuthorizationController($server, $response);
+
+        $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest = Mockery::mock('League\OAuth2\Server\RequestTypes\AuthorizationRequest'));
+        $server->shouldReceive('completeAuthorizationRequest')->with($authRequest, Mockery::type('Psr\Http\Message\ResponseInterface'))->andReturn('approved');
+
+        $request = Mockery::mock('Illuminate\Http\Request');
+        $request->shouldReceive('user')->once()->andReturn($user = Mockery::mock());
+        $user->shouldReceive('getKey')->andReturn(1);
+        $request->shouldNotReceive('session');
+
+        $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
+        $authRequest->shouldReceive('getScopes')->once()->andReturn([new Laravel\Passport\Bridge\Scope('scope-1')]);
+        $authRequest->shouldReceive('setUser')->once()->andReturnNull();
+        $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
+
+        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clients->shouldReceive('find')->with(1)->andReturn('client');
+
+        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
+        $tokens->shouldReceive('getValidToken')->with($user, 'client')->andReturn($token = Mockery::mock('Laravel\Passport\Token'));
+        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['scope-1']);
+
+        $this->assertEquals('approved', $controller->authorize(
+            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
+        ));
     }
 }


### PR DESCRIPTION
In reference to https://github.com/laravel/passport/issues/16

This PR skips the approval screen if the user has a valid token for the same client that has the same scope as the scope requested, Passport will auto-approve the request and return a new token.