### PR TITLE
Personal access tokens can't get "*" scope

### DIFF
--- a/src/Bridge/ScopeRepository.php
+++ b/src/Bridge/ScopeRepository.php
@@ -25,7 +25,7 @@ class ScopeRepository implements ScopeRepositoryInterface
         array $scopes, $grantType,
         ClientEntityInterface $clientEntity, $userIdentifier = null)
     {
-        if ($grantType !== 'password') {
+        if (! in_array($grantType, ['password', 'personal_access'])) {
             $scopes = collect($scopes)->reject(function ($scope) {
                 return trim($scope->getIdentifier()) === '*';
             })->values()->all();


### PR DESCRIPTION
Trying to create a personal token for testing purposes I've found that when I try to create a personal access token with `*` scopes permissions it gets removed from requested scopes.

Digging in the code I've found that only tokens that are granted with `password_grant` can request `*` permission.

This PR attempts to resolve it.

I don't know if its on purpose. If it is, just close this PR.

Cheers.