### PR TITLE
Adds invalid scopes exception

### DIFF
--- a/src/Exceptions/InvalidScopesException.php
+++ b/src/Exceptions/InvalidScopesException.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Passport\Exceptions;
 
-use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
 
-class InvalidScopesException extends Exception
+class InvalidScopesException extends AuthorizationException
 {
     /**
      * The scope(s) that failed authorization.

--- a/src/Exceptions/InvalidScopesException.php
+++ b/src/Exceptions/InvalidScopesException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laravel\Passport\Exceptions;
+
+use Exception;
+
+class InvalidScopesException extends Exception
+{
+    /**
+     * The scope(s) that failed authorization.
+     *
+     * @var array
+     */
+    protected $scopes;
+
+    /**
+     * Create a new invalid scope exception.
+     *
+     * @param  array|string  $scopes
+     * @param  string  $message
+     * @return void
+     */
+    public function __construct($scopes = [], $message = 'Invalid scope(s) provided.')
+    {
+        parent::__construct($message);
+        $this->scopes = is_array($scopes) ? $scopes : [$scopes];
+    }
+
+    /**
+     * Get the scopes that were failed authorization.
+     *
+     * @return array
+     */
+    public function scopes()
+    {
+        return $this->scopes;
+    }
+}

--- a/src/Http/Middleware/CheckForAnyScope.php
+++ b/src/Http/Middleware/CheckForAnyScope.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Illuminate\Auth\AuthenticationException;
+use Laravel\Passport\Exceptions\InvalidScopesException;
 
 class CheckForAnyScope
 {
@@ -26,6 +27,6 @@ class CheckForAnyScope
             }
         }
 
-        throw new AuthenticationException;
+        throw new InvalidScopesException($scopes);
     }
 }

--- a/src/Http/Middleware/CheckScopes.php
+++ b/src/Http/Middleware/CheckScopes.php
@@ -3,7 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Illuminate\Auth\AuthenticationException;
-use Illuminate\Auth\Access\AuthorizationException;
+use Laravel\Passport\Exceptions\InvalidScopesException;
 
 class CheckScopes
 {
@@ -23,7 +23,7 @@ class CheckScopes
 
         foreach ($scopes as $scope) {
             if (! $request->user()->tokenCan($scope)) {
-                throw new AuthorizationException;
+                throw new InvalidScopesException($scope);
             }
         }
 

--- a/tests/CheckForAnyScopeTest.php
+++ b/tests/CheckForAnyScopeTest.php
@@ -26,7 +26,7 @@ class CheckForAnyScopesTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Illuminate\Auth\AuthenticationException
+     * @expectedException Laravel\Passport\Exceptions\InvalidScopesException
      */
     public function test_exception_is_thrown_if_token_doesnt_have_scope()
     {

--- a/tests/CheckScopesTest.php
+++ b/tests/CheckScopesTest.php
@@ -26,7 +26,7 @@ class CheckScopesTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Auth\Access\AuthorizationException
+     * @expectedException Laravel\Passport\Exceptions\InvalidScopesException
      */
     public function test_exception_is_thrown_if_token_doesnt_have_scope()
     {


### PR DESCRIPTION
In reference to #198. This adds the `InvalidScopesException` to allow the user to send a custom response showing which scope(s) have failed authorization. You can catch this exception in your application's exception handler as shown below.

```php
use \Laravel\Passport\Exceptions\InvalidScopesException;

...

/**
 * Render an exception into an HTTP response.
 *
 * @param  \Illuminate\Http\Request $request
 * @param  \Exception $exception
 *
 * @return \Illuminate\Http\Response
 */
public function render($request, Exception $exception)
{
    if ($exception instanceof InvalidScopesException) {
        return response()->json(['scopes' => $exception->scopes()]);
    }

    return parent::render($request, $exception);
}
```