### PR TITLE
Query with revoked true instead of 1 at isRefreshTokenRevoked.

### DIFF
--- a/src/Bridge/RefreshTokenRepository.php
+++ b/src/Bridge/RefreshTokenRepository.php
@@ -74,6 +74,6 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
     public function isRefreshTokenRevoked($tokenId)
     {
         return $this->database->table('oauth_refresh_tokens')
-                    ->where('id', $tokenId)->where('revoked', 1)->exists();
+                    ->where('id', $tokenId)->where('revoked', true)->exists();
     }
 }


### PR DESCRIPTION
isRefreshTokenRevoked queries with revoked 1, but 1 does not work with MongoDB and I think should be changed to true.

reference to #204 