### PR TITLE
Fixed Auth::user() exception

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -112,11 +112,11 @@ class TokenGuard
             // If the access token is valid we will retrieve the user according to the user ID
             // associated with the token. We will use the provider implementation which may
             // be used to retrieve users from Eloquent. Next, we'll be ready to continue.
-            $user = $this->provider->retrieveById(
-                $psr->getAttribute('oauth_user_id')
-            );
+            if ($userId = $psr->getAttribute('oauth_user_id')) {
+                $user = $this->provider->retrieveById($userId);
+            }
 
-            if (! $user) {
+            if (!$userId || !$user) {
                 return;
             }
 


### PR DESCRIPTION
There is an issue where calling `Auth::user()` will throw an `Exception` if the access token was generated by `ClientCredentialsGrant`. What happens is the TokenGuard tries to `$this->provider->retrieveById` with an id of `""`.

Admittedly, I don't know the library super well. So, even though this fixed the issue for me, it could use an experienced set of eyes to make sure I'm not causing any breakage elsewhere.