### PR TITLE
Allow X-XSRF-TOKEN

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -200,8 +200,16 @@ class TokenGuard
      */
     protected function validCsrf($token, $request)
     {
-        return isset($token['csrf']) && hash_equals(
-            $token['csrf'], (string) $request->header('X-CSRF-TOKEN')
-        );
+        $csrfToken = $request->header('X-CSRF-TOKEN');
+
+        if (! $csrfToken && $header = $request->header('X-XSRF-TOKEN')) {
+            $csrfToken = $this->encrypter->decrypt($header);
+        }
+
+        if (! is_string($csrfToken) || ! isset($token['csrf'])) {
+            return false;
+        }
+
+        return hash_equals($token['csrf'], (string) $csrfToken);
     }
 }


### PR DESCRIPTION
Allow the XSRF token cookie to validate the CSRF token as well. I noticed that the switch to axios in L5.4 no longer requires you to pass along the X-CSRF-TOKEN header like vue-resource did. This will allow passport to work out of the box w/ the CreateFreshApiToken middleware w/ L5.4