### PR TITLE
Add index to oauth_access_tokens.client_id field.

### DIFF
--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -16,7 +16,7 @@ class CreateOauthAccessTokensTable extends Migration
         Schema::create('oauth_access_tokens', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->integer('user_id')->index()->nullable();
-            $table->integer('client_id');
+            $table->integer('client_id')->index();
             $table->string('name')->nullable();
             $table->text('scopes')->nullable();
             $table->boolean('revoked');


### PR DESCRIPTION
This PR adds an index to the `oauth_access_tokens.client_id` field, since the `Token` model has a `BelongsTo` relationship to the `Client` using this field.