### PR TITLE
State no clients authorized instead of no display.

### DIFF
--- a/resources/assets/js/components/AuthorizedClients.vue
+++ b/resources/assets/js/components/AuthorizedClients.vue
@@ -16,7 +16,7 @@
 
                 <div class="panel-body">
                     <!-- No Tokens Notice -->
-                    <p class="m-b-none" v-if="Object.keys(tokens).length === 0 || tokens.length === 0">
+                    <p class="m-b-none" v-if="tokens.length === 0">
                         You have not authorized any applications.
                     </p>
 

--- a/resources/assets/js/components/AuthorizedClients.vue
+++ b/resources/assets/js/components/AuthorizedClients.vue
@@ -10,13 +10,18 @@
 
 <template>
     <div>
-        <div v-if="tokens.length > 0">
+        <div>
             <div class="panel panel-default">
                 <div class="panel-heading">Authorized Applications</div>
 
                 <div class="panel-body">
+                    <!-- No Tokens Notice -->
+                    <p class="m-b-none" v-if="Object.keys(tokens).length === 0 || tokens.length === 0">
+                        You have not authorized any applications.
+                    </p>
+
                     <!-- Authorized Tokens -->
-                    <table class="table table-borderless m-b-none">
+                    <table class="table table-borderless m-b-none" v-if="tokens.length > 0">
                         <thead>
                             <tr>
                                 <th>Name</th>


### PR DESCRIPTION
Previously if no clients were authorized - even though this is clearly a
valid situation - the user would see a blank screen. To be
consistent with the other sibling Vue components this proposal is to
state that no clients are authorized.

This has the following benefits:

* It's obvious the Vue component is working!

* If someone is using this, authorizes a client, they don't have to
  figure out if the Vue component is working OR if they've done
  something wrong in their testing or setup.

The test may not be elegant however testing for tokens.length === 0
didn't catch when no clients at all had been authorized. If there is a
more elegant (or more Vue like way), that would be really good.