### PR TITLE
A non existing token should return true for revoked

### DIFF
--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -56,7 +56,12 @@ class TokenRepository
      */
     public function isAccessTokenRevoked($id)
     {
-        return Token::where('id', $id)->where('revoked', true)->exists();
+        if ($token = $this->find($id)) {
+            return $token->revoked;
+        }
+
+        // If does not exists, so asume revoked
+        return true;
     }
 
     /**


### PR DESCRIPTION
Passport check if a token is revoked based on the result of 

`return Token::where('id', $id)->where('revoked', true)->exists();`

It works when the token exists, but when the token does not exists it still returning false.

This problem allows to send an old token and still having access.

**Test Case:**

Create an access_token and copy the value.
Reset the database or just remove that specific access_token from the oauth_access_tokens table
Send a request using the already removed token
You can see that is still passing

It is because `Token::where('id', $id)->where('revoked', true)->exists();` is false when the token does not exists.



