### PR TITLE
The user bridge should not assume the column name for the password column

### DIFF
--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -51,7 +51,7 @@ class UserRepository implements UserRepositoryInterface
             if (! $user->validateForPassportPasswordGrant($password)) {
                 return;
             }
-        } elseif (! $this->hasher->check($password, $user->password)) {
+        } elseif (! $this->hasher->check($password, $user->getAuthPassword())) {
             return;
         }
 


### PR DESCRIPTION
We should use the getAuthPassword() method defined in the AuthenticatableContract instead.