### PR TITLE
Option to use with phpseclib ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "league/oauth2-server": "~5.0",
         "symfony/psr-http-message-bridge": "~1.0",
         "zendframework/zend-diactoros": "~1.0",
-        "phpseclib/phpseclib": "^2.0"
+        "phpseclib/phpseclib": "^2.0|^3.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",


### PR DESCRIPTION
If you are using Tymon JWT and want to support both ways of autentication there is no way to install both on Laravel 5.3
deps:
tymon/jwt-auth: 0.5.*