### PR TITLE
Stored client redirect should be optional

### DIFF
--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -18,7 +18,7 @@ class CreateOauthClientsTable extends Migration
             $table->integer('user_id')->index()->nullable();
             $table->string('name');
             $table->string('secret', 100);
-            $table->text('redirect');
+            $table->text('redirect')->nullable();
             $table->boolean('personal_access_client');
             $table->boolean('password_client');
             $table->boolean('revoked');

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -62,7 +62,7 @@ class ClientController
     {
         $this->validation->make($request->all(), [
             'name' => 'required|max:255',
-            'redirect' => 'required|url',
+            'redirect' => 'url',
         ])->validate();
 
         return $this->clients->create(
@@ -85,7 +85,7 @@ class ClientController
 
         $this->validation->make($request->all(), [
             'name' => 'required|max:255',
-            'redirect' => 'required|url',
+            'redirect' => 'url',
         ])->validate();
 
         return $this->clients->update(

--- a/tests/ClientControllerTest.php
+++ b/tests/ClientControllerTest.php
@@ -42,7 +42,7 @@ class ClientControllerTest extends PHPUnit_Framework_TestCase
             'redirect' => 'http://localhost',
         ], [
             'name' => 'required|max:255',
-            'redirect' => 'required|url',
+            'redirect' => 'url',
         ])->andReturn($validator);
         $validator->shouldReceive('validate')->once();
 
@@ -80,7 +80,7 @@ class ClientControllerTest extends PHPUnit_Framework_TestCase
             'redirect' => 'http://localhost',
         ], [
             'name' => 'required|max:255',
-            'redirect' => 'required|url',
+            'redirect' => 'url',
         ])->andReturn($validator);
         $validator->shouldReceive('validate')->once();
 


### PR DESCRIPTION
According to the [OAuth 2.0 Authorization Framework RFC](https://tools.ietf.org/html/rfc6749) – which the PHP League's OAuth 2.0 Server [supports](https://oauth2.thephpleague.com/) – a pre-registered client redirect can be optional.

```
   If multiple redirection URIs have been registered, if only part of
   the redirection URI has been registered, or if no redirection URI has
   been registered, the client MUST include a redirection URI with the
   authorization request using the "redirect_uri" request parameter.
```

### Why?

Flexibility. When Passport is serving multiple domains, it is very nice not having to create a separate client for every redirect URI. Especially when wildcards are not supported.

### Migration

This change requires the `redirect` field on the `oauth_clients` to be nullable. (the OAuth 2.0 Server checks if the redirect uri `is_null()`)

Which means we'd need to either modify the existing migration or add a new one.

If we add a new migration to run `$table->text('redirect')->nullable()->change()`, [it won't work without first requiring `doctrine/dbal`](https://laravel.com/docs/5.4/migrations#modifying-columns)

However, changing an existing migration is probably not exactly considered good practice – even if it's a minor, backwards compatible change.

For now, this PR modifies the existing migration. But it would be great if somebody could share a better approach. (if there is one!)

**Thoughts?**
