### PR TITLE
Added support for multi auth

### DIFF
--- a/database/migrations/2017_02_01_000006_add_provider_to_access_tokens_table.php
+++ b/database/migrations/2017_02_01_000006_add_provider_to_access_tokens_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use \Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddProviderToAccessTokensTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oauth_access_tokens', function (Blueprint $table) {
+            $table->string('provider')->nullable();
+        });
+
+        DB::table('oauth_access_tokens')->update(['provider' => 'users']);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oauth_access_tokens', function (Blueprint $table) {
+            $table->dropColumn('provider');
+        });
+    }
+}

--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -17,6 +17,13 @@ class UserRepository implements UserRepositoryInterface
     protected $hasher;
 
     /**
+     * The user provider
+     *
+     * @var string
+     */
+    protected $provider;
+
+    /**
      * Create a new repository instance.
      *
      * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
@@ -24,6 +31,7 @@ class UserRepository implements UserRepositoryInterface
      */
     public function __construct(Hasher $hasher)
     {
+        $this->provider = 'users';
         $this->hasher = $hasher;
     }
 
@@ -32,7 +40,7 @@ class UserRepository implements UserRepositoryInterface
      */
     public function getUserEntityByUserCredentials($username, $password, $grantType, ClientEntityInterface $clientEntity)
     {
-        $provider = config('auth.guards.api.provider');
+        $provider = $this->getProvider();
 
         if (is_null($model = config('auth.providers.'.$provider.'.model'))) {
             throw new RuntimeException('Unable to determine authentication model from configuration.');
@@ -56,5 +64,29 @@ class UserRepository implements UserRepositoryInterface
         }
 
         return new User($user->getAuthIdentifier());
+    }
+
+    /**
+     * Checks that the provider which has been set is also set in the auth config
+     *
+     * @param $provider
+     */
+    public function setProvider($provider)
+    {
+        $providers = array_keys(config('auth.providers'));
+
+        if(!in_array($this->provider, $providers)){
+            throw new RuntimeException('Provider was set to a value not present in the config');
+        }
+
+        $this->provider = $provider;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProvider()
+    {
+        return $this->provider;
     }
 }

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -90,7 +90,7 @@ class AccessTokenController
      */
     protected function overwritePasswordGrantUserRepository(ServerRequestInterface $request, string $provider)
     {
-        $grant_type = $request->getParsedBody()['grant_type'] ?? null;
+        $grant_type = isset($request->getParsedBody()['grant_type']) ? $request->getParsedBody()['grant_type'] : null;
 
         if($grant_type == 'password'){
 

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -2,9 +2,15 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
+use App;
+use Laravel\Passport\Bridge\RefreshTokenRepository;
+use Laravel\Passport\Bridge\UserRepository;
 use Laravel\Passport\Passport;
 use Laravel\Passport\TokenRepository;
 use Lcobucci\JWT\Parser as JwtParser;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\Grant\PasswordGrant;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response as Psr7Response;
 use Psr\Http\Message\ServerRequestInterface;
 use League\OAuth2\Server\AuthorizationServer;
@@ -59,8 +65,93 @@ class AccessTokenController
      */
     public function issueToken(ServerRequestInterface $request)
     {
-        return $this->withErrorHandling(function () use ($request) {
+        $provider = $this->getProvider($request);
+
+        $this->overwritePasswordGrantUserRepository($request, $provider);
+
+        $response = $this->withErrorHandling(function () use ($request) {
             return $this->server->respondToAccessTokenRequest($request, new Psr7Response);
         });
+
+        $this->storeTokenUserProvider($response, $provider);
+
+        return $response;
+    }
+
+    /**
+     * This creates a replacement PasswordGrant in the AuthorizationServer which has
+     * the correct user provider set in the user repository.
+     *
+     * While this shits all over the DI, it also avoids having to add provider support
+     * in the league/oauth2-server package.
+     *
+     * @param ServerRequestInterface $request
+     * @param string $provider
+     */
+    protected function overwritePasswordGrantUserRepository(ServerRequestInterface $request, string $provider)
+    {
+        $grant_type = $request->getParsedBody()['grant_type'] ?? null;
+
+        if($grant_type == 'password'){
+
+            $userRepository = App::make(UserRepository::class);
+            $userRepository->setProvider($provider);
+
+            $refreshTokenRepository = App::make(RefreshTokenRepository::class);
+
+            $grant = new PasswordGrant(
+                $userRepository,
+                $refreshTokenRepository
+            );
+
+            $grant->setRefreshTokenTTL(Passport::refreshTokensExpireIn());
+
+            $this->server->enableGrantType(
+                $grant,
+                Passport::tokensExpireIn()
+            );
+        }
+
+    }
+
+    /**
+     * This bends the OAuth2 spec slightly, by allowing clients to
+     * specify a provider, defaulting to "users"
+     *
+     * @param ServerRequestInterface $request
+     * @return string
+     * @throws OAuthServerException
+     */
+    protected function getProvider(ServerRequestInterface $request)
+    {
+        $providers = array_keys(config('auth.providers'));
+        $provider = isset($request->getParsedBody()['provider']) ? $request->getParsedBody()['provider'] : 'users';
+
+        if(!in_array($provider, $providers)){
+            throw OAuthServerException::invalidRequest('provider');
+        }
+
+        return $provider;
+    }
+
+    /**
+     * Extracts the token from the AuthorizationServer response, finds
+     * the token in the repository, and sets the correct provider.
+     *
+     * @param ResponseInterface $response
+     * @param $provider
+     */
+    protected function storeTokenUserProvider(ResponseInterface $response, $provider)
+    {
+        $body = \GuzzleHttp\json_decode($response->getBody());
+
+        if(isset($body->error)){
+            return;
+        }
+
+        $jwt = $this->jwt->parse($body->access_token);
+        $token = $this->tokens->find($jwt->getHeader('jti'));
+        $token->provider = $provider;
+        $this->tokens->save($token);
     }
 }

--- a/src/Token.php
+++ b/src/Token.php
@@ -70,9 +70,9 @@ class Token extends Model
      */
     public function user()
     {
-        $provider = config('auth.guards.api.provider');
+        $provider = $this->provider ? $this->provider : 'users';
 
-        return $this->belongsTo(config('auth.providers.'.$provider.'.model'));
+        return $this->belongsTo(config('auth.providers.'.$provider.'.model'), 'user_id');
     }
 
     /**

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -32,7 +32,7 @@ class TokenRepository
     /**
      * Get a valid token instance for the given user and client.
      *
-     * @param  Model  $userId
+     * @param  Model  $user
      * @param  Client  $client
      * @return Token|null
      */


### PR DESCRIPTION
Previously, using multiple user providers with Passport would work in a completely insecure way (due to user_id collisions in the access tokens).

These changes allow for password grants to specify a provider (defaulting to "users"), instead of hard-coding "users" within Passport. Other grants haven't been updated to do the same yet (need to update the new tokens with the provider name after the AuthorizationServer issues them).

TokenGuard authentication now checks that the token belongs to the actual user (allowing for multiple providers), rather than just matching the user_id and resulting in potential unintentional access when using multiple user providers/Passport guards.

Since multiple user providers are not part of the OAuth2 spec, and since all the token issuing and response preparation is done by league/oauth2-server, the adjustments here are quite clunky (reinjecting an amended UserRepository, parsing AuthorizationServer grant responses and updating the corresponding token) to avoid having to change or affect the oauth2-server.
