### PR TITLE
Accept * scope as valid when verifying client_credentials

### DIFF
--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -47,11 +47,15 @@ class CheckClientCredentials
             throw new AuthenticationException;
         }
 
-        foreach ($scopes as $scope) {
-           if (!in_array($scope,$psr->getAttribute('oauth_scopes'))) {
-             throw new AuthenticationException;
-           }
-         }
+        $tokenScopes = $psr->getAttribute('oauth_scopes');
+        
+        if (!in_array('*', $tokenScopes)) {
+            foreach ($scopes as $scope) {
+               if (!in_array($scope,$tokenScopes)) {
+                 throw new AuthenticationException;
+               }
+             }
+        }
 
         return $next($request);
     }

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -17,7 +17,8 @@ class CheckClientCredentialsTest extends PHPUnit_Framework_TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
-
+        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
+        
         $middleware = new CheckClientCredentials($resourceServer);
 
         $request = Request::create('/');


### PR DESCRIPTION
When using the middleware 'client_credentials:some_scope', requests are rejected if the
token was requested using '*' scope during a client credentials grant. They are accepted
if the token was explicitly requested using 'some_scope', in this case.

If I understand correctly that the '*' scope, if granted, would allow all requests for
routes protected by any scope, then this pull request will allow this to happen.
