### PR TITLE
Token Issuing Should Use Api Middleware Group

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -69,7 +69,7 @@ class RouteRegistrar
     {
         $this->router->post('/token', [
             'uses' => 'AccessTokenController@issueToken',
-            'middleware' => 'throttle'
+            'middleware' => 'api'
         ]);
 
         $this->router->group(['middleware' => ['web', 'auth']], function ($router) {


### PR DESCRIPTION
Currently, the route for token issuing uses only the throttle middleware, but it should use all the middlewares defined in the "api" middleware group, giving more control over this to the developer. This will allow to the programmer to include additional middleware to this route quickly.

For example, CORS middleware, of course, the throttling, and other custom middleware.

As it is working currently, the developer must register this route again in the `routes/api.php` to use all the "api" middleware.