### PR TITLE
Secure isRefreshTokenRevoked

### DIFF
--- a/src/Bridge/RefreshTokenRepository.php
+++ b/src/Bridge/RefreshTokenRepository.php
@@ -69,11 +69,29 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Check if the refresh token has been revoked.
+     *
+     * @param string $tokenId
+     *
+     * @return bool Return true if this token has been revoked or doesn't exists
      */
     public function isRefreshTokenRevoked($tokenId)
     {
-        return $this->database->table('oauth_refresh_tokens')
-                    ->where('id', $tokenId)->where('revoked', true)->exists();
+        if ($token = $this->find($tokenId)) {
+            return $token->revoked;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get a refresh token by the given ID.
+     *
+     * @param  string  $tokenId
+     * @return RefreshToken
+     */
+    public function find($tokenId)
+    {
+        return $this->database->table('oauth_refresh_tokens')->where('id', $tokenId)->first();
     }
 }


### PR DESCRIPTION
I've noticed that the isRefreshTokenRevoked method from RefreshTokenRepository class returns true when the refresh token doesn't exists in the database:
`return $this->database->table('oauth_refresh_tokens')->where('id', $tokenId)->where('revoked', true)->exists();`
Although the supplied request must have a valid refresh_token (pass the decryption stage), a valid cliend_id and client_secret in order to get a new valid access_token and refresh_token... I think it's a security flaw.
I've changed the logic using the same that was implemented in isAccessTokenRevoked from TokenRepository class in here:
https://github.com/laravel/passport/blob/22a37c62cb9f8e32c384ea526f2dd3a6ed7e3d1e/src/TokenRepository.php#L76