### PR TITLE
Add user_id awareness to client credentials grant

### DIFF
--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -6,9 +6,9 @@ use League\OAuth2\Server\Entities\Traits\ClientTrait;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 
-class Client implements ClientEntityInterface
+class Client implements ClientEntityInterface, UserAwareInterface
 {
-    use ClientTrait, EntityTrait;
+    use ClientTrait, EntityTrait, UserAwareTrait;
 
     /**
      * Create a new client instance.

--- a/src/Bridge/ClientCredentialsGrant.php
+++ b/src/Bridge/ClientCredentialsGrant.php
@@ -11,9 +11,9 @@
 
 namespace Laravel\Passport\Bridge;
 
+use Psr\Http\Message\ServerRequestInterface;
 use League\OAuth2\Server\Grant\AbstractGrant;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Client credentials grant class.

--- a/src/Bridge/ClientCredentialsGrant.php
+++ b/src/Bridge/ClientCredentialsGrant.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * OAuth 2.0 Client credentials grant with support for Laravel Passport's Client entity.
+ *
+ * @author      Alex Bilbie <hello@alexbilbie.com>, Paul Chiu <paulchiu@gmail.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace Laravel\Passport\Bridge;
+
+use League\OAuth2\Server\Grant\AbstractGrant;
+use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Client credentials grant class.
+ */
+class ClientCredentialsGrant extends AbstractGrant
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function respondToAccessTokenRequest(
+        ServerRequestInterface $request,
+        ResponseTypeInterface $responseType,
+        \DateInterval $accessTokenTTL
+    ) {
+        // Validate request
+        $client = $this->validateClient($request);
+        $scopes = $this->validateScopes($this->getRequestParameter('scope', $request));
+
+        // Get user id if available
+        $userId = null;
+        if ($client instanceof UserAwareInterface && $client->getUser()) {
+            $userId = $client->getUser()->getIdentifier();
+        }
+
+        // Finalize the requested scopes
+        $scopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client);
+
+        // Issue and persist access token
+        $accessToken = $this->issueAccessToken(
+            $accessTokenTTL,
+            $client,
+            $userId,
+            $scopes
+        );
+
+        // Inject access token into response type
+        $responseType->setAccessToken($accessToken);
+
+        return $responseType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        return 'client_credentials';
+    }
+}

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
+use Laravel\Passport\Client as PassportClient;
 use Laravel\Passport\ClientRepository as ClientModelRepository;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 
@@ -48,8 +49,8 @@ class ClientRepository implements ClientRepositoryInterface
         );
 
         // Attach a user to the client if user_id is set
-        if (property_exists($record, 'user_id') &&$record->user_id) {
-            $user = new User($record->user_id);
+        if ($record instanceof PassportClient && $record->getAttribute('user_id')) {
+            $user = new User($record->getAttribute('user_id'));
             $client->setUser($user);
         }
 

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -47,6 +47,12 @@ class ClientRepository implements ClientRepositoryInterface
             $clientIdentifier, $record->name, $record->redirect
         );
 
+        // Attach a user to the client if user_id is set
+        if (property_exists($record, 'user_id') &&$record->user_id) {
+            $user = new User($record->user_id);
+            $client->setUser($user);
+        }
+
         if ($mustValidateSecret &&
             ! hash_equals($record->secret, (string) $clientSecret)) {
             return;

--- a/src/Bridge/UserAwareInterface.php
+++ b/src/Bridge/UserAwareInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Passport\Bridge;
+
+interface UserAwareInterface
+{
+    /**
+     * Get the user associated with the entity
+     *
+     * @return User
+     */
+    public function getUser();
+
+    /**
+     * @param User $user
+     *
+     * @return void
+     */
+    public function setUser($user);
+}

--- a/src/Bridge/UserAwareTrait.php
+++ b/src/Bridge/UserAwareTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Passport\Bridge;
+
+trait UserAwareTrait
+{
+    /**
+     * @var User $user
+     */
+    protected $user;
+
+    /**
+     * @return User
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param User $user
+     */
+    public function setUser($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -18,8 +18,8 @@ use League\OAuth2\Server\Grant\ImplicitGrant;
 use League\OAuth2\Server\Grant\PasswordGrant;
 use Laravel\Passport\Bridge\PersonalAccessGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
+use Laravel\Passport\Bridge\ClientCredentialsGrant;
 use Laravel\Passport\Bridge\RefreshTokenRepository;
-use League\OAuth2\Server\Grant\ClientCredentialsGrant;
 
 class PassportServiceProvider extends ServiceProvider
 {

--- a/tests/BridgeClientCredentialsGrantTest.php
+++ b/tests/BridgeClientCredentialsGrantTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use Zend\Diactoros\ServerRequest;
+use Laravel\Passport\Bridge\User;
+use Laravel\Passport\Bridge\Client;
+use Laravel\Passport\Bridge\AccessToken;
+use League\OAuth2\Server\Grant\ClientCredentialsGrant;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
+
+class BridgeClientCredentialsGrantTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function test_get_identifier()
+    {
+        $grant = new ClientCredentialsGrant();
+        $this->assertEquals('client_credentials', $grant->getIdentifier());
+    }
+
+    public function test_respond_to_request()
+    {
+        $client = new Client(1, 'foo', 'http://www.example.com');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessToken = new AccessToken('bar');
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn($accessToken);
+        $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
+        $grant = new ClientCredentialsGrant();
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withParsedBody(
+            [
+                'client_id'     => 'foo',
+                'client_secret' => 'bar',
+            ]
+        );
+
+        $responseType = new ResponseTypeStub();
+        $grant->respondToAccessTokenRequest($serverRequest, $responseType, new \DateInterval('PT5M'));
+
+        $this->assertTrue($responseType->getAccessToken() instanceof AccessTokenEntityInterface);
+
+        $accessTokenClient = $responseType->getAccessToken()->getClient();
+        $this->assertNull($accessTokenClient->getUser());
+    }
+
+    public function test_respond_to_request_if_user_is_attached()
+    {
+        $client = new Client(1, 'foo', 'http://www.example.com');
+        $user = new User('baz');
+        $client->setUser($user);
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessToken = new AccessToken('bar');
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn($accessToken);
+        $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
+        $grant = new ClientCredentialsGrant();
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withParsedBody(
+            [
+                'client_id'     => 'foo',
+                'client_secret' => 'bar',
+            ]
+        );
+
+        $responseType = new ResponseTypeStub();
+        $grant->respondToAccessTokenRequest($serverRequest, $responseType, new \DateInterval('PT5M'));
+
+        $this->assertTrue($responseType->getAccessToken() instanceof AccessTokenEntityInterface);
+
+        $accessTokenClient = $responseType->getAccessToken()->getClient();
+        $this->assertInstanceOf(User::class, $accessTokenClient->getUser());
+    }
+}
+
+class ResponseTypeStub implements ResponseTypeInterface
+{
+    protected $accessToken;
+
+    public function setAccessToken(AccessTokenEntityInterface $accessToken)
+    {
+        $this->accessToken = $accessToken;
+    }
+
+    public function setRefreshToken(\League\OAuth2\Server\Entities\RefreshTokenEntityInterface $refreshToken)
+    {
+        // No-op
+    }
+
+    public function generateHttpResponse(\Psr\Http\Message\ResponseInterface $response)
+    {
+        // No-op
+    }
+
+    public function getAccessToken()
+    {
+        return $this->accessToken;
+    }
+}

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Laravel\Passport\Client;
+use Laravel\Passport\Bridge\User;
 use Laravel\Passport\Bridge\ClientRepository;
 
 class BridgeClientRepositoryTest extends PHPUnit_Framework_TestCase
@@ -34,15 +36,40 @@ class BridgeClientRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Laravel\Passport\Bridge\Client', $repository->getClientEntity(1, 'client_credentials', 'secret', true));
         $this->assertNull($repository->getClientEntity(1, 'authorization_code', 'secret', true));
     }
+
+    public function test_can_get_client_with_user_id()
+    {
+        $userId = 1;
+        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $client = new BridgeClientRepositoryTestClientStub;
+        $client->user_id = $userId;
+        $clients->shouldReceive('findActive')->with(1)->andReturn($client);
+        $repository = new ClientRepository($clients);
+
+        $client = $repository->getClientEntity(1, 'client_credentials', 'secret', true);
+
+        $this->assertInstanceOf('Laravel\Passport\Bridge\Client', $client);
+        $this->assertInstanceOf(User::class, $client->getUser());
+        $this->assertEquals($userId, $client->getUser()->getIdentifier());
+    }
 }
 
-class BridgeClientRepositoryTestClientStub
+class BridgeClientRepositoryTestClientStub extends Client
 {
-    public $name = 'Client';
-    public $redirect = 'http://localhost';
-    public $secret = 'secret';
-    public $personal_access_client = false;
-    public $password_client = false;
+    public function __construct(array $attributes = [])
+    {
+        $attributes = array_merge([
+            'name' => 'Client',
+            'redirect' => 'http://localhost',
+            'secret' => 'secret',
+            'personal_access_client' => false,
+            'password_client' => false,
+            'user_id' => null,
+        ], $attributes);
+
+        parent::__construct($attributes);
+    }
+
     public function firstParty()
     {
         return $this->personal_access_client || $this->password_client;

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -23,6 +23,7 @@ class BridgeClientRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Laravel\Passport\Bridge\Client', $client);
         $this->assertNull($repository->getClientEntity(1, 'authorization_code', 'wrong-secret', true));
         $this->assertNull($repository->getClientEntity(1, 'client_credentials', 'wrong-secret', true));
+        $this->assertNull($client->getUser());
     }
 
     public function test_can_get_client_for_client_credentials_grant()


### PR DESCRIPTION
# Issue

Currently:

- Column `user_id` exists in the `oauth_access_tokens` table
- When generating a client credentials grant token using endpoint `/oauth/token` a user id is never used even if set; this is due to `userIdentifier` parameter being hard-coded to `null` in `\League\OAuth2\Server\Grant\ClientCredentialsGrant::respondToAccessTokenRequest`, line 38.

# Solution

- Added the ability to get `Passport\Bridge\User` from `Passport\Bridge\Client`
- Added ability for `Passport\Bridge\ClientRepository` to recongize when we are dealing with `Passport\Client` entities and set the bridge user identifier
- Created `Passport\Bridge\ClientCredentialsGrant` class, which checks for and utilises `Passport\Bridge\User` instances attached to a given `Passport\Bridge\Client` when calling `issueAccessToken`
