### PR TITLE
Allow Passport to integrate with other user providers

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -41,6 +41,20 @@ class ClientRepository
     }
 
     /**
+     * Get the client instances for the given user ID.
+     *
+     * @param  int  $clientId
+     * @param  mixed  $userId
+     * @return Client|null
+     */
+    public function findForUser($clientId, $userId)
+    {
+        return Client::where('user_id', $userId)
+                      ->where('id', $clientId)
+                      ->first();
+    }
+
+    /**
      * Get the active client instances for the given user ID.
      *
      * @param  mixed  $userId

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -79,7 +79,9 @@ class ClientController
      */
     public function update(Request $request, $clientId)
     {
-        if (! $request->user()->clients->find($clientId)) {
+        $client = $this->clients->findForUser($clientId, $request->user()->getKey());
+
+        if (! $client) {
             return new Response('', 404);
         }
 
@@ -89,7 +91,7 @@ class ClientController
         ])->validate();
 
         return $this->clients->update(
-            $request->user()->clients->find($clientId),
+            $client,
             $request->name, $request->redirect
         );
     }
@@ -103,12 +105,14 @@ class ClientController
      */
     public function destroy(Request $request, $clientId)
     {
-        if (! $request->user()->clients->find($clientId)) {
+        $client = $this->clients->findForUser($clientId, $request->user()->getKey());
+
+        if (! $client) {
             return new Response('', 404);
         }
 
         $this->clients->delete(
-            $request->user()->clients->find($clientId)
+            $client
         );
     }
 }

--- a/src/Http/Controllers/PersonalAccessTokenController.php
+++ b/src/Http/Controllers/PersonalAccessTokenController.php
@@ -7,6 +7,8 @@ use Illuminate\Http\Response;
 use Laravel\Passport\Passport;
 use Laravel\Passport\PersonalAccessTokenResult;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+use Laravel\Passport\Token;
+use Laravel\Passport\TokenRepository;
 
 class PersonalAccessTokenController
 {
@@ -18,14 +20,22 @@ class PersonalAccessTokenController
     protected $validation;
 
     /**
+     * @var TokenRepository
+     */
+    protected $tokenRepository;
+
+    /**
      * Create a controller instance.
      *
-     * @param  ValidationFactory  $validation
+     * @param  ValidationFactory $validation
+     * @param  TokenRepository   $tokenRepository
+     *
      * @return void
      */
-    public function __construct(ValidationFactory $validation)
+    public function __construct(ValidationFactory $validation, TokenRepository $tokenRepository)
     {
         $this->validation = $validation;
+        $this->tokenRepository = $tokenRepository;
     }
 
     /**
@@ -36,7 +46,9 @@ class PersonalAccessTokenController
      */
     public function forUser(Request $request)
     {
-        return $request->user()->tokens->load('client')->filter(function ($token) {
+        $tokens = $this->tokenRepository->forUser($request->user()->getKey());
+
+        return $tokens->load('client')->filter(function ($token) {
             return $token->client->personal_access_client && ! $token->revoked;
         })->values();
     }
@@ -68,7 +80,9 @@ class PersonalAccessTokenController
      */
     public function destroy(Request $request, $tokenId)
     {
-        if (is_null($token = $request->user()->tokens->find($tokenId))) {
+        $token = $this->tokenRepository->findForUser($tokenId, $request->user()->getKey());
+
+        if (is_null($token)) {
             return new Response('', 404);
         }
 

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -30,6 +30,29 @@ class TokenRepository
     }
 
     /**
+     * Get a token by the given ID.
+     *
+     * @param  string  $id
+     * @param  int     $userId
+     * @return Token|null
+     */
+    public function findForUser($id, $userId)
+    {
+        return Token::where('id', $id)->where('user_id', $userId)->first();
+    }
+
+    /**
+     * Get the token instances for the given user ID.
+     *
+     * @param  mixed  $userId
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function forUser($userId)
+    {
+        return Token::where('user_id', $userId)->get();
+    }
+
+    /**
      * Get a valid token instance for the given user and client.
      *
      * @param  Model  $userId
@@ -39,7 +62,7 @@ class TokenRepository
     public function getValidToken($user, $client)
     {
         return $client->tokens()
-                    ->whereUserId($user->id)
+                    ->whereUserId($user->getKey())
                     ->whereRevoked(0)
                     ->where('expires_at', '>', Carbon::now())
                     ->first();
@@ -92,7 +115,7 @@ class TokenRepository
     public function findValidToken($user, $client)
     {
         return $client->tokens()
-                      ->whereUserId($user->id)
+                      ->whereUserId($user->getKey())
                       ->whereRevoked(0)
                       ->where('expires_at', '>', Carbon::now())
                       ->latest('expires_at')

--- a/tests/AuthorizedAccessTokenControllerTest.php
+++ b/tests/AuthorizedAccessTokenControllerTest.php
@@ -2,12 +2,33 @@
 
 use Illuminate\Http\Request;
 use Laravel\Passport\Client;
+use Laravel\Passport\Http\Controllers\AuthorizedAccessTokenController;
+use Laravel\Passport\TokenRepository;
+use Mockery\Mock;
 
 class AuthorizedAccessTokenControllerTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Mock|TokenRepository
+     */
+    protected $tokenRepository;
+
+    /**
+     * @var AuthorizedAccessTokenController
+     */
+    protected $controller;
+
     public function tearDown()
     {
         Mockery::close();
+    }
+
+    public function setUp()
+    {
+        $this->tokenRepository = Mockery::mock(TokenRepository::class);
+        $this->controller = new Laravel\Passport\Http\Controllers\AuthorizedAccessTokenController(
+            $this->tokenRepository
+        );
     }
 
     public function test_tokens_can_be_retrieved_for_users()
@@ -17,27 +38,30 @@ class AuthorizedAccessTokenControllerTest extends PHPUnit_Framework_TestCase
         $token1 = new Laravel\Passport\Token;
         $token2 = new Laravel\Passport\Token;
 
+        $userTokens = Mockery::mock();
+        $client1 = new Client;
+        $client1->personal_access_client = true;
+        $client2 = new Client;
+        $client2->personal_access_client = false;
+        $token1->client = $client1;
+        $token2->client = $client2;
+        $userTokens->shouldReceive('load')->with('client')->andReturn(collect([
+            $token1, $token2,
+        ]));
+
+        $this->tokenRepository->shouldReceive('forUser')->andReturn($userTokens);
+
         $request->setUserResolver(function () use ($token1, $token2) {
             $user = Mockery::mock();
-            $user->id = 1;
-            $user->tokens = Mockery::mock();
-            $client1 = new Client;
-            $client1->personal_access_client = true;
-            $client2 = new Client;
-            $client2->personal_access_client = false;
-            $token1->client = $client1;
-            $token2->client = $client2;
-            $user->tokens->shouldReceive('load')->with('client')->andReturn(collect([
-                $token1, $token2,
-            ]));
+            $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
-        $controller = new Laravel\Passport\Http\Controllers\AuthorizedAccessTokenController;
+        $tokens = $this->controller->forUser($request);
 
-        $this->assertEquals(1, count($controller->forUser($request)));
-        $this->assertEquals($token2, $controller->forUser($request)[0]);
+        $this->assertEquals(1, count($tokens));
+        $this->assertEquals($token2, $tokens[0]);
     }
 
     public function test_tokens_can_be_deleted()
@@ -47,46 +71,32 @@ class AuthorizedAccessTokenControllerTest extends PHPUnit_Framework_TestCase
         $token1 = Mockery::mock(Laravel\Passport\Token::class.'[revoke]');
         $token1->id = 1;
         $token1->shouldReceive('revoke')->once();
-        $token2 = Mockery::mock(Laravel\Passport\Token::class.'[revoke]');
-        $token2->id = 2;
-        $token2->shouldReceive('revoke')->never();
 
-        $request->setUserResolver(function () use ($token1, $token2) {
+        $this->tokenRepository->shouldReceive('findForUser')->andReturn($token1);
+
+        $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->id = 1;
-            $user->tokens = new Illuminate\Database\Eloquent\Collection([$token1, $token2]);
+            $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
-        $controller = new Laravel\Passport\Http\Controllers\AuthorizedAccessTokenController($validator);
-
-        $controller->destroy($request, 1);
+        $this->controller->destroy($request, 1);
     }
 
     public function test_not_found_response_is_returned_if_user_doesnt_have_token()
     {
         $request = Request::create('/', 'GET');
 
-        $token1 = Mockery::mock(Laravel\Passport\Token::class.'[revoke]');
-        $token1->id = 1;
-        $token1->shouldReceive('revoke')->never();
-        $token2 = Mockery::mock(Laravel\Passport\Token::class.'[revoke]');
-        $token2->id = 2;
-        $token2->shouldReceive('revoke')->never();
+        $this->tokenRepository->shouldReceive('findForUser')->with(3, 1)->andReturnNull();
 
-        $request->setUserResolver(function () use ($token1, $token2) {
+        $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->id = 1;
-            $user->tokens = new Illuminate\Database\Eloquent\Collection([$token1, $token2]);
+            $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
-        $controller = new Laravel\Passport\Http\Controllers\AuthorizedAccessTokenController($validator);
-
-        $this->assertEquals(404, $controller->destroy($request, 3)->status());
+        $this->assertEquals(404, $this->controller->destroy($request, 3)->status());
     }
 }

--- a/tests/ClientControllerTest.php
+++ b/tests/ClientControllerTest.php
@@ -56,16 +56,14 @@ class ClientControllerTest extends PHPUnit_Framework_TestCase
     public function test_clients_can_be_updated()
     {
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $client = Mockery::mock('Laravel\Passport\Client');
+        $clients->shouldReceive('findForUser')->with(1, 1)->andReturn($client);
 
         $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->id = 1;
-            $user->clients = Mockery::mock();
-            $user->clients->shouldReceive('find')->with(1)->andReturn(
-                $client = Mockery::mock('Laravel\Passport\Client')
-            );
+            $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
@@ -94,14 +92,13 @@ class ClientControllerTest extends PHPUnit_Framework_TestCase
     public function test_404_response_if_client_doesnt_belong_to_user()
     {
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clients->shouldReceive('findForUser')->with(1, 1)->andReturnNull();
 
         $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->id = 1;
-            $user->clients = Mockery::mock();
-            $user->clients->shouldReceive('find')->with(1)->andReturn(null);
+            $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
@@ -120,16 +117,14 @@ class ClientControllerTest extends PHPUnit_Framework_TestCase
     public function test_clients_can_be_deleted()
     {
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $client = Mockery::mock('Laravel\Passport\Client');
+        $clients->shouldReceive('findForUser')->with(1, 1)->andReturn($client);
 
         $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->id = 1;
-            $user->clients = Mockery::mock();
-            $user->clients->shouldReceive('find')->with(1)->andReturn(
-                $client = Mockery::mock('Laravel\Passport\Client')
-            );
+            $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
@@ -150,14 +145,13 @@ class ClientControllerTest extends PHPUnit_Framework_TestCase
     public function test_404_response_if_client_doesnt_belong_to_user_on_delete()
     {
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clients->shouldReceive('findForUser')->with(1, 1)->andReturnNull();
 
         $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->id = 1;
-            $user->clients = Mockery::mock();
-            $user->clients->shouldReceive('find')->with(1)->andReturn(null);
+            $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });

--- a/tests/PersonalAccessTokenControllerTest.php
+++ b/tests/PersonalAccessTokenControllerTest.php
@@ -2,6 +2,7 @@
 
 use Laravel\Passport\Passport;
 use Illuminate\Http\Request;
+use Laravel\Passport\TokenRepository;
 
 class PersonalAccessTokenControllerTest extends PHPUnit_Framework_TestCase
 {
@@ -17,21 +18,25 @@ class PersonalAccessTokenControllerTest extends PHPUnit_Framework_TestCase
         $token1 = new Laravel\Passport\Token;
         $token2 = new Laravel\Passport\Token;
 
+        $userTokens = Mockery::mock();
+        $token1->client = (object) ['personal_access_client' => true];
+        $token2->client = (object) ['personal_access_client' => false];
+        $userTokens->shouldReceive('load')->with('client')->andReturn(collect([
+            $token1, $token2,
+        ]));
+
+        $tokenRepository = Mockery::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('forUser')->andReturn($userTokens);
+
         $request->setUserResolver(function () use ($token1, $token2) {
             $user = Mockery::mock();
-            $user->id = 1;
-            $user->tokens = Mockery::mock();
-            $token1->client = (object) ['personal_access_client' => true];
-            $token2->client = (object) ['personal_access_client' => false];
-            $user->tokens->shouldReceive('load')->with('client')->andReturn(collect([
-                $token1, $token2,
-            ]));
+            $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
         $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
-        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($validator);
+        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($validator, $tokenRepository);
 
         $this->assertEquals(1, count($controller->forUser($request)));
         $this->assertEquals($token1, $controller->forUser($request)[0]);
@@ -63,9 +68,8 @@ class PersonalAccessTokenControllerTest extends PHPUnit_Framework_TestCase
         ])->andReturn($validator);
         $validator->shouldReceive('validate')->once();
 
-        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController(
-            $validator
-        );
+        $tokenRepository = Mockery::mock(TokenRepository::class);
+        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($validator, $tokenRepository);
 
         $this->assertEquals('response', $controller->store($request));
     }
@@ -77,20 +81,19 @@ class PersonalAccessTokenControllerTest extends PHPUnit_Framework_TestCase
         $token1 = Mockery::mock(Laravel\Passport\Token::class.'[revoke]');
         $token1->id = 1;
         $token1->shouldReceive('revoke')->once();
-        $token2 = Mockery::mock(Laravel\Passport\Token::class.'[revoke]');
-        $token2->id = 2;
-        $token2->shouldReceive('revoke')->never();
 
-        $request->setUserResolver(function () use ($token1, $token2) {
+        $tokenRepository = Mockery::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('findForUser')->andReturn($token1);
+
+        $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->id = 1;
-            $user->tokens = new Illuminate\Database\Eloquent\Collection([$token1, $token2]);
+            $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
         $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
-        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($validator);
+        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($validator, $tokenRepository);
 
         $controller->destroy($request, 1);
     }
@@ -99,23 +102,18 @@ class PersonalAccessTokenControllerTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('/', 'GET');
 
-        $token1 = Mockery::mock(Laravel\Passport\Token::class.'[revoke]');
-        $token1->id = 1;
-        $token1->shouldReceive('revoke')->never();
-        $token2 = Mockery::mock(Laravel\Passport\Token::class.'[revoke]');
-        $token2->id = 2;
-        $token2->shouldReceive('revoke')->never();
+        $tokenRepository = Mockery::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('findForUser')->with(3, 1)->andReturnNull();
 
-        $request->setUserResolver(function () use ($token1, $token2) {
+        $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->id = 1;
-            $user->tokens = new Illuminate\Database\Eloquent\Collection([$token1, $token2]);
+            $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
         $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
-        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($validator);
+        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($validator, $tokenRepository);
 
         $this->assertEquals(404, $controller->destroy($request, 3)->status());
     }


### PR DESCRIPTION
Currently it's partially possible to user Passport with other user providers (e.g. Doctrine) as long as they embrace Eloquent being used for storing/retrieving the access tokens.

However to make it fully possible a couple of changes are necessary. 

Other user providers can now with the minimum effort of supplying a `getKey()` on their user model, integrate with Passport. 

No breaking changes should have been made. 

Solves: #326