### PR TITLE
missing scope exception instead of authentication exception

### DIFF
--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
+use Laravel\Passport\Exceptions\MissingScopeException;
 use League\OAuth2\Server\ResourceServer;
 use Illuminate\Auth\AuthenticationException;
 use League\OAuth2\Server\Exception\OAuthServerException;
@@ -59,7 +60,7 @@ class CheckClientCredentials
      * @param  array  $scopes
      * @return void
      *
-     * @throws \Illuminate\Auth\AuthenticationException
+     * @throws \Laravel\Passport\Exceptions\MissingScopeException
      */
     protected function validateScopes($psr, $scopes)
     {
@@ -69,7 +70,7 @@ class CheckClientCredentials
 
         foreach ($scopes as $scope) {
             if (! in_array($scope, $tokenScopes)) {
-                throw new AuthenticationException;
+                throw new MissingScopeException($scope);
             }
         }
     }

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -54,7 +54,7 @@ class CheckClientCredentialsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Illuminate\Auth\AuthenticationException
+     * @expectedException \Laravel\Passport\Exceptions\MissingScopeException
      */
     public function test_exception_is_thrown_if_token_does_not_have_required_scopes()
     {


### PR DESCRIPTION
A missing scope should lead to an authorization error instead of an authentication one.