### PR TITLE
Fix implicit flow athorization denied redirect

### DIFF
--- a/src/Http/Controllers/DenyAuthorizationController.php
+++ b/src/Http/Controllers/DenyAuthorizationController.php
@@ -35,11 +35,13 @@ class DenyAuthorizationController
      */
     public function deny(Request $request)
     {
-        $redirect = $this->getAuthRequestFromSession($request)
-                    ->getClient()->getRedirectUri();
+        $authRequest = $this->getAuthRequestFromSession($request);
+
+        $authRequest->getClient()->getRedirectUri();
+        $separator = $authRequest->getGrantTypeId() === 'implicit' ? '#' : '?';
 
         return $this->response->redirectTo(
-            $redirect.'?error=access_denied&state='.$request->input('state')
+            $redirect.$separator.'error=access_denied&state='.$request->input('state')
         );
     }
 }

--- a/src/Http/Controllers/DenyAuthorizationController.php
+++ b/src/Http/Controllers/DenyAuthorizationController.php
@@ -37,8 +37,9 @@ class DenyAuthorizationController
     {
         $authRequest = $this->getAuthRequestFromSession($request);
 
-        $authRequest->getClient()->getRedirectUri();
+        $redirect = $authRequest->getClient()->getRedirectUri();
         $separator = $authRequest->getGrantTypeId() === 'implicit' ? '#' : '?';
+
 
         return $this->response->redirectTo(
             $redirect.$separator.'error=access_denied&state='.$request->input('state')

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -26,6 +26,34 @@ class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
         ));
 
         $authRequest->shouldReceive('setUser')->once();
+        $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
+        $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
+        $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn('http://localhost');
+
+        $response->shouldReceive('redirectTo')->once()->andReturnUsing(function ($url) {
+            return $url;
+        });
+
+        $this->assertEquals('http://localhost?error=access_denied&state=state', $controller->deny($request));
+    }
+
+    public function test_authorization_can_be_denied_implicit()
+    {
+        $response = Mockery::mock(ResponseFactory::class);
+
+        $controller = new Laravel\Passport\Http\Controllers\DenyAuthorizationController($response);
+
+        $request = Mockery::mock('Illuminate\Http\Request');
+
+        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request->shouldReceive('user')->andReturn(new DenyAuthorizationControllerFakeUser);
+        $request->shouldReceive('input')->with('state')->andReturn('state');
+
+        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = Mockery::mock(
+            'League\OAuth2\Server\RequestTypes\AuthorizationRequest'
+        ));
+
+        $authRequest->shouldReceive('setUser')->once();
         $authRequest->shouldReceive('getGrantTypeId')->andReturn('implicit');
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
         $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn('http://localhost');

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -26,6 +26,7 @@ class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
         ));
 
         $authRequest->shouldReceive('setUser')->once();
+        $authRequest->shouldReceive('getGrantTypeId')->andReturn('implicit');
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
         $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn('http://localhost');
 
@@ -33,7 +34,7 @@ class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
             return $url;
         });
 
-        $this->assertEquals('http://localhost?error=access_denied&state=state', $controller->deny($request));
+        $this->assertEquals('http://localhost#error=access_denied&state=state', $controller->deny($request));
     }
 }
 


### PR DESCRIPTION
Laravel Passport will redirect incorrectly when the authorization request has been denied by a user while using the implicit flow.