### PR TITLE
not-found clients are revoked

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -174,8 +174,8 @@ class ClientRepository
      */
     public function revoked($id)
     {
-        return Client::where('id', $id)
-                ->where('revoked', true)->exists();
+        return ! Client::where('id', $id)
+                ->where('revoked', false)->exists();
     }
 
     /**


### PR DESCRIPTION
The current code does not work if someone deletes the record from DB. It is a security risk I guess.