### PR TITLE
dont revoke tokens of a deleting client

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -186,8 +186,6 @@ class ClientRepository
      */
     public function delete(Client $client)
     {
-        $client->tokens()->update(['revoked' => true]);
-
         $client->forceFill(['revoked' => true])->save();
     }
 }


### PR DESCRIPTION
Is there any reason to revoke tokens of a revoked clients?

The number of tokens of a deleting client may be huge. Besides, it seems there is no need to revoke the tokens because of the following check in `TokeGuard` class:
```php
    protected function authenticateViaBearerToken($request)
    {
            ...
            // Finally, we will verify if the client that issued this token is still valid and
            // its tokens may still be used. If not, we will bail out since we don't want a
            // user to be able to send access tokens for deleted or revoked applications.
            if ($this->clients->revoked($clientId)) {
                return;
            }
            ...
    }
```
