### PR TITLE
Call to registerGuard method from boot method instead of register method (in service provider)

### DIFF
--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -30,6 +30,8 @@ class PassportServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+		$this->registerGuard();
+		
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'passport');
 
         $this->deleteCookieOnLogout();
@@ -79,8 +81,6 @@ class PassportServiceProvider extends ServiceProvider
         $this->registerAuthorizationServer();
 
         $this->registerResourceServer();
-
-        $this->registerGuard();
     }
 
     /**


### PR DESCRIPTION
Installed Passport on a clean Laravel installation, but when I tried to execute `php artisan migrate`, the following error occurred:

>   [ReflectionException]
>   Class auth does not exist

I discovered that the error occurs because of the call to `registerGuard()` method, as you can see in the log:
```
[2017-05-23 14:38:44] local.ERROR: ReflectionException: Class auth does not exist in C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Container\Container.php:721
Stack trace:
#0 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Container\Container.php(721): ReflectionClass->__construct('auth')
#1 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Container\Container.php(600): Illuminate\Container\Container->build('auth')
#2 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Container\Container.php(567): Illuminate\Container\Container->resolve('auth')
#3 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Foundation\Application.php(708): Illuminate\Container\Container->make('auth')
#4 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Container\Container.php(1153): Illuminate\Foundation\Application->make('auth')
#5 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Support\Facades\Facade.php(159): Illuminate\Container\Container->offsetGet('auth')
#6 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Support\Facades\Facade.php(128): Illuminate\Support\Facades\Facade::resolveFacadeInstance('auth')
#7 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Support\Facades\Facade.php(215): Illuminate\Support\Facades\Facade::getFacadeRoot()
#8 C:\Apache24\htdocs\learn\passport\vendor\laravel\passport\src\PassportServiceProvider.php(233): Illuminate\Support\Facades\Facade::__callStatic('extend', Array)
#9 C:\Apache24\htdocs\learn\passport\vendor\laravel\passport\src\PassportServiceProvider.php(83): Laravel\Passport\PassportServiceProvider->registerGuard()
#10 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Foundation\Application.php(574): Laravel\Passport\PassportServiceProvider->register()
#11 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Foundation\ProviderRepository.php(75): Illuminate\Foundation\Application->register(Object(Laravel\Passport\PassportServiceProvider))
#12 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Foundation\Application.php(549): Illuminate\Foundation\ProviderRepository->load(Array)
#13 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Foundation\Bootstrap\RegisterProviders.php(17): Illuminate\Foundation\Application->registerConfiguredProviders()
#14 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Foundation\Application.php(208): Illuminate\Foundation\Bootstrap\RegisterProviders->bootstrap(Object(Illuminate\Foundation\Application))
#15 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Foundation\Console\Kernel.php(267): Illuminate\Foundation\Application->bootstrapWith(Array)
#16 C:\Apache24\htdocs\learn\passport\vendor\laravel\framework\src\Illuminate\Foundation\Console\Kernel.php(114): Illuminate\Foundation\Console\Kernel->bootstrap()
#17 C:\Apache24\htdocs\learn\passport\artisan(35): Illuminate\Foundation\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#18 {main}  

```

I solved this by moving the call to `registerGuard()` method in `PassportServiceProvider.php` from `register()` method to `boot()` method

