### PR TITLE
Adding foreign keys to Client model relationships

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -47,7 +47,7 @@ class Client extends Model
      */
     public function authCodes()
     {
-        return $this->hasMany(AuthCode::class);
+        return $this->hasMany(AuthCode::class, 'client_id');
     }
 
     /**
@@ -57,7 +57,7 @@ class Client extends Model
      */
     public function tokens()
     {
-        return $this->hasMany(Token::class);
+        return $this->hasMany(Token::class, 'client_id');
     }
 
     /**


### PR DESCRIPTION
When we extending the Client model in our Laravel app and giving different name to it (such as OAuthClient), the relation with no foreign key provided will cause an error: the Laravel thinks that our database field is o_auth_client_id instead of client_id.

This will fix the error.