### PR TITLE
fixed issue which was breaking on last commit issue #394

### DIFF
--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -32,10 +32,8 @@ class KeysCommand extends Command
     {
         $keys = $rsa->createKey(4096);
 
-        [$privateKey, $publicKey] = [
-            Passport::keyPath('oauth-public.key'),
-            Passport::keyPath('oauth-private.key'),
-        ];
+        $privateKey = Passport::keyPath('oauth-private.key');
+        $publicKey  = Passport::keyPath('oauth-public.key');
 
         if ((file_exists($publicKey) || file_exists($privateKey)) && ! $this->option('force')) {
             return $this->error("Encryption keys already exist. Use the --force option to overwrite them.");


### PR DESCRIPTION
fixes #394 
was throwing error on composer update [Symfony\Component\Debug\Exception\FatalThrowableError]
  Parse error: syntax error, unexpected '='
which was breaking as soon as composer update is done. URGENT