### PR TITLE
Fix: wrong array index filenames

### DIFF
--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -32,7 +32,7 @@ class KeysCommand extends Command
     {
         $keys = $rsa->createKey(4096);
 
-        list($privateKey, $publicKey) = [
+        list($publicKey, $privateKey) = [
             Passport::keyPath('oauth-public.key'),
             Passport::keyPath('oauth-private.key'),
         ];


### PR DESCRIPTION
Wrong indexes for file locations of SSL keys.