### PR TITLE
Updated league/oauth2-server to latest version to fix security patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/encryption": "~5.4",
         "illuminate/http": "~5.4",
         "illuminate/support": "~5.4",
-        "league/oauth2-server": "~5.0",
+        "league/oauth2-server": "^6.0",
         "symfony/psr-http-message-bridge": "~1.0",
         "zendframework/zend-diactoros": "~1.0",
         "phpseclib/phpseclib": "^2.0"

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -200,7 +200,7 @@ class PassportServiceProvider extends ServiceProvider
             $this->app->make(Bridge\AccessTokenRepository::class),
             $this->app->make(Bridge\ScopeRepository::class),
             'file://'.Passport::keyPath('oauth-private.key'),
-            'file://'.Passport::keyPath('oauth-public.key')
+            env('APP_KEY')
         );
     }
 


### PR DESCRIPTION
Today I released `league/oauth2-server` which addresses a number of potential security vulnerabilities discovered by a security audit.

I've updated Passport to pull in this version and I've modified the library for the one breaking change to the constructor of `AuthorizationServer` to use the `APP_KEY` environment variable instead of requiring a public key. As a result the encryption is significantly stronger.

I've not tested this in a working Passport app implementation but I don't know of any other changes to the library that will affect Passport.