### PR TITLE
Set encryption key on the Authorization server.

### DIFF
--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -195,13 +195,17 @@ class PassportServiceProvider extends ServiceProvider
      */
     public function makeAuthorizationServer()
     {
-        return new AuthorizationServer(
+        $server = new AuthorizationServer(
             $this->app->make(Bridge\ClientRepository::class),
             $this->app->make(Bridge\AccessTokenRepository::class),
             $this->app->make(Bridge\ScopeRepository::class),
             'file://'.Passport::keyPath('oauth-private.key'),
             'file://'.Passport::keyPath('oauth-public.key')
         );
+
+        $server->setEncryptionKey(env('APP_KEY'));
+
+        return $server;
     }
 
     /**


### PR DESCRIPTION
After updating composer packages (`composer update`) and pulling the latest Laravel 5.4.28. 
I started getting this message `You must set the encryption key going forward to improve the security of this library - see this page for more information https://oauth2.thephpleague.com/v5-security-improvements/` when I run my tests. 
I checked this page https://oauth2.thephpleague.com/v5-security-improvements/ and checked Passport code, and I couldn't find where you're setting the Encryption key. So I added it.