### PR TITLE
Set encryption key on the Authorization server.

### DIFF
--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -92,6 +92,8 @@ class PassportServiceProvider extends ServiceProvider
     {
         $this->app->singleton(AuthorizationServer::class, function () {
             return tap($this->makeAuthorizationServer(), function ($server) {
+                $server->setEncryptionKey(env('APP_KEY'));
+
                 $server->enableGrantType(
                     $this->makeAuthCodeGrant(), Passport::tokensExpireIn()
                 );


### PR DESCRIPTION
After updating composer packages (composer update) and run app, 
I started getting this message You must set the encryption key going forward to improve the security of this library - see this page for more information https://oauth2.thephpleague.com/v5-security-improvements/ when I run my tests.
I checked this page https://oauth2.thephpleague.com/v5-security-improvements/ and checked Passport code, and I couldn't find where you're setting the Encryption key. So I added it.