### PR TITLE
Update PassportServiceProvider.php

### DIFF
--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -204,6 +204,7 @@ class PassportServiceProvider extends ServiceProvider
         );
         
         $server->setEncryptionKey(app('encrypter')->getKey());
+
         return $server;
     }
 

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -195,13 +195,16 @@ class PassportServiceProvider extends ServiceProvider
      */
     public function makeAuthorizationServer()
     {
-        return new AuthorizationServer(
+        $server = new AuthorizationServer(
             $this->app->make(Bridge\ClientRepository::class),
             $this->app->make(Bridge\AccessTokenRepository::class),
             $this->app->make(Bridge\ScopeRepository::class),
             'file://'.Passport::keyPath('oauth-private.key'),
             'file://'.Passport::keyPath('oauth-public.key')
         );
+        
+        $server->setEncryptionKey(app('encrypter')->getKey());
+        return $server;
     }
 
     /**


### PR DESCRIPTION
Seem's that League/OAuth security update has been propagated to 5.0.x version of their repository, involving mandatory setEncryptionKey on AuthorizationServer creation.
Changed like v3.0 (using app('encrypter'))