### PR TITLE
Send CryptKey instance to oauth2 with new permission check disabled.

### DIFF
--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Guards\TokenGuard;
+use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\ResourceServer;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
@@ -189,6 +190,21 @@ class PassportServiceProvider extends ServiceProvider
     }
 
     /**
+     * Create a CryptKey instance without permissions check
+     *
+     * @param string $key
+     * @return \League\OAuth2\Server\CryptKey
+     */
+    protected function makeCryptKey($key)
+    {
+        return new CryptKey(
+            'file://'.Passport::keyPath($key),
+            null,
+            false
+        );
+    }
+
+    /**
      * Make the authorization service instance.
      *
      * @return \League\OAuth2\Server\AuthorizationServer
@@ -199,7 +215,7 @@ class PassportServiceProvider extends ServiceProvider
             $this->app->make(Bridge\ClientRepository::class),
             $this->app->make(Bridge\AccessTokenRepository::class),
             $this->app->make(Bridge\ScopeRepository::class),
-            'file://'.Passport::keyPath('oauth-private.key'),
+            $this->makeCryptKey('oauth-private.key'),
             app('encrypter')->getKey()
         );
     }
@@ -214,7 +230,7 @@ class PassportServiceProvider extends ServiceProvider
         $this->app->singleton(ResourceServer::class, function () {
             return new ResourceServer(
                 $this->app->make(Bridge\AccessTokenRepository::class),
-                'file://'.Passport::keyPath('oauth-public.key')
+                $this->makeCryptKey('oauth-public.key')
             );
         });
     }


### PR DESCRIPTION
This will fix https://github.com/laravel/passport/issues/453 that is caused by the changes to thephpleague/oauth2-server from here https://github.com/thephpleague/oauth2-server/pull/776. 

This disables the new permission check that was added in version 6.0.2 of oauth2-server.  I feel like the permission check should be controlled through configuration and not just be statically disabled but passport does not currently have any need for configuration and it would be a pain to add configuration for one setting. So I think some decisions still need to be made on how to handle this change. However, this is a quick solution that restores passport to working order. 