### PR TITLE
optimize Passport scopeIds(), delete unnecessary call values()

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -163,7 +163,7 @@ class Passport
      */
     public static function scopeIds()
     {
-        return static::scopes()->pluck('id')->values()->all();
+        return static::scopes()->pluck('id')->all();
     }
 
     /**


### PR DESCRIPTION
`return static::scopes()->pluck('id')->values()->all();`
This pluck('id') call already return a collection with items [id1, id2, id3], no need to call the values() to resort the key again on the collection. 