### PR TITLE
Fix AuthCode model relationship with Client

### DIFF
--- a/src/AuthCode.php
+++ b/src/AuthCode.php
@@ -41,10 +41,10 @@ class AuthCode extends Model
     /**
      * Get the client that owns the authentication code.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function client()
     {
-        return $this->hasMany(Client::class);
+        return $this->belongsTo(Client::class);
     }
 }


### PR DESCRIPTION
I guess it was a copy-paste from the `Client` model. Since the models aren't tested, this relationship was wrong and no one noticed.