### PR TITLE
Fixing deny response with multiple redirect uris

### DIFF
--- a/src/Http/Controllers/DenyAuthorizationController.php
+++ b/src/Http/Controllers/DenyAuthorizationController.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
-use Illuminate\Contracts\Routing\ResponseFactory;
-use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use Illuminate\Http\Request;
+use Illuminate\Contracts\Routing\ResponseFactory;
 
 class DenyAuthorizationController
 {

--- a/src/Http/Controllers/DenyAuthorizationController.php
+++ b/src/Http/Controllers/DenyAuthorizationController.php
@@ -2,8 +2,9 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 
 class DenyAuthorizationController
 {
@@ -30,7 +31,6 @@ class DenyAuthorizationController
     /**
      * Deny the authorization request.
      *
-     *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\RedirectResponse
      */
@@ -38,7 +38,9 @@ class DenyAuthorizationController
     {
         $authRequest = $this->getAuthRequestFromSession($request);
 
-        $uri = $authRequest->getClient()->getRedirectUri();
+        if (is_array($uri = $authRequest->getClient()->getRedirectUri())) {
+            $uri = Arr::first($uri);
+        }
 
         $separator = $authRequest->getGrantTypeId() === 'implicit' ? '#' : '?';
 

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -37,6 +37,34 @@ class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://localhost?error=access_denied&state=state', $controller->deny($request));
     }
 
+    public function test_authorization_can_be_denied_with_multiple_redirect_uris()
+    {
+        $response = Mockery::mock(ResponseFactory::class);
+
+        $controller = new Laravel\Passport\Http\Controllers\DenyAuthorizationController($response);
+
+        $request = Mockery::mock('Illuminate\Http\Request');
+
+        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request->shouldReceive('user')->andReturn(new DenyAuthorizationControllerFakeUser);
+        $request->shouldReceive('input')->with('state')->andReturn('state');
+
+        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = Mockery::mock(
+            'League\OAuth2\Server\RequestTypes\AuthorizationRequest'
+        ));
+
+        $authRequest->shouldReceive('setUser')->once();
+        $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
+        $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
+        $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn(['http://localhost']);
+
+        $response->shouldReceive('redirectTo')->once()->andReturnUsing(function ($url) {
+            return $url;
+        });
+
+        $this->assertEquals('http://localhost?error=access_denied&state=state', $controller->deny($request));
+    }
+
     public function test_authorization_can_be_denied_implicit()
     {
         $response = Mockery::mock(ResponseFactory::class);


### PR DESCRIPTION
Fixes an array to string conversion exception when someone denies a request when there are multiple return uris. Fixes https://github.com/laravel/passport/issues/457

Arrays are an allowed return type of `$client->getRedirectUri()`. See:
https://github.com/laravel/passport/blob/3.0/src/Bridge/Client.php#L26
https://github.com/thephpleague/oauth2-server/blob/master/src/Entities/Traits/ClientTrait.php#L40