### PR TITLE
Use Illuminate Response so that middlewares can always work

### DIFF
--- a/src/Http/Controllers/HandlesOAuthErrors.php
+++ b/src/Http/Controllers/HandlesOAuthErrors.php
@@ -17,7 +17,7 @@ trait HandlesOAuthErrors
      * Perform the given callback with exception handling.
      *
      * @param  \Closure  $callback
-     * @return \Illuminate\Http\Response|\Psr\Http\Message\ResponseInterface
+     * @return \Illuminate\Http\Response
      */
     protected function withErrorHandling($callback)
     {
@@ -25,8 +25,13 @@ trait HandlesOAuthErrors
             return $callback();
         } catch (OAuthServerException $e) {
             $this->exceptionHandler()->report($e);
+            $psr7Response = $e->generateHttpResponse(new Psr7Response);
 
-            return $e->generateHttpResponse(new Psr7Response);
+            return new Response(
+                $psr7Response->getBody(),
+                $psr7Response->getStatusCode(),
+                $psr7Response->getHeaders()
+            );
         } catch (Exception $e) {
             $this->exceptionHandler()->report($e);
 


### PR DESCRIPTION
If that specific exception is thrown, a middleware applied to `web` that interacts with the response would fail, since the return type would be `Zend\Diactoros\Response` instead of a `Illuminate\Http\Response`. This is a simplistic example of a middleware that would fail:

```php
class SecurityHeader
{
    public function handle($request, \Closure $next)
    {
        $response = $next($request);

        return $response->header('X-Frame-Options', 'deny');
    }
}
```

I don't know if the approach taken is the best, but I think that it's important to use a standard response for it.