### PR TITLE
Use Illuminate Response as a standard so that middlewares can always work

### DIFF
--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -59,7 +59,9 @@ class AccessTokenController
     public function issueToken(ServerRequestInterface $request)
     {
         return $this->withErrorHandling(function () use ($request) {
-            return $this->server->respondToAccessTokenRequest($request, new Psr7Response);
+            return $this->convertResponse(
+                $this->server->respondToAccessTokenRequest($request, new Psr7Response)
+            );
         });
     }
 }

--- a/src/Http/Controllers/ApproveAuthorizationController.php
+++ b/src/Http/Controllers/ApproveAuthorizationController.php
@@ -39,8 +39,8 @@ class ApproveAuthorizationController
         return $this->withErrorHandling(function () use ($request) {
             $authRequest = $this->getAuthRequestFromSession($request);
 
-            return $this->server->completeAuthorizationRequest(
-                $authRequest, new Psr7Response
+            return $this->convertResponse(
+                $this->server->completeAuthorizationRequest($authRequest, new Psr7Response)
             );
         });
     }

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -104,7 +104,7 @@ class AuthorizationController
      *
      * @param  \League\OAuth2\Server\RequestTypes\AuthorizationRequest  $authRequest
      * @param  \Illuminate\Database\Eloquent\Model  $user
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return \Illuminate\Http\Response
      */
     protected function approveRequest($authRequest, $user)
     {
@@ -112,8 +112,8 @@ class AuthorizationController
 
         $authRequest->setAuthorizationApproved(true);
 
-        return $this->server->completeAuthorizationRequest(
-            $authRequest, new Psr7Response
+        return $this->convertResponse(
+            $this->server->completeAuthorizationRequest($authRequest, new Psr7Response)
         );
     }
 }

--- a/src/Http/Controllers/ConvertsPsrResponses.php
+++ b/src/Http/Controllers/ConvertsPsrResponses.php
@@ -1,0 +1,24 @@
+<?php
+namespace Laravel\Passport\Http\Controllers;
+
+use Illuminate\Http\Response;
+use Psr\Http\Message\ResponseInterface;
+
+trait ConvertsPsrResponses
+{
+    /**
+     * Convert a PSR7 response to a Illuminate Response.
+     *
+     * @param \Psr\Http\Message\ResponseInterface $psrResponse
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function convertResponse($psrResponse)
+    {
+        return new Response(
+            $psrResponse->getBody(),
+            $psrResponse->getStatusCode(),
+            $psrResponse->getHeaders()
+        );
+    }
+}

--- a/src/Http/Controllers/HandlesOAuthErrors.php
+++ b/src/Http/Controllers/HandlesOAuthErrors.php
@@ -13,11 +13,13 @@ use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 trait HandlesOAuthErrors
 {
+    use ConvertsPsrResponses;
+
     /**
      * Perform the given callback with exception handling.
      *
      * @param  \Closure  $callback
-     * @return \Illuminate\Http\Response|\Psr\Http\Message\ResponseInterface
+     * @return \Illuminate\Http\Response
      */
     protected function withErrorHandling($callback)
     {
@@ -26,7 +28,9 @@ trait HandlesOAuthErrors
         } catch (OAuthServerException $e) {
             $this->exceptionHandler()->report($e);
 
-            return $e->generateHttpResponse(new Psr7Response);
+            return $this->convertResponse(
+                $e->generateHttpResponse(new Psr7Response)
+            );
         } catch (Exception $e) {
             $this->exceptionHandler()->report($e);
 

--- a/src/Http/Controllers/PersonalAccessTokenController.php
+++ b/src/Http/Controllers/PersonalAccessTokenController.php
@@ -76,7 +76,7 @@ class PersonalAccessTokenController
      *
      * @param  Request  $request
      * @param  string  $tokenId
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function destroy(Request $request, $tokenId)
     {

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -3,7 +3,6 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
-use Illuminate\Http\Response;
 use Laravel\Passport\Passport;
 use Laravel\Passport\ApiTokenCookieFactory;
 
@@ -89,8 +88,7 @@ class CreateFreshApiToken
      */
     protected function responseShouldReceiveFreshToken($response)
     {
-        return $response instanceof Response &&
-                    ! $this->alreadyContainsToken($response);
+        return $this->alreadyContainsToken($response);
     }
 
     /**

--- a/tests/AccessTokenControllerTest.php
+++ b/tests/AccessTokenControllerTest.php
@@ -15,9 +15,12 @@ class AccessTokenControllerTest extends PHPUnit_Framework_TestCase
         $server = Mockery::mock('League\OAuth2\Server\AuthorizationServer');
         $tokens = Mockery::mock(Laravel\Passport\TokenRepository::class);
 
+        $psrResponse = new Zend\Diactoros\Response();
+        $psrResponse->getBody()->write(json_encode(['access_token' => 'access-token']));
+
         $server->shouldReceive('respondToAccessTokenRequest')->with(
             Mockery::type('Psr\Http\Message\ServerRequestInterface'), Mockery::type('Psr\Http\Message\ResponseInterface')
-        )->andReturn($response = new AccessTokenControllerTestStubResponse);
+        )->andReturn($psrResponse);
 
         $jwt = Mockery::mock(Lcobucci\JWT\Parser::class);
         // $jwt->shouldReceive('parse->getClaim')->andReturn('token-id');
@@ -27,14 +30,14 @@ class AccessTokenControllerTest extends PHPUnit_Framework_TestCase
 
         $controller = new Laravel\Passport\Http\Controllers\AccessTokenController($server, $tokens, $jwt);
 
-        $this->assertEquals($response, $controller->issueToken(Mockery::mock('Psr\Http\Message\ServerRequestInterface')));
+        $this->assertEquals('{"access_token":"access-token"}', $controller->issueToken(
+            Mockery::mock('Psr\Http\Message\ServerRequestInterface')
+        )->getContent());
     }
 
     public function test_exceptions_are_handled()
     {
-        $container = new Container;
-        Container::setInstance($container);
-        $container->instance(ExceptionHandler::class, $exceptions = Mockery::mock());
+        Container::getInstance()->instance(ExceptionHandler::class, $exceptions = Mockery::mock());
         $exceptions->shouldReceive('report')->once();
 
         $tokens = Mockery::mock(Laravel\Passport\TokenRepository::class);
@@ -43,31 +46,11 @@ class AccessTokenControllerTest extends PHPUnit_Framework_TestCase
         $server = Mockery::mock('League\OAuth2\Server\AuthorizationServer');
         $server->shouldReceive('respondToAccessTokenRequest')->with(
             Mockery::type('Psr\Http\Message\ServerRequestInterface'), Mockery::type('Psr\Http\Message\ResponseInterface')
-        )->andReturnUsing(function () {
-            throw new Exception('whoops');
-        });
+        )->andThrow(new Exception('whoops'));
 
         $controller = new Laravel\Passport\Http\Controllers\AccessTokenController($server, $tokens, $jwt);
 
         $this->assertEquals('whoops', $controller->issueToken(Mockery::mock('Psr\Http\Message\ServerRequestInterface'))->getOriginalContent());
-    }
-}
-
-class AccessTokenControllerTestStubResponse
-{
-    public function getStatusCode()
-    {
-        return 200;
-    }
-
-    public function getBody()
-    {
-        return $this;
-    }
-
-    public function __toString()
-    {
-        return json_encode(['access_token' => 'access-token']);
     }
 }
 

--- a/tests/ApproveAuthorizationControllerTest.php
+++ b/tests/ApproveAuthorizationControllerTest.php
@@ -24,9 +24,12 @@ class ApproveAuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $authRequest->shouldReceive('setUser')->once();
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
 
-        $server->shouldReceive('completeAuthorizationRequest')->with($authRequest, Mockery::type('Psr\Http\Message\ResponseInterface'))->andReturn('response');
+        $psrResponse = new Zend\Diactoros\Response();
+        $psrResponse->getBody()->write('response');
 
-        $this->assertEquals('response', $controller->approve($request));
+        $server->shouldReceive('completeAuthorizationRequest')->with($authRequest, Mockery::type('Psr\Http\Message\ResponseInterface'))->andReturn($psrResponse);
+
+        $this->assertEquals('response', $controller->approve($request)->getContent());
     }
 }
 


### PR DESCRIPTION
Basically, all responses that were directly returned by `League\OAuth2` classes would fail when used with Laravel middlewares  (`Zend\Diactoros\Response` is incompatible with `Illuminate\Http\Response`). Since passport routes are registered under `web` middlewares, any  middleware applied to `web` that interacts with the response would fail.

This is a simplistic example of a middleware that would fail:

```php
class SecurityHeader
{
    public function handle($request, \Closure $next)
    {
        $response = $next($request);

        return $response->header('X-Frame-Options', 'deny');
    }
}
```

To avoid monkey patches / `if`s on a bunch of middlewares, my proposal is to use `Illuminate\Http\Response` as a standard.

I don't know if the approach taken is the best, but I think that it's important to use a standard response for it. If needed, we can work on something else. (I can also change base to `master` branch if it's a breaking change)