### PR TITLE
Fix creating fresh api token

### DIFF
--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -88,7 +88,7 @@ class CreateFreshApiToken
      */
     protected function responseShouldReceiveFreshToken($response)
     {
-        return $this->alreadyContainsToken($response);
+        return ! $this->alreadyContainsToken($response);
     }
 
     /**


### PR DESCRIPTION
Adding back the missing `!` in `responseShouldReceiveFreshToken`.
It was some how left out during df5ddb28318a6ffac2cb0c96fc30e045afa2f9b9 (laravel/passport@df5ddb2#diff-21f5bd46f0aa959bdc94060671ea5b18L92).

Without it a new token will never be set if one has not been set already.