### PR TITLE
Add oauth_client_id attribute to request

### DIFF
--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -44,6 +44,7 @@ class CheckClientCredentials
 
         try {
             $psr = $this->server->validateAuthenticatedRequest($psr);
+            $request->attributes->add(['oauth_client_id' => $psr->getAttribute('oauth_client_id')]);
         } catch (OAuthServerException $e) {
             throw new AuthenticationException;
         }


### PR DESCRIPTION
Actually if someone needs information of the request access token decrypted must extend `CheckClientCredentials`middleware only to add one line. I think it's a common case.
Maybe the other attributes (oauth_access_token_id, oauth_user_id, oauth_scopes) of the access_token could be nice to have it too.
References: 
 - `Laravel\Passport\Http\Middleware\CheckClientCredentials`
 - `League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator`

Thanks for let users contribute and sorry for any english grammar mistake.