### PR TITLE
Make it possible to throw custom exceptions

### DIFF
--- a/src/Http/Controllers/HandlesOAuthErrors.php
+++ b/src/Http/Controllers/HandlesOAuthErrors.php
@@ -30,7 +30,7 @@ trait HandlesOAuthErrors
         } catch (Exception $e) {
             $this->exceptionHandler()->report($e);
 
-            return new Response($e->getMessage(), 500);
+            return $this->exceptionHandler()->render(request(), $e);
         } catch (Throwable $e) {
             $this->exceptionHandler()->report(new FatalThrowableError($e));
 

--- a/src/Http/Controllers/HandlesOAuthErrors.php
+++ b/src/Http/Controllers/HandlesOAuthErrors.php
@@ -30,7 +30,7 @@ trait HandlesOAuthErrors
         } catch (Exception $e) {
             $this->exceptionHandler()->report($e);
 
-            return $this->exceptionHandler()->render(request(), $e);
+            return $this->exceptionHandler()->render(\request(), $e);
         } catch (Throwable $e) {
             $this->exceptionHandler()->report(new FatalThrowableError($e));
 


### PR DESCRIPTION
It is not possible to throw a custom exception inside of custom Grant Types. The Laravel Passport shows exception message instead of rendering it.

This will fix it.