### PR TITLE
updated firebase/php-jwt dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "firebase/php-jwt": "~3.0|~4.0",
+        "firebase/php-jwt": "~3.0|~4.0|~5.0",
         "guzzlehttp/guzzle": "~6.0",
         "illuminate/auth": "~5.4",
         "illuminate/console": "~5.4",


### PR DESCRIPTION
updated firebase/php-jwt dependency which does not have any breaking changes so that it can be useful to use with when the project has 5.0 as dependency for firebase/php-jwt