### PR TITLE
CreateFreshApiToken doesn't issue a token

### DIFF
--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -88,7 +88,7 @@ class CreateFreshApiToken
      */
     protected function responseShouldReceiveFreshToken($response)
     {
-        return $this->alreadyContainsToken($response);
+        return ! $this->alreadyContainsToken($response);
     }
 
     /**


### PR DESCRIPTION
For some reasons it was removed 3 weeks ago by @rscafi
https://github.com/laravel/passport/commit/df5ddb28318a6ffac2cb0c96fc30e045afa2f9b9#diff-21f5bd46f0aa959bdc94060671ea5b18L92
Maybe mistake, not sure.

But current dev version doesn't issue tokens at all.