### PR TITLE
Bump coverage for Controllers and Middlewares 

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,4 +15,9 @@
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -31,6 +31,27 @@ class CheckClientCredentialsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('response', $response);
     }
 
+    public function test_request_is_passed_along_if_token_and_scope_are_valid()
+    {
+        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
+        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['see-profile']);
+
+        $middleware = new CheckClientCredentials($resourceServer);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $response = $middleware->handle($request, function () {
+            return 'response';
+        });
+
+        $this->assertEquals('response', $response);
+    }
+
     /**
      * @expectedException Illuminate\Auth\AuthenticationException
      */

--- a/tests/CreateFreshApiTokenTest.php
+++ b/tests/CreateFreshApiTokenTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Laravel\Passport\Http\Middleware\CreateFreshApiToken;
+use Laravel\Passport\Passport;
+
+class CreateFreshApiTokenTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function testShouldReceiveAFreshToken()
+    {
+        $cookieFactory = Mockery::mock(\Laravel\Passport\ApiTokenCookieFactory::class);
+
+        $middleware = new CreateFreshApiToken($cookieFactory);
+        $request = Mockery::mock(Request::class)->makePartial();
+
+        $response = new Response;
+
+        $guard = 'guard';
+        $user = Mockery::mock()
+            ->shouldReceive('getKey')
+            ->andReturn($userKey = 1)
+            ->getMock();
+
+        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request->shouldReceive('isMethod')->with('GET')->once()->andReturn(true);
+        $request->shouldReceive('user')->with($guard)->twice()->andReturn($user);
+        $session->shouldReceive('token')->withNoArgs()->once()->andReturn($token = 't0k3n');
+
+        $cookieFactory->shouldReceive('make')
+            ->with($userKey, $token)
+            ->once()
+            ->andReturn(new \Symfony\Component\HttpFoundation\Cookie(Passport::cookie()));
+
+        $result = $middleware->handle($request, function () use ($response) {
+            return $response;
+        }, $guard);
+
+        $this->assertSame($response, $result);
+        $this->assertTrue($this->hasPassportCookie($response));
+    }
+
+    public function testShouldNotReceiveAFreshTokenForOtherHttpVerbs()
+    {
+        $cookieFactory = Mockery::mock(\Laravel\Passport\ApiTokenCookieFactory::class);
+
+        $middleware = new CreateFreshApiToken($cookieFactory);
+        $request = Request::create('/', 'POST');
+        $response = new Response;
+
+        $result = $middleware->handle($request, function () use ($response) {
+            return $response;
+        });
+
+        $this->assertSame($response, $result);
+        $this->assertFalse($this->hasPassportCookie($response));
+    }
+
+    public function testShouldNotReceiveAFreshTokenForAnInvalidUser()
+    {
+        $cookieFactory = Mockery::mock(\Laravel\Passport\ApiTokenCookieFactory::class);
+
+        $middleware = new CreateFreshApiToken($cookieFactory);
+        $request = Request::create('/', 'GET');
+        $response = new Response;
+
+        $request->setUserResolver(function () {});
+
+        $result = $middleware->handle($request, function () use ($response) {
+            return $response;
+        });
+
+        $this->assertSame($response, $result);
+        $this->assertFalse($this->hasPassportCookie($response));
+    }
+
+    public function testShouldNotReceiveAFreshTokenForResponseThatAlreadyHasToken()
+    {
+        $cookieFactory = Mockery::mock(\Laravel\Passport\ApiTokenCookieFactory::class);
+
+        $middleware = new CreateFreshApiToken($cookieFactory);
+        $request = Request::create('/', 'GET');
+
+        $response = (new Response)->withCookie(
+            new \Symfony\Component\HttpFoundation\Cookie(Passport::cookie())
+        );
+
+        $request->setUserResolver(function () {
+            return Mockery::mock()
+                ->shouldReceive('getKey')
+                ->andReturn(1)
+                ->getMock();
+        });
+
+        $result = $middleware->handle($request, function () use ($response) {
+            return $response;
+        });
+
+        $this->assertSame($response, $result);
+        $this->assertTrue($this->hasPassportCookie($response));
+    }
+
+    private function hasPassportCookie($response)
+    {
+        foreach ($response->headers->getCookies() as $cookie) {
+            if ($cookie->getName() === Passport::cookie()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -92,6 +92,29 @@ class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('http://localhost#error=access_denied&state=state', $controller->deny($request));
     }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Authorization request was not present in the session.
+     */
+    public function test_auth_request_should_exist()
+    {
+        $response = Mockery::mock(ResponseFactory::class);
+
+        $controller = new Laravel\Passport\Http\Controllers\DenyAuthorizationController($response);
+
+        $request = Mockery::mock('Illuminate\Http\Request');
+
+        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request->shouldReceive('user')->never();
+        $request->shouldReceive('input')->never();
+
+        $session->shouldReceive('get')->once()->with('authRequest')->andReturnNull();
+
+        $response->shouldReceive('redirectTo')->never();
+
+        $controller->deny($request);
+    }
 }
 
 class DenyAuthorizationControllerFakeUser

--- a/tests/HandlesOAuthErrorsTest.php
+++ b/tests/HandlesOAuthErrorsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Http\Response;
+
+class HandlesOAuthErrorsTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function testShouldReturnCallbackResultIfNoErrorIsThrown()
+    {
+        $controller = new HandlesOAuthErrorsStubController;
+        $response = new Response;
+
+        $result = $controller->test(function () use ($response) {
+            return $response;
+        });
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testShouldHandleOAuthServerException()
+    {
+        Container::getInstance()->instance(ExceptionHandler::class, $handler = Mockery::mock());
+
+        $controller = new HandlesOAuthErrorsStubController;
+        $exception = new \League\OAuth2\Server\Exception\OAuthServerException('Error', 1, 'fatal');
+
+        $handler->shouldReceive('report')->once()->with($exception);
+
+        $result = $controller->test(function () use ($exception) {
+            throw $exception;
+        });
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertJsonStringEqualsJsonString('{"error":"fatal","message":"Error"}', $result->content());
+    }
+
+    public function testShouldHandleOtherExceptions()
+    {
+        Container::getInstance()->instance(ExceptionHandler::class, $handler = Mockery::mock());
+
+        $controller = new HandlesOAuthErrorsStubController;
+        $exception = new RuntimeException('Exception occurred', 1);
+
+        $handler->shouldReceive('report')->once()->with($exception);
+
+        $result = $controller->test(function () use ($exception) {
+            throw $exception;
+        });
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame('Exception occurred', $result->content());
+    }
+
+    public function testShouldHandleThrowables()
+    {
+        Container::getInstance()->instance(ExceptionHandler::class, $handler = Mockery::mock());
+
+        $controller = new HandlesOAuthErrorsStubController;
+        $exception = new Error('Fatal Error', 1);
+
+        $handler->shouldReceive('report')
+            ->once()
+            ->with(Mockery::type(Symfony\Component\Debug\Exception\FatalThrowableError::class));
+
+        $result = $controller->test(function () use ($exception) {
+            throw $exception;
+        });
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame('Fatal Error', $result->content());
+    }
+}
+
+class HandlesOAuthErrorsStubController
+{
+    use \Laravel\Passport\Http\Controllers\HandlesOAuthErrors;
+
+    public function test($callback)
+    {
+        return $this->withErrorHandling($callback);
+    }
+}

--- a/tests/HandlesOAuthErrorsTest.php
+++ b/tests/HandlesOAuthErrorsTest.php
@@ -66,7 +66,7 @@ class HandlesOAuthErrorsTest extends PHPUnit_Framework_TestCase
 
         $handler->shouldReceive('report')
             ->once()
-            ->with(Mockery::type(Symfony\Component\Debug\Exception\FatalThrowableError::class));
+            ->with(Mockery::type(Exception::class));
 
         $result = $controller->test(function () use ($exception) {
             throw $exception;

--- a/tests/KeysCommandTest.php
+++ b/tests/KeysCommandTest.php
@@ -48,11 +48,26 @@ class KeysCommandTest extends PHPUnit_Framework_TestCase
             ->with('Encryption keys generated successfully.')
             ->getMock();
 
-        $rsa = new phpseclib\Crypt\RSA();
-
-        $command->handle($rsa);
+        $command->handle(new phpseclib\Crypt\RSA);
 
         $this->assertFileExists(custom_path('oauth-private.key'));
         $this->assertFileExists(custom_path('oauth-public.key'));
+
+        return $command;
+    }
+
+    /**
+     * @depends testPrivateAndPublicKeysAreGeneratedInCustomPath
+     */
+    public function testPrivateAndPublicKeysShouldNotBeGeneratedTwice($command)
+    {
+        $command->shouldReceive('option')
+            ->with('force')
+            ->andReturn(false);
+
+        $command->shouldReceive('error')
+            ->with('Encryption keys already exist. Use the --force option to overwrite them.');
+
+        $command->handle(new phpseclib\Crypt\RSA);
     }
 }

--- a/tests/ScopeControllerTest.php
+++ b/tests/ScopeControllerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class ScopeControllerTest extends PHPUnit_Framework_TestCase
+{
+    public function testShouldGetScopes()
+    {
+        $controller = new \Laravel\Passport\Http\Controllers\ScopeController;
+
+        \Laravel\Passport\Passport::tokensCan($scopes = [
+            'place-orders' => 'Place orders',
+            'check-status' => 'Check order status',
+        ]);
+
+        $result = $controller->all();
+
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(\Laravel\Passport\Scope::class, $result);
+        $this->assertSame(['id' => 'place-orders', 'description' => 'Place orders'], $result[0]->toArray());
+        $this->assertSame(['id' => 'check-status', 'description' => 'Check order status'], $result[1]->toArray());
+    }
+}


### PR DESCRIPTION
**No source files were touched, only tests were added.**

Now `Controllers` and `Middleware` namespaces both have 100% coverage, especially `CreateFreshApiToken` class, which had a bug introduced by my last PR.