### PR TITLE
Change the checkbox label to description instead id

### DIFF
--- a/resources/assets/js/components/PersonalAccessTokens.vue
+++ b/resources/assets/js/components/PersonalAccessTokens.vue
@@ -106,7 +106,7 @@
                                                     @click="toggleScope(scope.id)"
                                                     :checked="scopeIsAssigned(scope.id)">
 
-                                                    {{ scope.id }}
+                                                    {{ scope.description }}
                                             </label>
                                         </div>
                                     </div>


### PR DESCRIPTION
Change the scopes checkbox label to description instead id in create access token modal.