### PR TITLE
[Laravel 5.5] Get proper errors field from JSON response

### DIFF
--- a/resources/assets/js/components/Clients.vue
+++ b/resources/assets/js/components/Clients.vue
@@ -333,7 +333,7 @@
                     })
                     .catch(error => {
                         if (typeof error.response.data === 'object') {
-                            form.errors = _.flatten(_.toArray(error.response.data));
+                            form.errors = _.flatten(_.toArray(error.response.data.errors));
                         } else {
                             form.errors = ['Something went wrong. Please try again.'];
                         }

--- a/resources/assets/js/components/PersonalAccessTokens.vue
+++ b/resources/assets/js/components/PersonalAccessTokens.vue
@@ -252,7 +252,7 @@
                         })
                         .catch(error => {
                             if (typeof error.response.data === 'object') {
-                                this.form.errors = _.flatten(_.toArray(error.response.data));
+                                this.form.errors = _.flatten(_.toArray(error.response.data.errors));
                             } else {
                                 this.form.errors = ['Something went wrong. Please try again.'];
                             }


### PR DESCRIPTION
As of Laravel 5.5 errors are wrapped within "errors" field in json response. This causes wrong values being shown in passport components.