### PR TITLE
Check that withCookie method exists in response

### DIFF
--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -88,7 +88,8 @@ class CreateFreshApiToken
      */
     protected function responseShouldReceiveFreshToken($response)
     {
-        return ! $this->alreadyContainsToken($response);
+        return method_exists($response, 'withCookie') &&
+               ! $this->alreadyContainsToken($response);
     }
 
     /**


### PR DESCRIPTION
When returning a `BinaryFileResponse`, e.g. `return response()->download($path);` I get this exception:

```
Call to undefined method Symfony\Component\HttpFoundation\BinaryFileResponse::withCookie() in file /vendor/laravel/passport/src/Http/Middleware/CreateFreshApiToken.php on line 51
```

In Passport 3.0, it would check if the the response was an instanceof the `Illuminate\Http\Response` class. That check was removed because they now extend other Symfony classes directly, so certain response types which do not use the `ResponseTrait` throw this exception.