### PR TITLE
Fixed small typo in command option description

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -11,7 +11,7 @@ class InstallCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'passport:install {--force : Overwrite keys they already exist}';
+    protected $signature = 'passport:install {--force : Overwrite keys if they already exist}';
 
     /**
      * The console command description.


### PR DESCRIPTION
I fixed a small typo in command option description, this time in the correct branch.