### PR TITLE
Allow * for client_credentials

### DIFF
--- a/src/Bridge/ScopeRepository.php
+++ b/src/Bridge/ScopeRepository.php
@@ -25,7 +25,7 @@ class ScopeRepository implements ScopeRepositoryInterface
         array $scopes, $grantType,
         ClientEntityInterface $clientEntity, $userIdentifier = null)
     {
-        if (! in_array($grantType, ['password', 'personal_access'])) {
+        if (! in_array($grantType, ['password', 'personal_access', 'client_credentials'])) {
             $scopes = collect($scopes)->reject(function ($scope) {
                 return trim($scope->getIdentifier()) === '*';
             })->values()->all();


### PR DESCRIPTION
PR for the issue https://github.com/laravel/passport/issues/516 

This, as far as I know, fixes the issue (allows `*` to be specified on client_credential grants).

Without this in, if you try to create a `client_credentials` access token, with just `*` specified as the scope, in the `oauth_access_tokens` table, the access token has an empty array of scopes.

With this fix, it correctly specified `[*]` as the scopes.