### PR TITLE
Fixed exception when returning a download response using CreateFreshApiToken middleware

### DIFF
--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Response;
 use Laravel\Passport\Passport;
 use Laravel\Passport\ApiTokenCookieFactory;
 
@@ -88,7 +89,7 @@ class CreateFreshApiToken
      */
     protected function responseShouldReceiveFreshToken($response)
     {
-        return ! $this->alreadyContainsToken($response);
+        return $response instanceof Response && !$this->alreadyContainsToken($response);
     }
 
     /**


### PR DESCRIPTION
Fixes #489 where returning a BinaryFileResponse would cause an exception to be thrown.