### PR TITLE
Add the ability to mark a client as trusted

### DIFF
--- a/database/migrations/2016_06_01_000006_alter_oauth_clients_table_add_trusted_column.php
+++ b/database/migrations/2016_06_01_000006_alter_oauth_clients_table_add_trusted_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AlterOauthClientsTableAddTrustedColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->boolean('trusted')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->dropColumn('trusted');
+        });
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -38,6 +38,7 @@ class Client extends Model
         'personal_access_client' => 'bool',
         'password_client' => 'bool',
         'revoked' => 'bool',
+        'trusted' => 'bool',
     ];
 
     /**

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -91,7 +91,7 @@ class ClientRepository
      * @param  bool  $password
      * @return \Laravel\Passport\Client
      */
-    public function create($userId, $name, $redirect, $personalAccess = false, $password = false)
+    public function create($userId, $name, $redirect, $personalAccess = false, $password = false, $trusted = false)
     {
         $client = (new Client)->forceFill([
             'user_id' => $userId,
@@ -101,6 +101,7 @@ class ClientRepository
             'personal_access_client' => $personalAccess,
             'password_client' => $password,
             'revoked' => false,
+            'trusted' => $trusted,
         ]);
 
         $client->save();

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -69,7 +69,7 @@ class AuthorizationController
                 $client = $clients->find($authRequest->getClient()->getIdentifier())
             );
 
-            if ($token && $token->scopes === collect($scopes)->pluck('id')->all()) {
+            if (($token && $token->scopes === collect($scopes)->pluck('id')->all()) || $client->trusted) {
                 return $this->approveRequest($authRequest, $user);
             }
 


### PR DESCRIPTION
As of issue #243 it is sometimes necessary to skip to authorization dialog for trusted first or third part applications.

This PR adds the ability to mark a client as trusted and skip the authorization dialog.