### PR TITLE
Support for Multi Guards

### DIFF
--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -17,6 +17,7 @@ class CreateOauthClientsTable extends Migration
             $table->increments('id');
             $table->integer('user_id')->index()->nullable();
             $table->string('name');
+            $table->string('guard_name')->nullable();
             $table->string('secret', 100);
             $table->text('redirect');
             $table->boolean('personal_access_client');

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,12 @@ Laravel Passport is an OAuth2 server and API authentication package that is simp
 
 Documentation for Passport can be found on the [Laravel website](http://laravel.com/docs/master/passport).
 
+For Multi Guards usage
+* Add guard name to your client on "guard_name" column.
+* Using different guard you should send it on request as well as setting it up
+ 
+    request()->route()->middleware('guardName');
+ 
 ## License
 
 Laravel Passport is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -9,20 +9,30 @@ use League\OAuth2\Server\Entities\ClientEntityInterface;
 class Client implements ClientEntityInterface
 {
     use ClientTrait, EntityTrait;
+    protected $guard;
 
     /**
      * Create a new client instance.
      *
      * @param  string  $identifier
      * @param  string  $name
+     * @param  string  $guard
      * @param  string  $redirectUri
      * @return void
      */
-    public function __construct($identifier, $name, $redirectUri)
+    public function __construct($identifier, $name, $guard, $redirectUri)
     {
         $this->setIdentifier($identifier);
-
+        $this->guard = $guard;
         $this->name = $name;
         $this->redirectUri = explode(',', $redirectUri);
+    }
+
+    /**
+     * Returns the registered guard name (as a string).
+     * @return string
+     */
+    public function getGuard(){
+        return $this->guard;
     }
 }

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -44,7 +44,7 @@ class ClientRepository implements ClientRepositoryInterface
         // and verify the secret if necessary. If the secret is valid we will be ready to
         // return this client instance back out to the consuming methods and finish up.
         $client = new Client(
-            $clientIdentifier, $record->name, $record->redirect
+            $clientIdentifier, $record->name,$record->guard_name, $record->redirect
         );
 
         if ($mustValidateSecret &&

--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -32,7 +32,7 @@ class UserRepository implements UserRepositoryInterface
      */
     public function getUserEntityByUserCredentials($username, $password, $grantType, ClientEntityInterface $clientEntity)
     {
-        $provider = config('auth.guards.api.provider');
+        $provider = config('auth.guards.'.($clientEntity->getGuard() ? $clientEntity->getGuard() : 'api').'.provider');
 
         if (is_null($model = config('auth.providers.'.$provider.'.model'))) {
             throw new RuntimeException('Unable to determine authentication model from configuration.');


### PR DESCRIPTION
Tweaked it to support multi guards using a column on clients table to store guard_name
to use multi guards all you need to do is 

1. Add guard name to your client on "guard_name" column.
2. send guard_name on request on your __construct()
`request()->route()->middleware('guardName');`
Ex
```
        $this->middleware('auth:admin');
        $request->route()->middleware('admin');
```