### PR TITLE
use app.url config instead of localhost hardcode

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -58,7 +58,7 @@ class ClientCommand extends Command
         );
 
         $client = $clients->createPersonalAccessClient(
-            null, $name, 'http://localhost'
+            null, $name, config('app.url')
         );
 
         $accessClient = new PersonalAccessClient();
@@ -84,7 +84,7 @@ class ClientCommand extends Command
         );
 
         $client = $clients->createPasswordGrantClient(
-            null, $name, 'http://localhost'
+            null, $name, config('app.url')
         );
 
         $this->info('Password grant client created successfully.');


### PR DESCRIPTION
"php artisan passport:install" command inserts 2 rows into the oauth_clients table.
but the redirect column was hardcoded with 'localhost'.
this change uses values from our app.url config instead