### PR TITLE
A fresh token should also be returned on JsonResponse classes

### DIFF
--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -90,7 +90,7 @@ class CreateFreshApiToken
      */
     protected function responseShouldReceiveFreshToken($response)
     {
-        return $response instanceof Response || $response instanceof JsonResponse && ! $this->alreadyContainsToken($response);
+        return ($response instanceof Response || $response instanceof JsonResponse) && ! $this->alreadyContainsToken($response);
     }
 
     /**

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Laravel\Passport\Passport;
 use Laravel\Passport\ApiTokenCookieFactory;
@@ -89,7 +90,7 @@ class CreateFreshApiToken
      */
     protected function responseShouldReceiveFreshToken($response)
     {
-        return $response instanceof Response && ! $this->alreadyContainsToken($response);
+        return $response instanceof Response || $response instanceof JsonResponse && ! $this->alreadyContainsToken($response);
     }
 
     /**


### PR DESCRIPTION
I added the ability to allow a new token to be given to first party applications from json requests. This way it's possible to implement login functionality without going outside the single page application. The option was there until the commit [2a8198d](https://github.com/laravel/passport/commit/2a8198db7e757ca67ac88e4a8ce6984a2118bc45) that fixed issue [#489](https://github.com/laravel/passport/issues/489). The current commit allows both file downloads and json responses to work properly and close issue [#540](https://github.com/laravel/passport/issues/540)