### PR TITLE
Cast to string the 'identifier' field for Client.

### DIFF
--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientEntityInterface
      */
     public function __construct($identifier, $name, $redirectUri)
     {
-        $this->setIdentifier($identifier);
+        $this->setIdentifier((string) $identifier);
 
         $this->name = $name;
         $this->redirectUri = explode(',', $redirectUri);


### PR DESCRIPTION
The AuthCodeGrant class gets the client identifier of the object obtained from the client repository and compare it with the client_id from request, however the comparison is made using 'not identical'
operator which fails due to the type obtained from the repository (integer) and the type from the request (string).

According to the dock block in League\OAuth2\Server\Entities\Traits\EntityTrait the return type
for the getIdentifier method, must be a string.