### PR TITLE
Support X-XSRF-TOKEN header.

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -201,7 +201,8 @@ class TokenGuard
     protected function validCsrf($token, $request)
     {
         return isset($token['csrf']) && hash_equals(
-            $token['csrf'], (string) $request->header('X-CSRF-TOKEN')
+            $token['csrf'],
+            (string)($request->header('X-CSRF-TOKEN') ?: $this->encrypter->decrypt($request->header('X-XSRF-TOKEN')))
         );
     }
 }


### PR DESCRIPTION
Fix to be able to authenticate not only with `X-CSRF-TOKEN` header but also with encrypted `X-XSRF-TOKEN` header.

As stated in https://laravel.com/docs/5.5/csrf#csrf-x-xsrf-token, `X-XSRF-TOKEN` is a header automatically generated by the JavaScript framework. The `VerifyCsrfToken` middleware on Laravel already supports this.