### PR TITLE
[4.0] Updated mockery in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "zendframework/zend-diactoros": "~1.0"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9",
+        "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~5.0"
     },
     "autoload": {


### PR DESCRIPTION
Updated [`mockery/mockery`](https://github.com/mockery/mockery) to [`~1.0`](https://github.com/mockery/mockery/releases/tag/1.0).