### PR TITLE
[5.0] Update to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.0",
         "firebase/php-jwt": "~3.0|~4.0",
         "guzzlehttp/guzzle": "~6.0",
         "illuminate/auth": "~5.4",
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"

--- a/tests/AccessTokenControllerTest.php
+++ b/tests/AccessTokenControllerTest.php
@@ -1,9 +1,10 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 
-class AccessTokenControllerTest extends PHPUnit_Framework_TestCase
+class AccessTokenControllerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ApiTokenCookieFactoryTest.php
+++ b/tests/ApiTokenCookieFactoryTest.php
@@ -1,9 +1,10 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Encryption\Encrypter;
 use Laravel\Passport\ApiTokenCookieFactory;
 
-class ApiTokenCookieFactoryTest extends PHPUnit_Framework_TestCase
+class ApiTokenCookieFactoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ApproveAuthorizationControllerTest.php
+++ b/tests/ApproveAuthorizationControllerTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use League\OAuth2\Server\AuthorizationServer;
 
-class ApproveAuthorizationControllerTest extends PHPUnit_Framework_TestCase
+class ApproveAuthorizationControllerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -1,11 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use League\OAuth2\Server\AuthorizationServer;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Routing\ResponseFactory;
 
-class AuthorizationControllerTest extends PHPUnit_Framework_TestCase
+class AuthorizationControllerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/AuthorizedAccessTokenControllerTest.php
+++ b/tests/AuthorizedAccessTokenControllerTest.php
@@ -3,10 +3,11 @@
 use Mockery\Mock;
 use Illuminate\Http\Request;
 use Laravel\Passport\Client;
+use PHPUnit\Framework\TestCase;
 use Laravel\Passport\TokenRepository;
 use Laravel\Passport\Http\Controllers\AuthorizedAccessTokenController;
 
-class AuthorizedAccessTokenControllerTest extends PHPUnit_Framework_TestCase
+class AuthorizedAccessTokenControllerTest extends TestCase
 {
     /**
      * @var Mock|TokenRepository

--- a/tests/BridgeAccessTokenRepositoryTest.php
+++ b/tests/BridgeAccessTokenRepositoryTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
 
-class BridgeAccessTokenRepositoryTest extends PHPUnit_Framework_TestCase
+class BridgeAccessTokenRepositoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Bridge\ClientRepository;
 
-class BridgeClientRepositoryTest extends PHPUnit_Framework_TestCase
+class BridgeClientRepositoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/BridgeScopeRepositoryTest.php
+++ b/tests/BridgeScopeRepositoryTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Laravel\Passport\Passport;
+use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Bridge\Scope;
 use Laravel\Passport\Bridge\Client;
 use Laravel\Passport\Bridge\ScopeRepository;
 
-class BridgeScopeRepositoryTest extends PHPUnit_Framework_TestCase
+class BridgeScopeRepositoryTest extends TestCase
 {
     public function test_invalid_scopes_are_removed()
     {

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
 
-class CheckClientCredentialsTest extends PHPUnit_Framework_TestCase
+class CheckClientCredentialsTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/CheckForAnyScopeTest.php
+++ b/tests/CheckForAnyScopeTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Http\Middleware\CheckForAnyScope as CheckScopes;
 
-class CheckForAnyScopesTest extends PHPUnit_Framework_TestCase
+class CheckForAnyScopesTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/CheckScopesTest.php
+++ b/tests/CheckScopesTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Http\Middleware\CheckScopes;
 
-class CheckScopesTest extends PHPUnit_Framework_TestCase
+class CheckScopesTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ClientControllerTest.php
+++ b/tests/ClientControllerTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 
-class ClientControllerTest extends PHPUnit_Framework_TestCase
+class ClientControllerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Routing\ResponseFactory;
 
-class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
+class DenyAuthorizationControllerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/HasApiTokensTest.php
+++ b/tests/HasApiTokensTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 
-class HasApiTokensTest extends PHPUnit_Framework_TestCase
+class HasApiTokensTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/KeysCommandTest.php
+++ b/tests/KeysCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 function storage_path($file = null)
 {
     return __DIR__.DIRECTORY_SEPARATOR.$file;
@@ -10,7 +12,7 @@ function custom_path($file = null)
     return __DIR__.DIRECTORY_SEPARATOR.'files'.DIRECTORY_SEPARATOR.$file;
 }
 
-class KeysCommandTest extends PHPUnit_Framework_TestCase
+class KeysCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/PassportTest.php
+++ b/tests/PassportTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Laravel\Passport\Passport;
+use PHPUnit\Framework\TestCase;
 
-class PassportTest extends PHPUnit_Framework_TestCase
+class PassportTest extends TestCase
 {
     public function test_scopes_can_be_managed()
     {

--- a/tests/PersonalAccessTokenControllerTest.php
+++ b/tests/PersonalAccessTokenControllerTest.php
@@ -2,9 +2,10 @@
 
 use Illuminate\Http\Request;
 use Laravel\Passport\Passport;
+use PHPUnit\Framework\TestCase;
 use Laravel\Passport\TokenRepository;
 
-class PersonalAccessTokenControllerTest extends PHPUnit_Framework_TestCase
+class PersonalAccessTokenControllerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/PersonalAccessTokenFactoryTest.php
+++ b/tests/PersonalAccessTokenFactoryTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class PersonalAccessTokenFactoryTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PersonalAccessTokenFactoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class ScopeTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ScopeTest extends TestCase
 {
     public function test_scope_can_be_converted_to_array()
     {

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -3,10 +3,11 @@
 use Carbon\Carbon;
 use Firebase\JWT\JWT;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Laravel\Passport\Guards\TokenGuard;
 
-class TokenGuardTest extends PHPUnit_Framework_TestCase
+class TokenGuardTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class TokenTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class TokenTest extends TestCase
 {
     public function test_token_can_determine_if_it_has_scopes()
     {

--- a/tests/TransientTokenControllerTest.php
+++ b/tests/TransientTokenControllerTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
 
-class TransientTokenControllerTest extends PHPUnit_Framework_TestCase
+class TransientTokenControllerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/TransientTokenTest.php
+++ b/tests/TransientTokenTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class TransientTokenTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class TransientTokenTest extends TestCase
 {
     public function test_transient_token_can_do_anything()
     {


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0`.

Dropped support to `PHP 5.6`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25)?

PS: I've used [this commit](https://github.com/laravel/framework/pull/17864) from `laravel/framework` to prevent failed tests.