### PR TITLE
Changed private properties and functions to protected.

### DIFF
--- a/src/Bridge/AccessTokenRepository.php
+++ b/src/Bridge/AccessTokenRepository.php
@@ -26,7 +26,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      *
      * @var \Illuminate\Contracts\Events\Dispatcher
      */
-    private $events;
+    protected $events;
 
     /**
      * Create a new repository instance.

--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -16,7 +16,7 @@ class CheckClientCredentials
      *
      * @var \League\OAuth2\Server\ResourceServer
      */
-    private $server;
+    protected $server;
 
     /**
      * Create a new middleware instance.

--- a/tests/CreateFreshApiTokenTest.php
+++ b/tests/CreateFreshApiTokenTest.php
@@ -105,7 +105,7 @@ class CreateFreshApiTokenTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->hasPassportCookie($response));
     }
 
-    private function hasPassportCookie($response)
+    protected function hasPassportCookie($response)
     {
         foreach ($response->headers->getCookies() as $cookie) {
             if ($cookie->getName() === Passport::cookie()) {


### PR DESCRIPTION
There are two class properties and one test function that are marked as `private`. This PR changes their visibility to `protected`.

While this doesn't matter much for the test function, the private property requires the developer to redefine the property when extending the affected classes (which is how I came across the issue).