### PR TITLE
Add authenticated event for bearer tokens

### DIFF
--- a/src/Events/Authenticated.php
+++ b/src/Events/Authenticated.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Laravel\Passport\Events;
+
+class Authenticated
+{
+    /**
+     * The newly created token ID.
+     *
+     * @var string
+     */
+    public $tokenId;
+
+    /**
+     * The user associated with the token.
+     *
+     * @var string
+     */
+    public $user;
+
+    /**
+     * The ID of the client associated with the token.
+     *
+     * @var string
+     */
+    public $clientId;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $tokenId
+     * @param  string  $user
+     * @param  string  $clientId
+     * @return void
+     */
+    public function __construct($tokenId, $user, $clientId)
+    {
+        $this->user = $user;
+        $this->tokenId = $tokenId;
+        $this->clientId = $clientId;
+    }
+}

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -148,9 +148,9 @@ class TokenGuard
                 return;
             }
 
-            if($user->withAccessToken($token)) {
+            if($token) {
                 $this->events->dispatch(new Authenticated($token->id, $user, $clientId));
-                return $token;
+                return $user->withAccessToken($token);
             }
 
             return null;

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -16,6 +16,8 @@ use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Passport\Events\Authenticated;
 
 class TokenGuard
 {
@@ -55,6 +57,13 @@ class TokenGuard
     protected $encrypter;
 
     /**
+     * The event dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    private $events;
+
+    /**
      * Create a new token guard instance.
      *
      * @param  \League\OAuth2\Server\ResourceServer  $server
@@ -62,19 +71,22 @@ class TokenGuard
      * @param  \Laravel\Passport\TokenRepository  $tokens
      * @param  \Laravel\Passport\ClientRepository  $clients
      * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @return void
      */
     public function __construct(ResourceServer $server,
                                 UserProvider $provider,
                                 TokenRepository $tokens,
                                 ClientRepository $clients,
-                                Encrypter $encrypter)
+                                Encrypter $encrypter,
+                                Dispatcher $events)
     {
         $this->server = $server;
         $this->tokens = $tokens;
         $this->clients = $clients;
         $this->provider = $provider;
         $this->encrypter = $encrypter;
+        $this->events = $events;
     }
 
     /**
@@ -136,7 +148,12 @@ class TokenGuard
                 return;
             }
 
-            return $token ? $user->withAccessToken($token) : null;
+            if($user->withAccessToken($token)) {
+                $this->events->dispatch(new Authenticated($token->id, $user, $clientId));
+                return $token;
+            }
+
+            return null;
         } catch (OAuthServerException $e) {
             return Container::getInstance()->make(
                 ExceptionHandler::class

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -263,7 +263,8 @@ class PassportServiceProvider extends ServiceProvider
                 Auth::createUserProvider($config['provider']),
                 $this->app->make(TokenRepository::class),
                 $this->app->make(ClientRepository::class),
-                $this->app->make('encrypter')
+                $this->app->make('encrypter'),
+                $this->app['events']
             ))->user($request);
         }, $this->app['request']);
     }


### PR DESCRIPTION
I've added in a new Authenticated event to Passport which gets fired whenever a Bearer token is successfully authenticated. There's an open issue about this at #398 where some users would like to be able to set contexts or undertake other actions.