### PR TITLE
Test against PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 sudo: false
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != 7.1 ]] ; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != 7.2 ]] ; then phpenv config-rm xdebug.ini; fi
 
 install: travis_retry composer install --no-interaction --prefer-dist --no-suggest
 


### PR DESCRIPTION
With the release of [`PHP 7.2`](http://php.net/archive/2017.php#id2017-11-30-1), would be nice to test Passport against it.