### PR TITLE
Client.vue: frontend-quickstart vue import fix

### DIFF
--- a/resources/assets/js/components/Clients.vue
+++ b/resources/assets/js/components/Clients.vue
@@ -215,6 +215,8 @@
 </template>
 
 <script>
+    var axios = require('axios');
+    var _ = require('underscore');
     export default {
         /*
          * The component's data.


### PR DESCRIPTION
Axios and underscore libraries referenced but not included in script. I'm not sure if this is the proper way to handle these imports or if it was initially done by the authors at a higher level. However, the vanilla code requires these imports to suppress errors. #592 
  