### PR TITLE
Remove decrypt from TokenGuard.

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -186,7 +186,7 @@ class TokenGuard
     protected function decodeJwtTokenCookie($request)
     {
         return (array) JWT::decode(
-            $this->encrypter->decrypt($request->cookie(Passport::cookie())),
+            $request->cookie(Passport::cookie()),
             $this->encrypter->getKey(), ['HS256']
         );
     }

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -98,10 +98,10 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
         $request = Request::create('/');
         $request->headers->set('X-CSRF-TOKEN', 'token');
         $request->cookies->set('laravel_token',
-            $encrypter->encrypt(JWT::encode([
+            JWT::encode([
                 'sub' => 1, 'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)))
+            ], str_repeat('a', 16))
         );
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
@@ -124,10 +124,10 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
         $request = Request::create('/');
         $request->headers->set('X-CSRF-TOKEN', 'wrong_token');
         $request->cookies->set('laravel_token',
-            $encrypter->encrypt(JWT::encode([
+            JWT::encode([
                 'sub' => 1, 'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)))
+            ], str_repeat('a', 16))
         );
 
         $userProvider->shouldReceive('retrieveById')->never();
@@ -148,10 +148,10 @@ class TokenGuardTest extends PHPUnit_Framework_TestCase
         $request = Request::create('/');
         $request->headers->set('X-CSRF-TOKEN', 'token');
         $request->cookies->set('laravel_token',
-            $encrypter->encrypt(JWT::encode([
+            JWT::encode([
                 'sub' => 1, 'csrf' => 'token',
                 'expiry' => Carbon::now()->subMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)))
+            ], str_repeat('a', 16))
         );
 
         $userProvider->shouldReceive('retrieveById')->never();


### PR DESCRIPTION
After following the instructions for "Consuming Your API with JavaScript" the api requests return 401 unauthorized. This was because the JWT cookie being added to the site was not encrypted using laravels encryption service, however when it was being processed in the TokenGuard it was decrypted using laravels encryption service which threw an error.
This could either be fixed by encrypting the cookie before it is sent or removing the decryption code when it is received. I chose the latter as the token is encoded in the php-jwt package.
I apologise if I have missed something and this is the correct behaviour, or if I did the fix the wrong way round.