### PR TITLE
Get user id for new token from model

### DIFF
--- a/src/Bridge/AccessTokenRepository.php
+++ b/src/Bridge/AccessTokenRepository.php
@@ -54,7 +54,10 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      */
     public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity)
     {
-        if (($user_id = $accessTokenEntity->getUserIdentifier()) && !is_numeric($user_id)) {
+        // We'll get the user id from the accessTokenEntity. If it's numeric, assume it's a primary key.
+        // If it's not numeric, we'll have to find it using findForPassport,
+        // and then get the id from the returned model
+        if (($userId = $accessTokenEntity->getUserIdentifier()) && !is_numeric($userId)) {
             $provider = config('auth.guards.api.provider');
 
             if (is_null($model = config('auth.providers.'.$provider.'.model'))) {
@@ -65,14 +68,14 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
                 $user = (new $model)->findForPassport($accessTokenEntity->getUserIdentifier());
 
                 if ($user) {
-                    $user_id = $user->getKey();
+                    $userId = $user->getKey();
                 }
             }
         }
 
         $this->tokenRepository->create([
             'id' => $accessTokenEntity->getIdentifier(),
-            'user_id' => $user_id,
+            'user_id' => $userId,
             'client_id' => $accessTokenEntity->getClient()->getIdentifier(),
             'scopes' => $this->scopesToArray($accessTokenEntity->getScopes()),
             'revoked' => false,


### PR DESCRIPTION
`AccessTokenRepository->persistNewAccessToken` makes an assumption that the `$accessTokenEntity`'s user identifier contains the user model's primary key. Although this is the default, it may not be the case if the user model has overridden `getAuthIdentifierName` and is using another field (e.g., an email address). In this case, an incorrect identifier will be passed, and the `user_id` field on the token will be `null`, thereby breaking the relationship.

This attempts to rectify this by first checking if the passed value is numeric. If it is, we assume the primary key is being sent, and use that. If it's not, we check for the presence of `findForPassport` on the model, and use the primary key from the returned user.

Fixes #609 