### PR TITLE
Redirect denied authorization callbacks to the correct redirect_uri

### DIFF
--- a/src/Http/Controllers/DenyAuthorizationController.php
+++ b/src/Http/Controllers/DenyAuthorizationController.php
@@ -38,8 +38,12 @@ class DenyAuthorizationController
     {
         $authRequest = $this->getAuthRequestFromSession($request);
 
-        if (is_array($uri = $authRequest->getClient()->getRedirectUri())) {
-            $uri = Arr::first($uri);
+        $uri = $authRequest->getRedirectUri();
+        $client_uris = $authRequest->getClient()->getRedirectUri();
+        $client_uris = is_array($client_uris) ? $client_uris : array($client_uris);
+
+        if (!in_array($uri, $client_uris)) {
+            $uri = Arr::first($client_uris);
         }
 
         $separator = $authRequest->getGrantTypeId() === 'implicit' ? '#' : '?';

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -28,6 +28,7 @@ class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $authRequest->shouldReceive('setUser')->once();
         $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
+        $authRequest->shouldReceive('getRedirectUri')->andReturn('http://localhost');
         $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn('http://localhost');
 
         $response->shouldReceive('redirectTo')->once()->andReturnUsing(function ($url) {
@@ -56,7 +57,8 @@ class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $authRequest->shouldReceive('setUser')->once();
         $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
-        $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn(['http://localhost']);
+        $authRequest->shouldReceive('getRedirectUri')->andReturn('http://localhost');
+        $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn(['http://localhost.localdomain','http://localhost']);
 
         $response->shouldReceive('redirectTo')->once()->andReturnUsing(function ($url) {
             return $url;
@@ -84,6 +86,7 @@ class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $authRequest->shouldReceive('setUser')->once();
         $authRequest->shouldReceive('getGrantTypeId')->andReturn('implicit');
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
+        $authRequest->shouldReceive('getRedirectUri')->andReturn('http://localhost');
         $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn('http://localhost');
 
         $response->shouldReceive('redirectTo')->once()->andReturnUsing(function ($url) {


### PR DESCRIPTION
Redirect denied authorization callbacks to the redirect_uri in the authorization request if it is one of the redirect_uris configured for the client; otherwise, use the first redirect_uri configured for the client.

Fixes issue #621 