### PR TITLE
Added caching support for client and token repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /vendor
 composer.phar
 composer.lock

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Passport;
 
+use Illuminate\Support\Facades\Cache;
+
 class ClientRepository
 {
     /**


### PR DESCRIPTION
Just wrapped the repository functions with standard Laravel Cache facades, so if using caching in env it will cache tokens and clients for 1 minute. Invalidates on delete and update methods too.