### PR TITLE
Fix oauth_clients redirect to be stored as a native array

### DIFF
--- a/database/migrations/2016_06_01_000006_fix_oauth_clients_table_redirect_column.php
+++ b/database/migrations/2016_06_01_000006_fix_oauth_clients_table_redirect_column.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class FixOauthClientsTableRedirectColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::hasTable('oauth_clients')) {
+            $clients = DB::select('SELECT id, redirect FROM oauth_clients');
+
+            foreach($clients as $client) {
+                if (is_null(json_decode($client->redirect, true))) {
+                    $affected = DB::update('UPDATE oauth_clients SET redirect = :redirect WHERE id = :id', [
+                        'id' => $client->id,
+                        'redirect' => json_encode(explode(',', $client->redirect)),
+                    ]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::hasTable('oauth_clients')) {
+            $clients = DB::select('SELECT id, redirect FROM oauth_clients');
+
+            foreach($clients as $client) {
+                if (!is_null($redirect = json_decode($client->redirect, true))) {
+                    $affected = DB::update('UPDATE oauth_clients SET redirect = :redirect WHERE id = :id', [
+                        'id' => $client->id,
+                        'redirect' => implode(',', $redirect),
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/resources/assets/js/components/Clients.vue
+++ b/resources/assets/js/components/Clients.vue
@@ -6,6 +6,21 @@
     .m-b-none {
         margin-bottom: 0;
     }
+
+    .redirect-urls > .redirect-url {
+        margin-bottom: 5px;
+    }
+    .redirect-urls > .redirect-url .input-group {
+        width: 100%;
+    }
+
+    .redirect-urls > .redirect-url .input-group .form-control:first-child {
+        border-radius: 4px;
+    }
+    .redirect-urls > .redirect-url ~ .redirect-url .input-group .form-control:first-child {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
 </style>
 
 <template>
@@ -90,14 +105,10 @@
 
                     <div class="modal-body">
                         <!-- Form Errors -->
-                        <div class="alert alert-danger" v-if="createForm.errors.length > 0">
+                        <div class="alert alert-danger" v-if="createForm.errors.message">
                             <p><strong>Whoops!</strong> Something went wrong!</p>
                             <br>
-                            <ul>
-                                <li v-for="error in createForm.errors">
-                                    {{ error }}
-                                </li>
-                            </ul>
+                            {{ createForm.errors.message }}
                         </div>
 
                         <!-- Create Client Form -->
@@ -108,7 +119,15 @@
 
                                 <div class="col-md-7">
                                     <input id="create-client-name" type="text" class="form-control"
-                                                                @keyup.enter="store" v-model="createForm.name">
+                                                                @keyup.enter="store" v-model="createForm.fields.name">
+
+                                    <div class="alert alert-danger" v-if="createForm.errors.errors && createForm.errors.errors.name">
+                                        <ul>
+                                            <li v-for="error in createForm.errors.errors.name">
+                                                {{ error }}
+                                            </li>
+                                        </ul>
+                                    </div>
 
                                     <span class="help-block">
                                         Something your users will recognize and trust.
@@ -116,17 +135,36 @@
                                 </div>
                             </div>
 
-                            <!-- Redirect URL -->
+                            <!-- Redirect URLs -->
                             <div class="form-group">
-                                <label class="col-md-3 control-label">Redirect URL</label>
+                                <label class="col-md-3 control-label">Redirect URL(s)</label>
 
-                                <div class="col-md-7">
-                                    <input type="text" class="form-control" name="redirect"
-                                                    @keyup.enter="store" v-model="createForm.redirect">
+                                <div class="col-md-7 redirect-urls">
+                                    <div class="redirect-url" v-for="(url, index) in createForm.fields.redirect">
+                                        <div class="input-group">
+                                            <input type="text" class="form-control"
+                                                            @keyup.enter="store" v-model="createForm.fields.redirect[index]"/>
+
+                                            <div class="input-group-btn" v-if="index > 0">
+                                                <button class="btn btn-danger" 
+                                                            @click.stop.prevent="removeRedirectUrl(createForm, index)">X</button>
+                                            </div>
+                                        </div>
+
+                                        <div class="alert alert-danger" v-if="createForm.errors.errors && createForm.errors.errors['redirect.'+index]">
+                                            <ul>
+                                                <li v-for="error in createForm.errors.errors['redirect.'+index]">
+                                                    {{ error }}
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
 
                                     <span class="help-block">
-                                        Your application's authorization callback URL.
+                                        Your application's authorization callback URL(s).
                                     </span>
+
+                                    <button class="btn btn-success" @click.stop.prevent="addRedirectUrl(createForm)">Add Redirect URL</button>
                                 </div>
                             </div>
                         </form>
@@ -176,7 +214,15 @@
 
                                 <div class="col-md-7">
                                     <input id="edit-client-name" type="text" class="form-control"
-                                                                @keyup.enter="update" v-model="editForm.name">
+                                                                @keyup.enter="update" v-model="editForm.fields.name">
+
+                                    <div class="alert alert-danger" v-if="editForm.errors.errors && editForm.errors.errors.name">
+                                        <ul>
+                                            <li v-for="error in editForm.errors.errors.name">
+                                                {{ error }}
+                                            </li>
+                                        </ul>
+                                    </div>
 
                                     <span class="help-block">
                                         Something your users will recognize and trust.
@@ -184,17 +230,36 @@
                                 </div>
                             </div>
 
-                            <!-- Redirect URL -->
+                            <!-- Redirect URLs -->
                             <div class="form-group">
-                                <label class="col-md-3 control-label">Redirect URL</label>
+                                <label class="col-md-3 control-label">Redirect URL(s)</label>
 
-                                <div class="col-md-7">
-                                    <input type="text" class="form-control" name="redirect"
-                                                    @keyup.enter="update" v-model="editForm.redirect">
+                                <div class="col-md-7 redirect-urls">
+                                    <div class="redirect-url" v-for="(url, index) in editForm.fields.redirect">
+                                        <div class="input-group">
+                                            <input type="text" class="form-control"
+                                                            @keyup.enter="store" v-model="editForm.fields.redirect[index]"/>
+
+                                            <div class="input-group-btn" v-if="index > 0">
+                                                <button class="btn btn-danger" 
+                                                            @click.stop.prevent="removeRedirectUrl(editForm, index)">X</button>
+                                            </div>
+                                        </div>
+
+                                        <div class="alert alert-danger" v-if="editForm.errors.errors && editForm.errors.errors['redirect.'+index]">
+                                            <ul>
+                                                <li v-for="error in editForm.errors.errors['redirect.'+index]">
+                                                    {{ error }}
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
 
                                     <span class="help-block">
-                                        Your application's authorization callback URL.
+                                        Your application's authorization callback URL(s).
                                     </span>
+
+                                    <button class="btn btn-success" @click.stop.prevent="addRedirectUrl(editForm)">Add Redirect URL</button>
                                 </div>
                             </div>
                         </form>
@@ -225,14 +290,19 @@
 
                 createForm: {
                     errors: [],
-                    name: '',
-                    redirect: ''
+                    fields: {
+                        name: '',
+                        redirect: ['']
+                    }
                 },
 
                 editForm: {
+                    id: '',
                     errors: [],
-                    name: '',
-                    redirect: ''
+                    fields: {
+                        name: '',
+                        redirect: ['']
+                    }
                 }
             };
         },
@@ -268,6 +338,22 @@
             },
 
             /**
+             * Add redirect url to form
+             */
+            addRedirectUrl(form) {
+                form.fields.redirect.push('');
+            },
+
+            /**
+             * Remove specified redirect url from form
+             */
+            removeRedirectUrl(form, index) {
+                if (index > 0) {
+                    form.fields.redirect.splice(index, 1);
+                }
+            },
+
+            /**
              * Get all of the OAuth clients for the user.
              */
             getClients() {
@@ -299,8 +385,8 @@
              */
             edit(client) {
                 this.editForm.id = client.id;
-                this.editForm.name = client.name;
-                this.editForm.redirect = client.redirect;
+                this.editForm.fields.name = client.name;
+                this.editForm.fields.redirect = client.redirect;
 
                 $('#modal-edit-client').modal('show');
             },
@@ -321,21 +407,24 @@
             persistClient(method, uri, form, modal) {
                 form.errors = [];
 
-                axios[method](uri, form)
+                axios[method](uri, form.fields)
                     .then(response => {
                         this.getClients();
 
-                        form.name = '';
-                        form.redirect = '';
+                        form.fields.name = '';
+                        form.fields.redirect = [''];
                         form.errors = [];
+                        if (form.id) {
+                            form.id = '';
+                        }
 
                         $(modal).modal('hide');
                     })
                     .catch(error => {
                         if (typeof error.response.data === 'object') {
-                            form.errors = _.flatten(_.toArray(error.response.data));
+                            form.errors = error.response.data;
                         } else {
-                            form.errors = ['Something went wrong. Please try again.'];
+                            form.errors = {'message': 'Something went wrong. Please try again.'};
                         }
                     });
             },

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -18,11 +18,11 @@ class Client implements ClientEntityInterface
      * @param  string  $redirectUri
      * @return void
      */
-    public function __construct($identifier, $name, $redirectUri)
+    public function __construct($identifier, $name, array $redirectUri)
     {
         $this->setIdentifier((string) $identifier);
 
         $this->name = $name;
-        $this->redirectUri = explode(',', $redirectUri);
+        $this->redirectUri = $redirectUri;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -38,6 +38,7 @@ class Client extends Model
         'personal_access_client' => 'bool',
         'password_client' => 'bool',
         'revoked' => 'bool',
+        'redirect' => 'array',
     ];
 
     /**

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -86,12 +86,12 @@ class ClientRepository
      *
      * @param  int  $userId
      * @param  string  $name
-     * @param  string  $redirect
+     * @param  array  $redirect
      * @param  bool  $personalAccess
      * @param  bool  $password
      * @return \Laravel\Passport\Client
      */
-    public function create($userId, $name, $redirect, $personalAccess = false, $password = false)
+    public function create($userId, $name, array $redirect, $personalAccess = false, $password = false)
     {
         $client = (new Client)->forceFill([
             'user_id' => $userId,
@@ -113,10 +113,10 @@ class ClientRepository
      *
      * @param  int  $userId
      * @param  string  $name
-     * @param  string  $redirect
+     * @param  array  $redirect
      * @return \Laravel\Passport\Client
      */
-    public function createPersonalAccessClient($userId, $name, $redirect)
+    public function createPersonalAccessClient($userId, $name, array $redirect)
     {
         return $this->create($userId, $name, $redirect, true);
     }
@@ -126,10 +126,10 @@ class ClientRepository
      *
      * @param  int  $userId
      * @param  string  $name
-     * @param  string  $redirect
+     * @param  array  $redirect
      * @return \Laravel\Passport\Client
      */
-    public function createPasswordGrantClient($userId, $name, $redirect)
+    public function createPasswordGrantClient($userId, $name, array $redirect)
     {
         return $this->create($userId, $name, $redirect, false, true);
     }
@@ -139,10 +139,10 @@ class ClientRepository
      *
      * @param  Client  $client
      * @param  string  $name
-     * @param  string  $redirect
+     * @param  array  $redirect
      * @return \Laravel\Passport\Client
      */
-    public function update(Client $client, $name, $redirect)
+    public function update(Client $client, $name, array $redirect)
     {
         $client->forceFill([
             'name' => $name, 'redirect' => $redirect,

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -60,7 +60,7 @@ class ClientController
     {
         $this->validation->make($request->all(), [
             'name' => 'required|max:255',
-            'redirect' => 'required|url',
+            'redirect.*' => 'required|url',
         ])->validate();
 
         return $this->clients->create(
@@ -85,7 +85,7 @@ class ClientController
 
         $this->validation->make($request->all(), [
             'name' => 'required|max:255',
-            'redirect' => 'required|url',
+            'redirect.*' => 'required|url',
         ])->validate();
 
         return $this->clients->update(

--- a/src/Http/Controllers/DenyAuthorizationController.php
+++ b/src/Http/Controllers/DenyAuthorizationController.php
@@ -38,7 +38,7 @@ class DenyAuthorizationController
     {
         $authRequest = $this->getAuthRequestFromSession($request);
 
-        $clientUris = Arr::wrap($authRequest->getClient()->getRedirectUri());
+        $clientUris = $authRequest->getClient()->getRedirectUri();
 
         if (! in_array($uri = $authRequest->getRedirectUri(), $clientUris)) {
             $uri = Arr::first($clientUris);

--- a/tests/BridgeAccessTokenRepositoryTest.php
+++ b/tests/BridgeAccessTokenRepositoryTest.php
@@ -33,7 +33,7 @@ class BridgeAccessTokenRepositoryTest extends PHPUnit_Framework_TestCase
         $accessToken = new Laravel\Passport\Bridge\AccessToken(2, [new Laravel\Passport\Bridge\Scope('scopes')]);
         $accessToken->setIdentifier(1);
         $accessToken->setExpiryDateTime($expiration);
-        $accessToken->setClient(new Laravel\Passport\Bridge\Client('client-id', 'name', 'redirect'));
+        $accessToken->setClient(new Laravel\Passport\Bridge\Client('client-id', 'name', ['redirect']));
 
         $repository = new Laravel\Passport\Bridge\AccessTokenRepository($tokenRepository, $events);
 

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -39,7 +39,7 @@ class BridgeClientRepositoryTest extends PHPUnit_Framework_TestCase
 class BridgeClientRepositoryTestClientStub
 {
     public $name = 'Client';
-    public $redirect = 'http://localhost';
+    public $redirect = ['http://localhost'];
     public $secret = 'secret';
     public $personal_access_client = false;
     public $password_client = false;

--- a/tests/BridgeScopeRepositoryTest.php
+++ b/tests/BridgeScopeRepositoryTest.php
@@ -16,7 +16,7 @@ class BridgeScopeRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = new ScopeRepository;
 
         $scopes = $repository->finalizeScopes(
-            [$scope1 = new Scope('scope-1'), new Scope('scope-2')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
+            [$scope1 = new Scope('scope-1'), new Scope('scope-2')], 'client_credentials', new Client('id', 'name', ['http://localhost']), 1
         );
 
         $this->assertEquals([$scope1], $scopes);
@@ -31,7 +31,7 @@ class BridgeScopeRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = new ScopeRepository;
 
         $scopes = $repository->finalizeScopes(
-            [$scope1 = new Scope('*')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
+            [$scope1 = new Scope('*')], 'client_credentials', new Client('id', 'name', ['http://localhost']), 1
         );
 
         $this->assertEquals([], $scopes);

--- a/tests/ClientControllerTest.php
+++ b/tests/ClientControllerTest.php
@@ -29,20 +29,20 @@ class ClientControllerTest extends PHPUnit_Framework_TestCase
     {
         $clients = Mockery::mock('Laravel\Passport\ClientRepository');
 
-        $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
+        $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => ['http://localhost']]);
         $request->setUserResolver(function () {
             return new ClientControllerFakeUser;
         });
 
-        $clients->shouldReceive('create')->once()->with(1, 'client name', 'http://localhost')->andReturn($client = new Laravel\Passport\Client);
+        $clients->shouldReceive('create')->once()->with(1, 'client name', ['http://localhost'])->andReturn($client = new Laravel\Passport\Client);
 
         $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
         $validator->shouldReceive('make')->once()->with([
             'name' => 'client name',
-            'redirect' => 'http://localhost',
+            'redirect' => ['http://localhost'],
         ], [
             'name' => 'required|max:255',
-            'redirect' => 'required|url',
+            'redirect.*' => 'required|url',
         ])->andReturn($validator);
         $validator->shouldReceive('validate')->once();
 
@@ -59,7 +59,7 @@ class ClientControllerTest extends PHPUnit_Framework_TestCase
         $client = Mockery::mock('Laravel\Passport\Client');
         $clients->shouldReceive('findForUser')->with(1, 1)->andReturn($client);
 
-        $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
+        $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => ['http://localhost']]);
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
@@ -69,16 +69,16 @@ class ClientControllerTest extends PHPUnit_Framework_TestCase
         });
 
         $clients->shouldReceive('update')->once()->with(
-            Mockery::type('Laravel\Passport\Client'), 'client name', 'http://localhost'
+            Mockery::type('Laravel\Passport\Client'), 'client name', ['http://localhost']
         )->andReturn('response');
 
         $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
         $validator->shouldReceive('make')->once()->with([
             'name' => 'client name',
-            'redirect' => 'http://localhost',
+            'redirect' => ['http://localhost'],
         ], [
             'name' => 'required|max:255',
-            'redirect' => 'required|url',
+            'redirect.*' => 'required|url',
         ])->andReturn($validator);
         $validator->shouldReceive('validate')->once();
 

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -29,7 +29,7 @@ class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
         $authRequest->shouldReceive('getRedirectUri')->andReturn('http://localhost');
-        $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn('http://localhost');
+        $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn(['http://localhost']);
 
         $response->shouldReceive('redirectTo')->once()->andReturnUsing(function ($url) {
             return $url;
@@ -87,7 +87,7 @@ class DenyAuthorizationControllerTest extends PHPUnit_Framework_TestCase
         $authRequest->shouldReceive('getGrantTypeId')->andReturn('implicit');
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
         $authRequest->shouldReceive('getRedirectUri')->andReturn('http://localhost');
-        $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn('http://localhost');
+        $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn(['http://localhost']);
 
         $response->shouldReceive('redirectTo')->once()->andReturnUsing(function ($url) {
             return $url;


### PR DESCRIPTION
Fixes #627 - Store oauth_clients redirect as a native array in the Client model rather than exploding on commas to create an array.
