### PR TITLE
Fixes infinite recursion on OAuthServerException

### DIFF
--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -64,6 +64,13 @@ class TokenGuardTest extends TestCase
         );
 
         $this->assertNull($guard->user($request));
+
+        // This assert that the second call after failed doesn't
+        // call the `validateAuthenticatedRequest` again.
+        $this->assertNull($guard->user($request));
+
+        // Avoids this test from interfering on other tests
+        TokenGuard::$failed = false;
     }
 
     public function test_null_is_returned_if_no_user_is_found()


### PR DESCRIPTION
Hi there,

## The issue

As explained on issue #632, when an `OAuthServerException` occurs, an *infinite recursion* is triggered, causing the script to fail with PHP's `maximum execution time exceeded` error.

## The reason

The reason is that when failed, Laravel Passport [triggers the `ExceptionHandler->report()`](https://github.com/laravel/passport/blob/a04b9193054a8a7c50c26ff4f0519d3f7b5f5a30/src/Guards/TokenGuard.php#L140-L142), that will try to report the error giving the context, [that by the way calls the `Auth::user()` method](https://github.com/laravel/framework/blob/ac2c64ec61192771b106215296e6322a09221974/src/Illuminate/Foundation/Exceptions/Handler.php#L152) again, causing the recursion since `TokenGuard` doesn't keep track of failed authentication, causing multiple unnecessary (and expensive too) calls to the `authenticateViaBearerToken()` guard method.

## The proposed fix

My proposed fix is to [add an `failed` static](https://github.com/iget-master/passport/blob/e1b99f6c6d0ea74450f11b65d06a55b05b0e1f3b/src/Guards/TokenGuard.php#L57-L62) (must be static to work) boolean flag to the `TokenGuard`, and [raise it when the `OAuthServerException` occurs](https://github.com/iget-master/passport/blob/e1b99f6c6d0ea74450f11b65d06a55b05b0e1f3b/src/Guards/TokenGuard.php#L154). 

This allows that our `user()` method [checks if a failure occured](https://github.com/iget-master/passport/blob/e1b99f6c6d0ea74450f11b65d06a55b05b0e1f3b/src/Guards/TokenGuard.php#L95-L100) and skip the call to the `authenticateViaBearerToken()` since we already know that the authentication failed previously, and anything changed, so the result will be always the same.

I really expect that this could be fixed, since our application is broken due to this.

## Breaking impacts

This should not have breaking impacts since it just optimizes an failing process.