### PR TITLE
TokenGuard did not check for x-xsrf-token header

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -161,7 +161,7 @@ class TokenGuard
         }
 
         // We will compare the CSRF token in the decoded API token against the CSRF header
-        // sent with the request. If the two don't match then this request is sent from
+        // sent with the request. If the two don't match then this request is not sent from
         // a valid source and we won't authenticate the request for further handling.
         if (! $this->validCsrf($token, $request) ||
             time() >= $token['expiry']) {

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -191,6 +191,23 @@ class TokenGuard
     }
 
     /**
+     * Get the CSRF token from the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     */
+    protected function getTokenFromRequest($request)
+    {
+        $token = $request->header('X-CSRF-TOKEN');
+
+        if (! $token && $header = $request->header('X-XSRF-TOKEN')) {
+            $token = $this->encrypter->decrypt($header);
+        }
+
+        return (string) $token;
+    }
+
+    /**
      * Determine if the CSRF / header are valid and match.
      *
      * @param  array  $token
@@ -200,7 +217,7 @@ class TokenGuard
     protected function validCsrf($token, $request)
     {
         return isset($token['csrf']) && hash_equals(
-            $token['csrf'], (string) $request->header('X-CSRF-TOKEN')
+            $token['csrf'], $this->getTokenFromRequest($request)
         );
     }
 }


### PR DESCRIPTION
If you are using an SPA and trying to consume your own API, it's impossible to use the blade engine to get the unencrypted CSRF token. Other middleware uses the header X-XSRF-TOKEN to get the encrypted token from the cookie.  I did the same in the token guard. The PR for laravel with code [#4128](https://github.com/laravel/laravel/pull/4128) had questioned whether or not passport should get updated to support this but no one got into it.