### PR TITLE
Call custom exceptions handling if exists for JSON APIs

### DIFF
--- a/src/Http/Controllers/HandlesOAuthErrors.php
+++ b/src/Http/Controllers/HandlesOAuthErrors.php
@@ -24,10 +24,11 @@ trait HandlesOAuthErrors
      */
     protected function withErrorHandling($callback)
     {
+        $response = $this->getResponse($callback);
         try {
             return $this->exceptionHandler()->renderForApi($response);
         } catch(Exception $e) {
-            return $this->getResponse($callback);
+            return $response;
         }
     }
 

--- a/src/Http/Controllers/HandlesOAuthErrors.php
+++ b/src/Http/Controllers/HandlesOAuthErrors.php
@@ -17,7 +17,7 @@ trait HandlesOAuthErrors
     use ConvertsPsrResponses;
 
     /**
-     * Perform the given callback with exception handling.
+     * Perform the exception handling.
      *
      * @param  \Closure  $callback
      * @return \Illuminate\Http\Response
@@ -25,23 +25,37 @@ trait HandlesOAuthErrors
     protected function withErrorHandling($callback)
     {
         try {
-            return $callback();
-        } catch (OAuthServerException $e) {
-            $this->exceptionHandler()->report($e);
-
-            return $this->convertResponse(
-                $e->generateHttpResponse(new Psr7Response)
-            );
-        } catch (Exception $e) {
-            $this->exceptionHandler()->report($e);
-
-            return new Response($this->configuration()->get('app.debug') ? $e->getMessage() : 'Error.', 500);
-        } catch (Throwable $e) {
-            $this->exceptionHandler()->report(new FatalThrowableError($e));
-
-            return new Response($this->configuration()->get('app.debug') ? $e->getMessage() : 'Error.', 500);
+            return $this->exceptionHandler()->renderForApi($response);
+        } catch(Exception $e) {
+            return $this->getResponse($callback);
         }
     }
+
+    /** 
+     * Get the response from the given callback with exception handling 
+     * 
+     * @param \Closure  $callback 
+     * @return \Illuminate\Http\Response 
+     */ 
+    protected function getResponse($callback) { 
+        try { 
+            return $callback(); 
+        } catch (OAuthServerException $e) { 
+            $this->exceptionHandler()->report($e); 
+ 
+            return $this->convertResponse( 
+                $e->generateHttpResponse(new Psr7Response) 
+            ); 
+        } catch (Exception $e) { 
+            $this->exceptionHandler()->report($e); 
+ 
+            return new Response($e->getMessage(), 500); 
+        } catch (Throwable $e) { 
+            $this->exceptionHandler()->report(new FatalThrowableError($e)); 
+ 
+            return new Response($e->getMessage(), 500); 
+        } 
+    } 
 
     /**
      * Get the configuration repository instance.

--- a/tests/AccessTokenControllerTest.php
+++ b/tests/AccessTokenControllerTest.php
@@ -40,9 +40,9 @@ class AccessTokenControllerTest extends TestCase
     public function test_exceptions_are_handled()
     {
         Container::getInstance()->instance(ExceptionHandler::class, $exceptions = Mockery::mock());
-        Container::getInstance()->instance(Repository::class, $config = Mockery::mock());
+        //Container::getInstance()->instance(Repository::class, $config = Mockery::mock());
         $exceptions->shouldReceive('report')->once();
-        $config->shouldReceive('get')->once()->andReturn(true);
+        //$config->shouldReceive('get')->once()->andReturn(true);
 
         $tokens = Mockery::mock(Laravel\Passport\TokenRepository::class);
         $jwt = Mockery::mock(Lcobucci\JWT\Parser::class);


### PR DESCRIPTION
Inserting a custom method call int `HandlesOAuthErrors.php@withErrorHandling` that allow to handle exceptions that not fire the custom laravel exception handler in `\App\Exceptions\Handler`

`return $this->exceptionHandler()->renderForApi($response);`

Will try call `renderForApi` method in `\App\Exceptions\Handler` if it exists. If not exists will return the `$reponse` handled by Passport 

Calling custom function allow to use localization in Exceptions messages and make some traits if wish before throw the exception.

Without this we cannot change messages or localize the messages if we use the Passport in a JSON API