### PR TITLE
Fix #632

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -137,9 +137,7 @@ class TokenGuard
 
             return $token ? $user->withAccessToken($token) : null;
         } catch (OAuthServerException $e) {
-            Container::getInstance()->make(
-                ExceptionHandler::class
-            )->report($e);
+            throw $e;
         }
     }
 

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -43,11 +43,6 @@ class TokenGuardTest extends TestCase
 
     public function test_oauth_throws_exception_when_authenticated_request_validation_not_passed()
     {
-        $container = new Container;
-        Container::setInstance($container);
-        $container->instance('Illuminate\Contracts\Debug\ExceptionHandler', $handler = Mockery::mock());
-        $handler->shouldReceive('report')->once()->with(Mockery::type('League\OAuth2\Server\Exception\OAuthServerException'));
-
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -41,7 +41,7 @@ class TokenGuardTest extends TestCase
         $this->assertEquals($token, $user->token());
     }
 
-    public function test_no_user_is_returned_when_oauth_throws_exception()
+    public function test_oauth_throws_exception_when_authenticated_request_validation_not_passed()
     {
         $container = new Container;
         Container::setInstance($container);
@@ -62,8 +62,6 @@ class TokenGuardTest extends TestCase
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
             new League\OAuth2\Server\Exception\OAuthServerException('message', 500, 'error type')
         );
-
-        $this->assertNull($guard->user($request));
     }
 
     public function test_null_is_returned_if_no_user_is_found()


### PR DESCRIPTION
We just need to throw the OAuthServerException whenever it's happens.

Because I think 'userId' and 'email' isn't necessary to send into logger in this section.