### PR TITLE
Move Model instantiation to repository

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -118,7 +118,13 @@ class ClientRepository
      */
     public function createPersonalAccessClient($userId, $name, $redirect)
     {
-        return $this->create($userId, $name, $redirect, true);
+        $client = $this->create($userId, $name, $redirect, true);
+
+        $accessClient = new PersonalAccessClient();
+        $accessClient->client_id = $client->id;
+        $accessClient->save();
+
+        return $client;
     }
 
     /**

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -61,10 +61,6 @@ class ClientCommand extends Command
             null, $name, 'http://localhost'
         );
 
-        $accessClient = new PersonalAccessClient();
-        $accessClient->client_id = $client->id;
-        $accessClient->save();
-
         $this->info('Personal access client created successfully.');
         $this->line('<comment>Client ID:</comment> '.$client->id);
         $this->line('<comment>Client Secret:</comment> '.$client->secret);


### PR DESCRIPTION
This fix moves the `PersonalAccessClient` model instantiation from the artisan command to the ClientRepository. 

It allows to easily swap Passport's persistence layer by binding a custom repository inside the container. 