### PR TITLE
Use Authenticatable::getAuthIdentifier() in place of Model::getKey()

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -64,7 +64,7 @@ trait HasApiTokens
     public function createToken($name, array $scopes = [])
     {
         return Container::getInstance()->make(PersonalAccessTokenFactory::class)->make(
-            $this->getKey(), $name, $scopes
+            $this->getAuthIdentifier(), $name, $scopes
         );
     }
 

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -108,7 +108,7 @@ class AuthorizationController
      */
     protected function approveRequest($authRequest, $user)
     {
-        $authRequest->setUser(new User($user->getKey()));
+        $authRequest->setUser(new User($user->getAuthIdentifier()));
 
         $authRequest->setAuthorizationApproved(true);
 

--- a/src/Http/Controllers/AuthorizedAccessTokenController.php
+++ b/src/Http/Controllers/AuthorizedAccessTokenController.php
@@ -34,7 +34,7 @@ class AuthorizedAccessTokenController
      */
     public function forUser(Request $request)
     {
-        $tokens = $this->tokenRepository->forUser($request->user()->getKey());
+        $tokens = $this->tokenRepository->forUser($request->user()->getAuthIdentifier());
 
         return $tokens->load('client')->filter(function ($token) {
             return ! $token->client->firstParty() && ! $token->revoked;
@@ -51,7 +51,7 @@ class AuthorizedAccessTokenController
     public function destroy(Request $request, $tokenId)
     {
         $token = $this->tokenRepository->findForUser(
-            $tokenId, $request->user()->getKey()
+            $tokenId, $request->user()->getAuthIdentifier()
         );
 
         if (is_null($token)) {

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -45,7 +45,7 @@ class ClientController
      */
     public function forUser(Request $request)
     {
-        $userId = $request->user()->getKey();
+        $userId = $request->user()->getAuthIdentifier();
 
         return $this->clients->activeForUser($userId)->makeVisible('secret');
     }
@@ -64,7 +64,7 @@ class ClientController
         ])->validate();
 
         return $this->clients->create(
-            $request->user()->getKey(), $request->name, $request->redirect
+            $request->user()->getAuthIdentifier(), $request->name, $request->redirect
         )->makeVisible('secret');
     }
 
@@ -77,7 +77,7 @@ class ClientController
      */
     public function update(Request $request, $clientId)
     {
-        $client = $this->clients->findForUser($clientId, $request->user()->getKey());
+        $client = $this->clients->findForUser($clientId, $request->user()->getAuthIdentifier());
 
         if (! $client) {
             return new Response('', 404);
@@ -102,7 +102,7 @@ class ClientController
      */
     public function destroy(Request $request, $clientId)
     {
-        $client = $this->clients->findForUser($clientId, $request->user()->getKey());
+        $client = $this->clients->findForUser($clientId, $request->user()->getAuthIdentifier());
 
         if (! $client) {
             return new Response('', 404);

--- a/src/Http/Controllers/PersonalAccessTokenController.php
+++ b/src/Http/Controllers/PersonalAccessTokenController.php
@@ -46,7 +46,7 @@ class PersonalAccessTokenController
      */
     public function forUser(Request $request)
     {
-        $tokens = $this->tokenRepository->forUser($request->user()->getKey());
+        $tokens = $this->tokenRepository->forUser($request->user()->getAuthIdentifier());
 
         return $tokens->load('client')->filter(function ($token) {
             return $token->client->personal_access_client && ! $token->revoked;
@@ -81,7 +81,7 @@ class PersonalAccessTokenController
     public function destroy(Request $request, $tokenId)
     {
         $token = $this->tokenRepository->findForUser(
-            $tokenId, $request->user()->getKey()
+            $tokenId, $request->user()->getAuthIdentifier()
         );
 
         if (is_null($token)) {

--- a/src/Http/Controllers/RetrievesAuthRequestFromSession.php
+++ b/src/Http/Controllers/RetrievesAuthRequestFromSession.php
@@ -22,7 +22,7 @@ trait RetrievesAuthRequestFromSession
                 throw new Exception('Authorization request was not present in the session.');
             }
 
-            $authRequest->setUser(new User($request->user()->getKey()));
+            $authRequest->setUser(new User($request->user()->getAuthIdentifier()));
 
             $authRequest->setAuthorizationApproved(true);
         });

--- a/src/Http/Controllers/TransientTokenController.php
+++ b/src/Http/Controllers/TransientTokenController.php
@@ -35,7 +35,7 @@ class TransientTokenController
     public function refresh(Request $request)
     {
         return (new Response('Refreshed.'))->withCookie($this->cookieFactory->make(
-            $request->user()->getKey(), $request->session()->token()
+            $request->user()->getAuthIdentifier(), $request->session()->token()
         ));
     }
 }

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -51,7 +51,7 @@ class CreateFreshApiToken
 
         if ($this->shouldReceiveFreshToken($request, $response)) {
             $response->withCookie($this->cookieFactory->make(
-                $request->user($this->guard)->getKey(), $request->session()->token()
+                $request->user($this->guard)->getAuthIdentifier(), $request->session()->token()
             ));
         }
 

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -62,7 +62,7 @@ class TokenRepository
     public function getValidToken($user, $client)
     {
         return $client->tokens()
-                    ->whereUserId($user->getKey())
+                    ->whereUserId($user->getAuthIdentifier())
                     ->whereRevoked(0)
                     ->where('expires_at', '>', Carbon::now())
                     ->first();
@@ -116,7 +116,7 @@ class TokenRepository
     public function findValidToken($user, $client)
     {
         return $client->tokens()
-                      ->whereUserId($user->getKey())
+                      ->whereUserId($user->getAuthIdentifier())
                       ->whereRevoked(0)
                       ->where('expires_at', '>', Carbon::now())
                       ->latest('expires_at')

--- a/tests/ApproveAuthorizationControllerTest.php
+++ b/tests/ApproveAuthorizationControllerTest.php
@@ -37,7 +37,7 @@ class ApproveAuthorizationControllerTest extends TestCase
 class ApproveAuthorizationControllerFakeUser
 {
     public $id = 1;
-    public function getKey()
+    public function getAuthIdentifier()
     {
         return $this->id;
     }

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -98,7 +98,7 @@ class AuthorizationControllerTest extends TestCase
 
         $request = Mockery::mock('Illuminate\Http\Request');
         $request->shouldReceive('user')->once()->andReturn($user = Mockery::mock());
-        $user->shouldReceive('getKey')->andReturn(1);
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldNotReceive('session');
 
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);

--- a/tests/AuthorizedAccessTokenControllerTest.php
+++ b/tests/AuthorizedAccessTokenControllerTest.php
@@ -54,7 +54,7 @@ class AuthorizedAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () use ($token1, $token2) {
             $user = Mockery::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -77,7 +77,7 @@ class AuthorizedAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -93,7 +93,7 @@ class AuthorizedAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });

--- a/tests/ClientControllerTest.php
+++ b/tests/ClientControllerTest.php
@@ -64,7 +64,7 @@ class ClientControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -99,7 +99,7 @@ class ClientControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -125,7 +125,7 @@ class ClientControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -152,7 +152,7 @@ class ClientControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -172,7 +172,7 @@ class ClientControllerTest extends TestCase
 class ClientControllerFakeUser
 {
     public $id = 1;
-    public function getKey()
+    public function getAuthIdentifier()
     {
         return $this->id;
     }

--- a/tests/CreateFreshApiTokenTest.php
+++ b/tests/CreateFreshApiTokenTest.php
@@ -24,7 +24,7 @@ class CreateFreshApiTokenTest extends TestCase
 
         $guard = 'guard';
         $user = Mockery::mock()
-            ->shouldReceive('getKey')
+            ->shouldReceive('getAuthIdentifier')
             ->andReturn($userKey = 1)
             ->getMock();
 
@@ -93,7 +93,7 @@ class CreateFreshApiTokenTest extends TestCase
 
         $request->setUserResolver(function () {
             return Mockery::mock()
-                ->shouldReceive('getKey')
+                ->shouldReceive('getAuthIdentifier')
                 ->andReturn(1)
                 ->getMock();
         });

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -124,7 +124,7 @@ class DenyAuthorizationControllerTest extends TestCase
 class DenyAuthorizationControllerFakeUser
 {
     public $id = 1;
-    public function getKey()
+    public function getAuthIdentifier()
     {
         return $this->id;
     }

--- a/tests/HasApiTokensTest.php
+++ b/tests/HasApiTokensTest.php
@@ -36,7 +36,7 @@ class HasApiTokensTest extends TestCase
 class HasApiTokensTestStub
 {
     use Laravel\Passport\HasApiTokens;
-    public function getKey()
+    public function getAuthIdentifier()
     {
         return 1;
     }

--- a/tests/PersonalAccessTokenControllerTest.php
+++ b/tests/PersonalAccessTokenControllerTest.php
@@ -31,7 +31,7 @@ class PersonalAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () use ($token1, $token2) {
             $user = Mockery::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -88,7 +88,7 @@ class PersonalAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -108,7 +108,7 @@ class PersonalAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = Mockery::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });

--- a/tests/TransientTokenControllerTest.php
+++ b/tests/TransientTokenControllerTest.php
@@ -17,7 +17,7 @@ class TransientTokenControllerTest extends TestCase
 
         $request = Mockery::mock(Illuminate\Http\Request::class);
         $request->shouldReceive('user')->andReturn($user = Mockery::mock());
-        $user->shouldReceive('getKey')->andReturn(1);
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldReceive('session->token')->andReturn('token');
 
         $controller = new Laravel\Passport\Http\Controllers\TransientTokenController($cookieFactory);


### PR DESCRIPTION
This PR enhance interoperability by using the `Authenticatable` contract's methods when Passport require an user's identifier, thus adding the ability to use passport with custom user classes / authentication drivers. 