### PR TITLE
Create clients only if migrations are being used

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Console;
 
+use Laravel\Passport\Passport;
 use Illuminate\Console\Command;
 
 class InstallCommand extends Command
@@ -29,7 +30,9 @@ class InstallCommand extends Command
     {
         $this->call('passport:keys', ['--force' => $this->option('force')]);
 
-        $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client']);
-        $this->call('passport:client', ['--password' => true, '--name' => config('app.name').' Password Grant Client']);
+        if (Passport::$runsMigrations) {
+            $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client']);
+            $this->call('passport:client', ['--password' => true, '--name' => config('app.name').' Password Grant Client']);
+        }
     }
 }


### PR DESCRIPTION
When you have defined `Passport::ignoreMigrations();` and call `php artisan passport:install` it obviously fails to create the clients because the database table does not exist. 

This simply checks whether migrations are being run before creating initial clients with `php artisan passport::install` command.