### PR TITLE
Alternative fix to Issue #632

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -137,6 +137,8 @@ class TokenGuard
 
             return $token ? $user->withAccessToken($token) : null;
         } catch (OAuthServerException $e) {
+            $request->headers->replace(['Authorization' => '']);
+
             Container::getInstance()->make(
                 ExceptionHandler::class
             )->report($e);

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -64,6 +64,9 @@ class TokenGuardTest extends TestCase
         );
 
         $this->assertNull($guard->user($request));
+
+        // Assert that `validateAuthenticatedRequest` isn't called twice on failure.
+        $this->assertNull($guard->user($request));
     }
 
     public function test_null_is_returned_if_no_user_is_found()


### PR DESCRIPTION
This is an alternative fix for Issue #632. (PR #634)

The proposal here is to reset the `Authorization` header on the request if OAuth2 fails, avoiding that the `user()` method try again to authenticate causing the infinite recursion.

Note that I've updated the tests too.