### PR TITLE
Possibility to create variable scopes for different authorization modes

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -63,7 +63,6 @@ class AuthorizationController
             $authRequest = $this->server->validateAuthorizationRequest($psrRequest);
 
             $scopes = $this->parseScopes($authRequest);
-
             $token = $tokens->findValidToken(
                 $user = $request->user(),
                 $client = $clients->find($authRequest->getClient()->getIdentifier())
@@ -93,6 +92,7 @@ class AuthorizationController
     protected function parseScopes($authRequest)
     {
         return Passport::scopesFor(
+			$authRequest->grantTypeId,
             collect($authRequest->getScopes())->map(function ($scope) {
                 return $scope->getIdentifier();
             })->all()

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -89,15 +89,16 @@ class AuthorizationController
      * @param  \League\OAuth2\Server\RequestTypes\AuthorizationRequest  $authRequest
      * @return array
      */
-    protected function parseScopes($authRequest)
+	protected function parseScopes($authRequest)
     {
-        return Passport::scopesFor(
-			$authRequest->grantTypeId,
-            collect($authRequest->getScopes())->map(function ($scope) {
-                return $scope->getIdentifier();
-            })->all()
-        );
-    }
+		return Passport::scopesFor(
+			collect($authRequest->getScopes())->map(function ($scope) {
+				return $scope->getIdentifier();
+			})->all(),
+			$authRequest->getGrantTypeId(),
+			$authRequest->getRedirectUri()
+		);
+	}
 
     /**
      * Approve the authorization request.

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -7,6 +7,7 @@ use DateInterval;
 use Carbon\Carbon;
 use DateTimeInterface;
 use Illuminate\Support\Facades\Route;
+use League\OAuth2\Server\Exception\OAuthServerException;
 
 class Passport
 {
@@ -44,11 +45,15 @@ class Passport
      * @var array
      */
     public static $scopes = [
+		//
+    ];
+
+	public static $repartedScopes = [
 		'all' => [],
 		'authorization_code' => [],
 		'password' => [],
         'client_credentials' => [],
-    ];
+	];
 
     /**
      * The date when access tokens expire.
@@ -195,18 +200,19 @@ class Passport
     /**
      * Get all of the scopes matching the given IDs.
      *
-     * @param  string  $grantTypeId
      * @param  array  $ids
+	 * @param  string $grant
+	 * @param  string $redirectUri
      * @return array
      */
-    public static function scopesFor($grantTypeId, array $ids)
+    public static function scopesFor(array $ids, $grantTypeId, $redirectUri = null)
     {
-        return collect($ids)->map(function ($id) {
-            if (isset(static::$scopes['all'][$id]) || isset(static::$scopes[$grantTypeId][$id])) {
+        return collect($ids)->map(function ($id) use ($grantTypeId, $redirectUri) {
+            if (isset(static::$repartedScopes['all'][$id]) || isset(static::$repartedScopes[$grantTypeId][$id])) {
                 return new Scope($id, static::$scopes[$id]);
             }
 
-            return;
+            throw OAuthServerException::invalidScope($id, $redirectUri);
         })->filter()->values()->all();
     }
 
@@ -218,7 +224,11 @@ class Passport
      */
     public static function tokensCan(array $scopes, $grantTypeId = 'all')
     {
-        static::$scopes[$grantTypeId] = $scopes;
+		static::$repartedScopes[$grantTypeId] = $scopes;
+
+		static::$scopes = [];
+		foreach (static::$repartedScopes as $scopes)
+			static::$scopes = array_merge(static::$scopes, $scopes);
     }
 
     /**
@@ -229,7 +239,7 @@ class Passport
      */
     public static function codeTokensCan(array $scopes)
     {
-        static::$scopes['authorization_code'] = $scopes;
+        static::tokensCan($scopes, 'authorization_code');
     }
 
     /**
@@ -240,7 +250,7 @@ class Passport
      */
     public static function passwordTokensCan(array $scopes)
     {
-        static::$scopes['password'] = $scopes;
+        static::tokensCan($scopes, 'password');
     }
 
     /**
@@ -251,7 +261,7 @@ class Passport
      */
     public static function clientTokensCan(array $scopes)
     {
-        static::$scopes['client_credentials'] = $scopes;
+		static::tokensCan($scopes, 'client_credentials');
     }
 
     /**

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -44,7 +44,10 @@ class Passport
      * @var array
      */
     public static $scopes = [
-        //
+		'all' => [],
+		'authorization_code' => [],
+		'password' => [],
+        'client_credentials' => [],
     ];
 
     /**
@@ -192,13 +195,14 @@ class Passport
     /**
      * Get all of the scopes matching the given IDs.
      *
+     * @param  string  $grantTypeId
      * @param  array  $ids
      * @return array
      */
-    public static function scopesFor(array $ids)
+    public static function scopesFor($grantTypeId, array $ids)
     {
         return collect($ids)->map(function ($id) {
-            if (isset(static::$scopes[$id])) {
+            if (isset(static::$scopes['all'][$id]) || isset(static::$scopes[$grantTypeId][$id])) {
                 return new Scope($id, static::$scopes[$id]);
             }
 
@@ -212,9 +216,42 @@ class Passport
      * @param  array  $scopes
      * @return void
      */
-    public static function tokensCan(array $scopes)
+    public static function tokensCan(array $scopes, $grantTypeId = 'all')
     {
-        static::$scopes = $scopes;
+        static::$scopes[$grantTypeId] = $scopes;
+    }
+
+    /**
+     * Define the scopes for code authorization application.
+     *
+     * @param  array  $scopes
+     * @return void
+     */
+    public static function codeTokensCan(array $scopes)
+    {
+        static::$scopes['authorization_code'] = $scopes;
+    }
+
+    /**
+     * Define the scopes for password authorization application.
+     *
+     * @param  array  $scopes
+     * @return void
+     */
+    public static function passwordTokensCan(array $scopes)
+    {
+        static::$scopes['password'] = $scopes;
+    }
+
+    /**
+     * Define the scopes for client credential application.
+     *
+     * @param  array  $scopes
+     * @return void
+     */
+    public static function clientTokensCan(array $scopes)
+    {
+        static::$scopes['client_credentials'] = $scopes;
     }
 
     /**

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -49,6 +49,9 @@ class AuthorizationControllerTest extends TestCase
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
         $tokens->shouldReceive('findValidToken')->with('user', 'client')->andReturnNull();
 
+		$authRequest->shouldReceive('getGrantTypeId')->once();
+		$authRequest->shouldReceive('getRedirectUri')->once();
+
         $this->assertEquals('view', $controller->authorize(
             Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
         ));
@@ -112,6 +115,9 @@ class AuthorizationControllerTest extends TestCase
         $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
         $tokens->shouldReceive('findValidToken')->with($user, 'client')->andReturn($token = Mockery::mock('Laravel\Passport\Token'));
         $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['scope-1']);
+
+		$authRequest->shouldReceive('getGrantTypeId')->once();
+		$authRequest->shouldReceive('getRedirectUri')->once();
 
         $this->assertEquals('approved', $controller->authorize(
             Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens


### PR DESCRIPTION
Like I explained in this issue #674, it is now not possible to make the difference for the scopes destined to be used by application using a certain authorization mode or another.

For example, if we take theses scopes:
- get-user: allow an application to get information about the current connected user
- get-users: allow an application to get information about all users (connected or not)

It is reasonnable not to access to the scope "get-users" when issuing authorization code with user connection needed and conversely, "get-user" would only be accessible by an application with access allowed by the connected user.

Obviously, this feature is backported.