### PR TITLE
Adding optional configuration.

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'token' => [
+        'model' => Laravel\Passport\Token::class,
+    ],
+];

--- a/src/Client.php
+++ b/src/Client.php
@@ -57,7 +57,7 @@ class Client extends Model
      */
     public function tokens()
     {
-        return $this->hasMany(Token::class, 'client_id');
+        return $this->hasMany(config('passport.token.model', Laravel\Passport\Token::class), 'client_id');
     }
 
     /**

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -30,7 +30,7 @@ trait HasApiTokens
      */
     public function tokens()
     {
-        return $this->hasMany(Token::class, 'user_id')->orderBy('created_at', 'desc');
+        return $this->hasMany(config('passport.token.model', Laravel\Passport\Token::class), 'user_id')->orderBy('created_at', 'desc');
     }
 
     /**

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -282,7 +282,7 @@ class Passport
      */
     public static function actingAs($user, $scopes = [], $guard = 'api')
     {
-        $token = Mockery::mock(Token::class)->shouldIgnoreMissing(false);
+        $token = Mockery::mock(config('passport.token.model', Laravel\Passport\Token::class))->shouldIgnoreMissing(false);
 
         foreach ($scopes as $scope) {
             $token->shouldReceive('can')->with($scope)->andReturn(true);

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -46,6 +46,10 @@ class PassportServiceProvider extends ServiceProvider
                 __DIR__.'/../resources/assets/js/components' => base_path('resources/assets/js/components/passport'),
             ], 'passport-components');
 
+            $this->publishes([
+                __DIR__.'/../config/passport.php' => config_path('passport.php'),
+            ], 'passport-config');
+
             $this->commands([
                 Console\InstallCommand::class,
                 Console\ClientCommand::class,

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -15,7 +15,7 @@ class TokenRepository
      */
     public function create($attributes)
     {
-        return Token::create($attributes);
+        return config('passport.token.model', Laravel\Passport\Token::class)::create($attributes);
     }
 
     /**
@@ -26,7 +26,7 @@ class TokenRepository
      */
     public function find($id)
     {
-        return Token::find($id);
+        return config('passport.token.model', Laravel\Passport\Token::class)::find($id);
     }
 
     /**
@@ -38,7 +38,7 @@ class TokenRepository
      */
     public function findForUser($id, $userId)
     {
-        return Token::where('id', $id)->where('user_id', $userId)->first();
+        return config('passport.token.model', Laravel\Passport\Token::class)::where('id', $id)->where('user_id', $userId)->first();
     }
 
     /**
@@ -49,7 +49,7 @@ class TokenRepository
      */
     public function forUser($userId)
     {
-        return Token::where('user_id', $userId)->get();
+        return config('passport.token.model', Laravel\Passport\Token::class)::where('user_id', $userId)->get();
     }
 
     /**
@@ -87,7 +87,7 @@ class TokenRepository
      */
     public function revokeAccessToken($id)
     {
-        return Token::where('id', $id)->update(['revoked' => true]);
+        return config('passport.token.model', Laravel\Passport\Token::class)::where('id', $id)->update(['revoked' => true]);
     }
 
     /**

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -123,6 +123,11 @@ class TokenRepository
                       ->first();
     }
 
+    /**
+     * Return a new instance of the token model.
+     *
+     * @return \Laravel\Passport\Token|null
+     */
     public function newTokenInstance()
     {
         return config('passport.token.model', Laravel\Passport\Token::class);

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -15,7 +15,7 @@ class TokenRepository
      */
     public function create($attributes)
     {
-        return config('passport.token.model', Laravel\Passport\Token::class)::create($attributes);
+        return $this->newTokenInstance()::create($attributes);
     }
 
     /**
@@ -26,7 +26,7 @@ class TokenRepository
      */
     public function find($id)
     {
-        return config('passport.token.model', Laravel\Passport\Token::class)::find($id);
+        return $this->newTokenInstance()::find($id);
     }
 
     /**
@@ -38,7 +38,7 @@ class TokenRepository
      */
     public function findForUser($id, $userId)
     {
-        return config('passport.token.model', Laravel\Passport\Token::class)::where('id', $id)->where('user_id', $userId)->first();
+        return $this->newTokenInstance()::where('id', $id)->where('user_id', $userId)->first();
     }
 
     /**
@@ -49,7 +49,7 @@ class TokenRepository
      */
     public function forUser($userId)
     {
-        return config('passport.token.model', Laravel\Passport\Token::class)::where('user_id', $userId)->get();
+        return $this->newTokenInstance()::where('user_id', $userId)->get();
     }
 
     /**
@@ -87,7 +87,7 @@ class TokenRepository
      */
     public function revokeAccessToken($id)
     {
-        return config('passport.token.model', Laravel\Passport\Token::class)::where('id', $id)->update(['revoked' => true]);
+        return $this->newTokenInstance()::where('id', $id)->update(['revoked' => true]);
     }
 
     /**
@@ -121,5 +121,10 @@ class TokenRepository
                       ->where('expires_at', '>', Carbon::now())
                       ->latest('expires_at')
                       ->first();
+    }
+
+    public function newTokenInstance()
+    {
+        return config('passport.token.model', Laravel\Passport\Token::class);
     }
 }


### PR DESCRIPTION
I use Passport for almost every project I have. It makes certain tasks fairly easy and it makes people integrating my site into theirs fairly easy. However, recently in one of my projects, I found the need to adjust a couple things in the `Token` model. There is no easy way to do this. So I propose, with this PR, that an optional configuration is added so if we need to use our own token model, we have the ability too.

I need to test a couple more things to make sure it works properly. I would like to go ahead and submit this PR to get some feedback on it and to see if this is a small enough change to where it can be easily merged into Passport.

Update: Just tested this PR on the project I wrote it for. Works as expected.