### PR TITLE
Support customized User::getAuthIdentifier()

### DIFF
--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -51,7 +51,7 @@ class CreateFreshApiToken
 
         if ($this->shouldReceiveFreshToken($request, $response)) {
             $response->withCookie($this->cookieFactory->make(
-                $request->user($this->guard)->getKey(), $request->session()->token()
+                $request->user($this->guard)->getAuthIdentifier(), $request->session()->token()
             ));
         }
 


### PR DESCRIPTION
In some cases, you want customize `User::getAuthIdentifier()` method. 
Eg. in my case, I want add prefix `u` and `s` for `User` and `Staff` model, and both two models authenticate by the guard `web`.
This pull request is support those cases.

Sorry, my English is not good.