### PR TITLE
Use warn message when encryption keys already exists

### DIFF
--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -38,7 +38,7 @@ class KeysCommand extends Command
         ];
 
         if ((file_exists($publicKey) || file_exists($privateKey)) && ! $this->option('force')) {
-            return $this->error('Encryption keys already exist. Use the --force option to overwrite them.');
+            return $this->warn('Encryption keys already exist. Use the --force option to overwrite them.');
         }
 
         file_put_contents($publicKey, array_get($keys, 'publickey'));


### PR DESCRIPTION
The message when the encryptions keys already exists shoud be a warning. Using a error message (in red) can lead the developer to investigate a a problem that doesn't really exists.