### PR TITLE
Add ability to set encryption keys from config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/encryption": "~5.6",
         "illuminate/http": "~5.6",
         "illuminate/support": "~5.6",
-        "league/oauth2-server": "^6.0",
+        "league/oauth2-server": "^7.0",
         "phpseclib/phpseclib": "^2.0",
         "symfony/psr-http-message-bridge": "~1.0",
         "zendframework/zend-diactoros": "~1.0"

--- a/config/passport.php
+++ b/config/passport.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption Keys
+    |--------------------------------------------------------------------------
+    |
+    | Passport uses encryption keys when generating secure access tokens.
+    | By default these keys are stored as local files, but can also be
+    | set using the following environment variables.
+    |
+    */
+
+    'private_key' => env('PASSPORT_PRIVATE_KEY'),
+
+    'public_key' => env('PASSPORT_PUBLIC_KEY'),
+
+];

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -28,7 +28,7 @@ class ClientRepository implements ClientRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getClientEntity($clientIdentifier, $grantType,
+    public function getClientEntity($clientIdentifier, $grantType = null,
                                     $clientSecret = null, $mustValidateSecret = true)
     {
         // First, we will verify that the client exists and is authorized to create personal

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -83,6 +83,8 @@ class PassportServiceProvider extends ServiceProvider
         $this->registerResourceServer();
 
         $this->registerGuard();
+
+        $this->offerPublishing();
     }
 
     /**
@@ -280,5 +282,19 @@ class PassportServiceProvider extends ServiceProvider
                 Cookie::queue(Cookie::forget(Passport::cookie()));
             }
         });
+    }
+
+    /**
+     * Setup the resource publishing groups for Passport.
+     *
+     * @return void
+     */
+    protected function offerPublishing()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/passport.php' => config_path('passport.php'),
+            ], 'passport-config');
+        }
     }
 }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -7,13 +7,13 @@ use Illuminate\Auth\RequestGuard;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Guards\TokenGuard;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\ResourceServer;
+use Illuminate\Config\Repository as Config;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\ImplicitGrant;
@@ -231,8 +231,11 @@ class PassportServiceProvider extends ServiceProvider
      */
     protected function makeCryptKey($type)
     {
-        $key = Config::get('passport.'.$type.'_key') ?? 'file://'.Passport::keyPath('oauth-'.$type.'.key');
-        $key = str_replace('\\n', "\n", $key);
+        $key = str_replace('\\n', "\n", $this->app->make(Config::class)->get('passport.'.$type.'_key'));
+
+        if (!$key) {
+            $key = 'file://'.Passport::keyPath('oauth-'.$type.'.key');
+        }
 
         return new CryptKey($key, null, false);
     }

--- a/tests/PassportServiceProviderTest.php
+++ b/tests/PassportServiceProviderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Config\Repository as Config;
+use Laravel\Passport\PassportServiceProvider;
+use Illuminate\Contracts\Foundation\Application as App;
+
+class PassportServiceProviderTest extends TestCase
+{
+    public function test_can_use_crypto_keys_from_config()
+    {
+        $config = Mockery::mock(Config::class, function ($config) {
+            $config->shouldReceive('get')
+                ->with('passport.private_key')
+                ->andReturn('-----BEGIN RSA PRIVATE KEY-----\nconfig\n-----END RSA PRIVATE KEY-----');
+        });
+
+        $provider = new PassportServiceProvider(
+            Mockery::mock(App::class, ['make' => $config])
+        );
+
+        // Call protected makeCryptKey method
+        $cryptKey = (function () {
+            return $this->makeCryptKey('private');
+        })->call($provider);
+
+        $this->assertSame(
+            "-----BEGIN RSA PRIVATE KEY-----\nconfig\n-----END RSA PRIVATE KEY-----",
+            file_get_contents($cryptKey->getKeyPath())
+        );
+    }
+
+    public function test_can_use_crypto_keys_from_local_disk()
+    {
+        Passport::loadKeysFrom(__DIR__.'/files');
+
+        file_put_contents(
+            __DIR__.'/files/oauth-private.key',
+            "-----BEGIN RSA PRIVATE KEY-----\ndisk\n-----END RSA PRIVATE KEY-----"
+        );
+
+        $config = Mockery::mock(Config::class, function ($config) {
+            $config->shouldReceive('get')->with('passport.private_key')->andReturn(null);
+        });
+
+        $provider = new PassportServiceProvider(
+            Mockery::mock(App::class, ['make' => $config])
+        );
+
+        // Call protected makeCryptKey method
+        $cryptKey = (function () {
+            return $this->makeCryptKey('private');
+        })->call($provider);
+
+        $this->assertSame(
+            "-----BEGIN RSA PRIVATE KEY-----\ndisk\n-----END RSA PRIVATE KEY-----",
+            file_get_contents($cryptKey->getKeyPath())
+        );
+
+        @unlink(__DIR__.'/files/oauth-private.key');
+    }
+}


### PR DESCRIPTION
Currently the only way to set encryption keys in Passport is with local files (`/storage/oauth-private.key` and `/storage/oauth-public.key`). However, this can be problematic in multi-server setups, where the same keys must be shared across multiple systems. In those situations, it's better to use environment variables. This PR adds the ability to do that.

The PHP League's OAuth 2.0 Server library supports passing either a file path or text version of the key to their `CryptKey` class. It does this by doing a regular expression to check if the string provided matches a RSA key pattern. If yes, it automatically saves the key to a temporary file, otherwise it treats the string as a file path. Unfortunately there was a bug with this regular expression in version 6 of the League's library, which is why this also includes an upgrade to version 7.

One gnarly thing here is dealing with line returns in the environment variables. Many services allow line returns (ie. Heroku), but the `vlucas/phpdotenv` library does not. To support this functionality locally, this PR automatically converts all `\n` instances to proper line returns. Here is how you would define this in the `.env` file:

```
PASSPORT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAw3KPag...\n-----END RSA PRIVATE KEY-----"
PASSPORT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOC...\n-----END PUBLIC KEY-----\n"
```