### PR TITLE
Added option to let Passport filter Client Scopes on Authorization

### DIFF
--- a/database/migrations/2018_04_10_085331_add_scopes_to_clients_table.php
+++ b/database/migrations/2018_04_10_085331_add_scopes_to_clients_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddScopesToClientsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oauth_clients', function(Blueprint $table){
+            $table->text('scopes')->after('redirect')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->dropColumn('scopes');
+        });
+    }
+}

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Entities\Traits\ClientTrait;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
@@ -9,6 +10,12 @@ use League\OAuth2\Server\Entities\ClientEntityInterface;
 class Client implements ClientEntityInterface
 {
     use ClientTrait, EntityTrait;
+
+    /**
+     * @var ScopeEntityInterface[]
+     */
+    protected $scopes = [];
+
 
     /**
      * Create a new client instance.
@@ -25,4 +32,36 @@ class Client implements ClientEntityInterface
         $this->name = $name;
         $this->redirectUri = explode(',', $redirectUri);
     }
+
+    /**
+     * Associate a scope with the token.
+     *
+     * @param ScopeEntityInterface $scope
+     */
+    public function addScope(ScopeEntityInterface $scope)
+    {
+        $this->scopes[$scope->getIdentifier()] = $scope;
+    }
+
+    /**
+     * Return an array of scopes associated with the token.
+     *
+     * @return ScopeEntityInterface[]
+     */
+    public function getScopes()
+    {
+        return array_values($this->scopes);
+    }
+
+    /**
+     * Determine if the given scope has been defined.
+     *
+     * @param string $id
+     * @return bool
+     */
+    public function hasScope($id)
+    {
+        return $id === '*' || array_key_exists($id, $this->scopes);
+    }
+
 }

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -47,6 +47,10 @@ class ClientRepository implements ClientRepositoryInterface
             $clientIdentifier, $record->name, $record->redirect
         );
 
+        foreach ($record->scopes as $scope){
+            $client->addScope(new Scope($scope));
+        }
+
         if ($mustValidateSecret &&
             ! hash_equals($record->secret, (string) $clientSecret)) {
             return;

--- a/src/Bridge/ScopeRepository.php
+++ b/src/Bridge/ScopeRepository.php
@@ -31,6 +31,12 @@ class ScopeRepository implements ScopeRepositoryInterface
             })->values()->all();
         }
 
+        if (true === Passport::$useClientScopes) {
+            $scopes = collect($scopes)->reject(function ($scope) use ($clientEntity) {
+                return !$clientEntity->hasScope($scope->getIdentifier());
+            })->values()->all();
+        }
+
         return collect($scopes)->filter(function ($scope) {
             return Passport::hasScope($scope->getIdentifier());
         })->values()->all();

--- a/src/Client.php
+++ b/src/Client.php
@@ -78,6 +78,6 @@ class Client extends Model
      */
     public function getScopesAttribute($scopes)
     {
-        return json_decode($scopes, true);
+        return json_decode($scopes, true) ?: [];
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -69,4 +69,15 @@ class Client extends Model
     {
         return $this->personal_access_client || $this->password_client;
     }
+
+    /**
+     * Get the Client Scopes as an array
+     *
+     * @param string $scopes
+     * @return array
+     */
+    public function getScopesAttribute($scopes)
+    {
+        return json_decode($scopes, true);
+    }
 }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -32,6 +32,13 @@ class Passport
     public static $pruneRevokedTokens = false;
 
     /**
+     * Indicates if Passport should use Client Scopes on Authorization.
+     *
+     * @var bool|array
+     */
+    public static $useClientScopes = false;
+
+    /**
      * The personal access token client ID.
      *
      * @var int
@@ -140,6 +147,17 @@ class Passport
      */
     public static function pruneRevokedTokens()
     {
+        return new static;
+    }
+
+    /**
+     * Instruct Passport to use Client Scopes when authorizing.
+     *
+     * @return static
+     */
+    public static function useClientScopes()
+    {
+        static::$useClientScopes = true;
         return new static;
     }
 

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -44,6 +44,7 @@ class BridgeClientRepositoryTestClientStub
     public $secret = 'secret';
     public $personal_access_client = false;
     public $password_client = false;
+    public $scopes = [];
     public function firstParty()
     {
         return $this->personal_access_client || $this->password_client;

--- a/tests/BridgeScopeRepositoryTest.php
+++ b/tests/BridgeScopeRepositoryTest.php
@@ -23,6 +23,49 @@ class BridgeScopeRepositoryTest extends TestCase
         $this->assertEquals([$scope1], $scopes);
     }
 
+    public function test_invalid_scopes_are_removed_when_passport_uses_client_scopes()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+        ]);
+
+        Passport::useClientScopes();
+
+        $repository = new ScopeRepository;
+
+        $scopes = $repository->finalizeScopes(
+            [$scope1 = new Scope('scope-1'), new Scope('scope-2')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
+        );
+
+        $this->assertEquals([], $scopes);
+    }
+
+    public function test_client_scopes_are_only_ones_applied_when_passport_uses_client_scopes()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+            'scope-2' => 'description'
+        ]);
+
+        Passport::useClientScopes();
+
+        $repository = new ScopeRepository;
+
+        $scope1 = new Scope('scope-1');
+
+        $client = new Client('id', 'name', 'http://localhost');
+        $client->addScope($scope1);
+
+        $scopes = $repository->finalizeScopes(
+            [$scope1, new Scope('scope-2')],
+            'client_credentials',
+            $client,
+            1
+        );
+
+        $this->assertEquals([$scope1], $scopes);
+    }
+
     public function test_superuser_scope_cant_be_applied_if_wrong_grant()
     {
         Passport::tokensCan([


### PR DESCRIPTION
It can be enabled or disabled with `Passport::useClientScopes()`.