### PR TITLE
change form action url using url name {{ url('authorize') }} instead of '/oauth/authorize'

### DIFF
--- a/resources/views/authorize.blade.php
+++ b/resources/views/authorize.blade.php
@@ -64,7 +64,7 @@
 
                         <div class="buttons">
                             <!-- Authorize Button -->
-                            <form method="post" action="/oauth/authorize">
+                            <form method="post" action="{{ url('oauth/authorize') }}">
                                 {{ csrf_field() }}
 
                                 <input type="hidden" name="state" value="{{ $request->state }}">
@@ -73,7 +73,7 @@
                             </form>
 
                             <!-- Cancel Button -->
-                            <form method="post" action="/oauth/authorize">
+                            <form method="post" action="{{ url('oauth/authorize') }}">
                                 {{ csrf_field() }}
                                 {{ method_field('DELETE') }}
 


### PR DESCRIPTION
This pull request are attempt to resolve the issue about `Wrong oauth/authorize url #591`

https://github.com/laravel/passport/issues/591