### PR TITLE
Bump up minimum php version required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "firebase/php-jwt": "~3.0|~4.0|~5.0",
         "guzzlehttp/guzzle": "~6.0",
         "illuminate/auth": "~5.6",


### PR DESCRIPTION
This is currently wrong as `illuminate/contracts` v5.6 requires at least php7.1.