### PR TITLE
Made model classes configurable

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -12,7 +12,7 @@ class ClientRepository
      */
     public function find($id)
     {
-        return Client::find($id);
+        return Passport::client()->where('id', $id)->first();
     }
 
     /**
@@ -37,7 +37,8 @@ class ClientRepository
      */
     public function findForUser($clientId, $userId)
     {
-        return Client::where('id', $clientId)
+        return Passport::client()
+                     ->where('id', $clientId)
                      ->where('user_id', $userId)
                      ->first();
     }
@@ -50,7 +51,8 @@ class ClientRepository
      */
     public function forUser($userId)
     {
-        return Client::where('user_id', $userId)
+        return Passport::client()
+                        ->where('user_id', $userId)
                         ->orderBy('name', 'asc')->get();
     }
 
@@ -74,11 +76,11 @@ class ClientRepository
      */
     public function personalAccessClient()
     {
-        if (Passport::$personalAccessClient) {
-            return $this->find(Passport::$personalAccessClient);
+        if (Passport::$personalAccessClientId) {
+            return $this->find(Passport::$personalAccessClientId);
         }
 
-        return PersonalAccessClient::orderBy('id', 'desc')->first()->client;
+        return Passport::personalAccessClient()->orderBy('id', 'desc')->first()->client;
     }
 
     /**
@@ -93,7 +95,7 @@ class ClientRepository
      */
     public function create($userId, $name, $redirect, $personalAccess = false, $password = false)
     {
-        $client = (new Client)->forceFill([
+        $client = Passport::client()->forceFill([
             'user_id' => $userId,
             'name' => $name,
             'secret' => str_random(40),
@@ -119,7 +121,7 @@ class ClientRepository
     public function createPersonalAccessClient($userId, $name, $redirect)
     {
         return tap($this->create($userId, $name, $redirect, true), function ($client) {
-            $accessClient = new PersonalAccessClient;
+            $accessClient = Passport::personalAccessClient();
             $accessClient->client_id = $client->id;
             $accessClient->save();
         });

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -36,7 +36,7 @@ class Passport
      *
      * @var int
      */
-    public static $personalAccessClient;
+    public static $personalAccessClientId;
 
     /**
      * All of the scopes defined for the application.
@@ -74,6 +74,34 @@ class Passport
      * @var string
      */
     public static $keyPath;
+
+    /**
+     * The auth code model class name.
+     *
+     * @var string
+     */
+    public static $authCodeModel = 'Laravel\Passport\AuthCode';
+
+    /**
+     * The client model class name.
+     *
+     * @var string
+     */
+    public static $clientModel = 'Laravel\Passport\Client';
+
+    /**
+     * The personal access client model class name.
+     *
+     * @var string
+     */
+    public static $personalAccessClientModel = 'Laravel\Passport\PersonalAccessClient';
+
+    /**
+     * The token model class name.
+     *
+     * @var string
+     */
+    public static $tokenModel = 'Laravel\Passport\Token';
 
     /**
      * Indicates if Passport migrations will be run.
@@ -149,9 +177,9 @@ class Passport
      * @param  int  $clientId
      * @return static
      */
-    public static function personalAccessClient($clientId)
+    public static function personalAccessClientId($clientId)
     {
-        static::$personalAccessClient = $clientId;
+        static::$personalAccessClientId = $clientId;
 
         return new static;
     }
@@ -321,6 +349,130 @@ class Passport
         return static::$keyPath
             ? rtrim(static::$keyPath, '/\\').DIRECTORY_SEPARATOR.$file
             : storage_path($file);
+    }
+
+    /**
+     * Set the auth code model class name.
+     *
+     * @param  string  $authCodeModel
+     * @return void
+     */
+    public static function useAuthCodeModel($authCodeModel)
+    {
+        static::$authCodeModel = $authCodeModel;
+    }
+
+    /**
+     * Get the auth code model class name.
+     *
+     * @return string
+     */
+    public static function authCodeModel()
+    {
+        return static::$authCode;
+    }
+
+    /**
+     * Get a new auth code model instance.
+     *
+     * @return \Laravel\Passport\AuthCode
+     */
+    public static function authCode()
+    {
+        return new static::$authCode;
+    }
+
+    /**
+     * Set the client model class name.
+     *
+     * @param  string  $clientModel
+     * @return void
+     */
+    public static function useClientModel($clientModel)
+    {
+        static::$clientModel = $clientModel;
+    }
+
+    /**
+     * Get the client model class name.
+     *
+     * @return string
+     */
+    public static function clientModel()
+    {
+        return static::$clientModel;
+    }
+
+    /**
+     * Get a new client model instance.
+     *
+     * @return \Laravel\Passport\Client
+     */
+    public static function client()
+    {
+        return new static::$client;
+    }
+
+    /**
+     * Set the personal access client model class name.
+     *
+     * @param  string  $clientModel
+     * @return void
+     */
+    public static function usePersonalAccessClientModel($clientModel)
+    {
+        static::$personalAccessClientModel = $clientModel;
+    }
+
+    /**
+     * Get the personal access client model class name.
+     *
+     * @return string
+     */
+    public static function personalAccessClientModel()
+    {
+        return static::$personalAccessClientModel;
+    }
+
+    /**
+     * Get a new personal access client model instance.
+     *
+     * @return \Laravel\Passport\PersonalAccessClient
+     */
+    public static function personalAccessClient()
+    {
+        return new static::$personalAccessClientModel;
+    }
+
+    /**
+     * Set the token model class name.
+     *
+     * @param  string  $tokenModel
+     * @return void
+     */
+    public static function useTokenModel($tokenModel)
+    {
+        static::$tokenModel = $tokenModel;
+    }
+
+    /**
+     * Get the token model class name.
+     *
+     * @return string
+     */
+    public static function tokenModel()
+    {
+        return static::$tokenModel;
+    }
+
+    /**
+     * Get a new personal access client model instance.
+     *
+     * @return \Laravel\Passport\Token
+     */
+    public static function token()
+    {
+        return new static::$tokenModel;
     }
 
     /**

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -15,7 +15,7 @@ class TokenRepository
      */
     public function create($attributes)
     {
-        return Token::create($attributes);
+        return Passport::token()->create($attributes);
     }
 
     /**
@@ -26,7 +26,7 @@ class TokenRepository
      */
     public function find($id)
     {
-        return Token::find($id);
+        return Passport::token()->where('id', $id)->first();
     }
 
     /**
@@ -38,7 +38,7 @@ class TokenRepository
      */
     public function findForUser($id, $userId)
     {
-        return Token::where('id', $id)->where('user_id', $userId)->first();
+        return Passport::token()->where('id', $id)->where('user_id', $userId)->first();
     }
 
     /**
@@ -49,7 +49,7 @@ class TokenRepository
      */
     public function forUser($userId)
     {
-        return Token::where('user_id', $userId)->get();
+        return Passport::token()->where('user_id', $userId)->get();
     }
 
     /**
@@ -87,7 +87,7 @@ class TokenRepository
      */
     public function revokeAccessToken($id)
     {
-        return Token::where('id', $id)->update(['revoked' => true]);
+        return Passport::token()->where('id', $id)->update(['revoked' => true]);
     }
 
     /**


### PR DESCRIPTION
With this PR, one can change and extend any model classes provided by Passport in a similar fashion as Spark. If people need stuff like UUIDs (#122), they can just add this functionality themselves without touching the Passport codebase. 

⚠️ Please note that this PR does not contain the complete change yet. But I would check with @taylorotwell and @themsaid first to see if they like this idea before putting more effort in it. 