### PR TITLE
feat: add array cast for grant_types

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -35,6 +35,7 @@ class Client extends Model
      * @var array
      */
     protected $casts = [
+        'grant_types' => 'array',
         'personal_access_client' => 'bool',
         'password_client' => 'bool',
         'revoked' => 'bool',


### PR DESCRIPTION
Following on from https://github.com/laravel/passport/pull/729#issuecomment-394377462, this change casts `grant_types` to an array in the Client Eloquent model.