### PR TITLE
Correct return type of tokens relation.

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -26,7 +26,7 @@ trait HasApiTokens
     /**
      * Get all of the access tokens for the user.
      *
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function tokens()
     {


### PR DESCRIPTION
### About
The `HasApiTokens` trait defines a `HasMany` relationship - `tokens()` - but the docblock has its return type set to `Collection` instead of `HasMany`, this PR fixes that.

**Changes:**
```diff
src/HasApiTokens.php


     /**
      * Get all of the access tokens for the user.
      *
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function tokens() { [...] }
```