### PR TITLE
Allow for URI with already existing query string

### DIFF
--- a/src/Http/Controllers/DenyAuthorizationController.php
+++ b/src/Http/Controllers/DenyAuthorizationController.php
@@ -44,7 +44,7 @@ class DenyAuthorizationController
             $uri = Arr::first($clientUris);
         }
 
-        $separator = $authRequest->getGrantTypeId() === 'implicit' ? '#' : '?';
+        $separator = $authRequest->getGrantTypeId() === 'implicit' ? '#' : (strstr($uri,'?') ? '&' : '?');
 
         return $this->response->redirectTo(
             $uri.$separator.'error=access_denied&state='.$request->input('state')


### PR DESCRIPTION
**Problem**

Currently the `deny` function of `src/Http/Controllers/DenyAuthorizationController.php` always simply appends a separator of either a `#` or `?` based on the outcome `$authRequest->getGrantTypeId()`, see: https://github.com/laravel/passport/blob/6.0/src/Http/Controllers/DenyAuthorizationController.php#L47

This works fine when using a redirect URL for a OAuth Client without a existing query string, such as:

`https://example.com/some_callback_function`

However, when providing a redirect URL for a OAuth Client that already contains a query string, such as:

`https://example.com/index.php?action=some_callback_function`

You will be redirected to:

`https://example.com/index.php?action=some_callback_function?error=access_denied&state=`

Which contains `?` twice, resulting in a unparseable URL for the OAuth Client.

Honestly it surprises me that no one ever noticed this behaviour before as this (fixed `?` separator) has been here since v1.0.

**Solution**

As a solution, this pull request checks if the redirect URL already contains a `?` using the native PHP function `strstr`:

```php
strstr($uri, '?') ? '&' : '?'
```

When the provided redirect URL contains a `?`, the separator used wil become a `&` appending the `error` and `state` parameters to the existing query string of the redirect URL.

Resulting in a correct URL like such:

`https://example.com/index.php?action=some_callback_function&error=access_denied&state=`