### PR TITLE
Remove hard-coded model key name in favour of Model::getKeyName()

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -12,7 +12,9 @@ class ClientRepository
      */
     public function find($id)
     {
-        return Passport::client()->where('id', $id)->first();
+        $client = Passport::client();
+
+        return $client->where($client->getKeyName(), $id)->first();
     }
 
     /**
@@ -37,8 +39,10 @@ class ClientRepository
      */
     public function findForUser($clientId, $userId)
     {
-        return Passport::client()
-                    ->where('id', $clientId)
+        $client = Passport::client();
+
+        return $client
+                    ->where($client->getKeyName(), $clientId)
                     ->where('user_id', $userId)
                     ->first();
     }
@@ -80,7 +84,9 @@ class ClientRepository
             return $this->find(Passport::$personalAccessClientId);
         }
 
-        return Passport::personalAccessClient()->orderBy('id', 'desc')->first()->client;
+        $client = Passport::personalAccessClient();
+
+        return $client->orderBy($client->getKeyName(), 'desc')->first()->client;
     }
 
     /**


### PR DESCRIPTION
This builds on the work done in https://github.com/laravel/passport/commit/47eaf7221411ba337faa518e20fdfaf9d9548cbf to remove the hard coding of the `id` field in favour of using [Model::getKeyName](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Database/Eloquent/Model.php#L1214)

Third part packages exist which allow Laravel and Laravel Passport to be used with MongoDB. This works in Passport 4.0. However, https://github.com/laravel/passport/commit/47eaf7221411ba337faa518e20fdfaf9d9548cbf prevents Passport from being used with MongoDB because the primary key field is `_id`