### PR TITLE
Added ability to restrict scopes for a client

### DIFF
--- a/src/Bridge/ScopeRepository.php
+++ b/src/Bridge/ScopeRepository.php
@@ -2,12 +2,20 @@
 
 namespace Laravel\Passport\Bridge;
 
+use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 
 class ScopeRepository implements ScopeRepositoryInterface
 {
+    protected $clients;
+
+    public function __construct(ClientRepository $clients)
+    {
+        $this->clients = $clients;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -31,8 +39,11 @@ class ScopeRepository implements ScopeRepositoryInterface
             })->values()->all();
         }
 
-        return collect($scopes)->filter(function ($scope) {
-            return Passport::hasScope($scope->getIdentifier());
+        $client = $this->clients->findActive($clientEntity->getIdentifier());
+
+        return collect($scopes)->filter(function ($scope) use($client) {
+            return Passport::hasScope($scope->getIdentifier())
+                && $client->hasScope($scope->getIdentifier());
         })->values()->all();
     }
 }

--- a/src/Bridge/ScopeRepository.php
+++ b/src/Bridge/ScopeRepository.php
@@ -9,8 +9,14 @@ use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 
 class ScopeRepository implements ScopeRepositoryInterface
 {
+    /**
+     * @var ClientRepository 
+     */
     protected $clients;
 
+    /**
+     * @param ClientRepository $clients
+     */
     public function __construct(ClientRepository $clients)
     {
         $this->clients = $clients;

--- a/src/Client.php
+++ b/src/Client.php
@@ -52,6 +52,12 @@ class Client extends Model
         return $this->hasMany(Passport::authCodeModel(), 'client_id');
     }
 
+    /**
+     * Determine if the client has the given scope.
+     *
+     * @param  string  $id
+     * @return bool
+     */
     public function hasScope($id)
     {
         return ! is_array($this->scopes) || empty($this->scopes) || array_key_exists($id, $this->scopes);

--- a/src/Client.php
+++ b/src/Client.php
@@ -39,6 +39,7 @@ class Client extends Model
         'personal_access_client' => 'bool',
         'password_client' => 'bool',
         'revoked' => 'bool',
+        'scopes' => 'array',
     ];
 
     /**
@@ -49,6 +50,11 @@ class Client extends Model
     public function authCodes()
     {
         return $this->hasMany(Passport::authCodeModel(), 'client_id');
+    }
+
+    public function hasScope($id)
+    {
+        return ! is_array($this->scopes) || empty($this->scopes) || array_key_exists($id, $this->scopes);
     }
 
     /**

--- a/tests/BridgeScopeRepositoryTest.php
+++ b/tests/BridgeScopeRepositoryTest.php
@@ -5,6 +5,8 @@ use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Bridge\Scope;
 use Laravel\Passport\Bridge\Client;
 use Laravel\Passport\Bridge\ScopeRepository;
+use Laravel\Passport\Client as ClientModel;
+use Laravel\Passport\ClientRepository;
 
 class BridgeScopeRepositoryTest extends TestCase
 {
@@ -14,7 +16,13 @@ class BridgeScopeRepositoryTest extends TestCase
             'scope-1' => 'description',
         ]);
 
-        $repository = new ScopeRepository;
+        $client = Mockery::mock(ClientModel::class);
+        $client->shouldReceive('hasScope')->andReturn(true);
+
+        $clients = Mockery::mock(ClientRepository::class);
+        $clients->shouldReceive('findActive')->withAnyArgs()->andReturn($client);
+
+        $repository = new ScopeRepository($clients);
 
         $scopes = $repository->finalizeScopes(
             [$scope1 = new Scope('scope-1'), new Scope('scope-2')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
@@ -29,10 +37,35 @@ class BridgeScopeRepositoryTest extends TestCase
             'scope-1' => 'description',
         ]);
 
-        $repository = new ScopeRepository;
+        $clients = Mockery::mock(ClientRepository::class);
+        $clients->shouldReceive('findActive')->withAnyArgs();
+
+        $repository = new ScopeRepository($clients);
 
         $scopes = $repository->finalizeScopes(
             [$scope1 = new Scope('*')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
+        );
+
+        $this->assertEquals([], $scopes);
+    }
+
+    public function test_scopes_which_client_cant_issue_are_removed()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+            'scope-2' => 'description',
+        ]);
+
+        $client = Mockery::mock(ClientModel::class)->makePartial();
+        $client->scopes = ['scope-1'];
+
+        $clients = Mockery::mock(ClientRepository::class);
+        $clients->shouldReceive('findActive')->withAnyArgs()->andReturn($client);
+
+        $repository = new ScopeRepository($clients);
+
+        $scopes = $repository->finalizeScopes(
+            [$scope1 = new Scope('scope-1')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
         );
 
         $this->assertEquals([], $scopes);


### PR DESCRIPTION
This is a partial fix for https://github.com/laravel/passport/issues/691.

With this change the scopes which a client can issue tokens for is limited to it's own array of `scopes`. This allows scopes to be used to protect internal machine-to-machine requests from being accessed by users with valid password grant tokens.

This adds functionality which exists in other PHP OAuth server implementations. e.g. https://bshaffer.github.io/oauth2-server-php-docs/overview/scope:

> The scope(s) available to a client are controlled by a combination of the scope field in the client storage, and the list of scopes available, as defined in the scope storage.
>
> When the client has a list of scopes configured alongside it, the client is restricted to use only those scopes. When there are no scopes configured, the client is not restricted in what scopes it may use, it is able to use all scopes available within the authorization server.

This implementation behaves in the same way.

One thing I noticed is that following https://github.com/laravel/passport/pull/729 the migration to create the `oauth_clilents` table hasn't been updated to include the `grant_types` column. If this PR gets merged I'll therefore do another PR to add both the `grant_types` and `scopes` columns, if that's helpful.