### PR TITLE
Update CheckClientCredentials middleware to fail if client is a first party client

### DIFF
--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\Client;
+use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
 
 class CheckClientCredentialsTest extends TestCase
@@ -13,6 +15,8 @@ class CheckClientCredentialsTest extends TestCase
 
     public function test_request_is_passed_along_if_token_is_valid()
     {
+        $clients = Mockery::mock(ClientRepository::class);
+        $clients->shouldReceive('findActive')->andReturn(new Client);
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
@@ -20,7 +24,7 @@ class CheckClientCredentialsTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
 
-        $middleware = new CheckClientCredentials($resourceServer);
+        $middleware = new CheckClientCredentials($resourceServer, $clients);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -34,6 +38,8 @@ class CheckClientCredentialsTest extends TestCase
 
     public function test_request_is_passed_along_if_token_and_scope_are_valid()
     {
+        $clients = Mockery::mock(ClientRepository::class);
+        $clients->shouldReceive('findActive')->andReturn(new Client);
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
@@ -41,7 +47,7 @@ class CheckClientCredentialsTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['see-profile']);
 
-        $middleware = new CheckClientCredentials($resourceServer);
+        $middleware = new CheckClientCredentials($resourceServer, $clients);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -58,12 +64,14 @@ class CheckClientCredentialsTest extends TestCase
      */
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
+        $clients = Mockery::mock(ClientRepository::class);
+        $clients->shouldReceive('findActive')->andReturn(new Client);
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
             new League\OAuth2\Server\Exception\OAuthServerException('message', 500, 'error type')
         );
 
-        $middleware = new CheckClientCredentials($resourceServer);
+        $middleware = new CheckClientCredentials($resourceServer, $clients);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -78,6 +86,8 @@ class CheckClientCredentialsTest extends TestCase
      */
     public function test_exception_is_thrown_if_token_does_not_have_required_scopes()
     {
+        $clients = Mockery::mock(ClientRepository::class);
+        $clients->shouldReceive('findActive')->andReturn(new Client);
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
@@ -85,7 +95,7 @@ class CheckClientCredentialsTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'notbar']);
 
-        $middleware = new CheckClientCredentials($resourceServer);
+        $middleware = new CheckClientCredentials($resourceServer, $clients);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -93,5 +103,33 @@ class CheckClientCredentialsTest extends TestCase
         $response = $middleware->handle($request, function () {
             return 'response';
         }, 'foo', 'bar');
+    }
+
+    /**
+     * @expectedException Illuminate\Auth\AuthenticationException
+     */
+    public function test_exception_is_thrown_if_client_is_first_party()
+    {
+        $client = new Client;
+        $client->personal_access_client = true;        
+        $clients = Mockery::mock(ClientRepository::class);
+        $clients->shouldReceive('findActive')->andReturn($client);
+        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
+        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['see-profile']);
+
+        $middleware = new CheckClientCredentials($resourceServer, $clients);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $response = $middleware->handle($request, function () {
+            return 'response';
+        });
+
+        $this->assertEquals('response', $response);
     }
 }


### PR DESCRIPTION
This fixes the issue discussed in https://github.com/laravel/passport/issues/691 by ensuring the `CheckClientCredentials` middleware doesn't grant access by tokens granted by personal access or password clients.

This is a slightly modified version of the workaround proposed by @ soundsgoodsofar in https://github.com/laravel/passport/issues/691#issuecomment-380209374