### PR TITLE
Fix key length issue on passport:install

### DIFF
--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -32,7 +32,7 @@ class KeysCommand extends Command
      */
     public function handle(RSA $rsa)
     {
-        $keys = $rsa->createKey($this->input ? $this->option('length') : 4096);
+        $keys = $rsa->createKey($this->input ? (int) $this->option('length') : 4096);
 
         list($publicKey, $privateKey) = [
             Passport::keyPath('oauth-public.key'),


### PR DESCRIPTION
`passport:install` is failing with:
 `openssl_pkey_new(): private key length is too short; it needs to be at least 384 bits, not 0`

Type casting the `passport:key` `--length` argument to an integer fixes this issue.

The RSA::createKey method requires an integer to be passed.
https://github.com/phpseclib/phpseclib/blob/master/phpseclib/Crypt/RSA.php#L334