### PR TITLE
Fix openssl_pkey_new ErrorException

### DIFF
--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -32,7 +32,7 @@ class KeysCommand extends Command
      */
     public function handle(RSA $rsa)
     {
-        $keys = $rsa->createKey($this->input ? $this->option('length') : 4096);
+        $keys = $rsa->createKey($this->input ? (int) $this->option('length') : 4096);
 
         list($publicKey, $privateKey) = [
             Passport::keyPath('oauth-public.key'),


### PR DESCRIPTION
$this->option('length') return string type\
openssl_pkey_new function throw exception
openssl_pkey_new(): private key length is too short; it needs to be at least 384 bits, not 0