### PR TITLE
Unique scopes on AuthorizationController

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -95,7 +95,7 @@ class AuthorizationController
         return Passport::scopesFor(
             collect($authRequest->getScopes())->map(function ($scope) {
                 return $scope->getIdentifier();
-            })->all()
+            })->unique()->all()
         );
     }
 


### PR DESCRIPTION
This small PR will make the parseScopes method returns an array of unique scopes.

![Example with duplicate scopes](https://cdn.ethaligan.fr/images/Z9rcSRL.png)