### PR TITLE
authIdentifierName should not be static for password grants

### DIFF
--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -42,7 +42,7 @@ class UserRepository implements UserRepositoryInterface
         if (method_exists($model, 'findForPassport')) {
             $user = (new $model)->findForPassport($username);
         } else {
-            $user = (new $model)->where('email', $username)->first();
+            $user = (new $model)->where((new $model)->getAuthIdentifierName(), $username)->first();
         }
 
         if (! $user) {


### PR DESCRIPTION
authIdentifierName column should not be static, should be same as stated in the Model.