### PR TITLE
Respect session's same_site configuration

### DIFF
--- a/src/ApiTokenCookieFactory.php
+++ b/src/ApiTokenCookieFactory.php
@@ -57,7 +57,9 @@ class ApiTokenCookieFactory
             $config['path'],
             $config['domain'],
             $config['secure'],
-            true
+            true,
+            false,
+            $config['same_site']
         );
     }
 

--- a/tests/ApiTokenCookieFactoryTest.php
+++ b/tests/ApiTokenCookieFactoryTest.php
@@ -19,6 +19,7 @@ class ApiTokenCookieFactoryTest extends TestCase
             'path' => '/',
             'domain' => null,
             'secure' => true,
+            'same_site' => 'lax',
         ]);
         $encrypter = new Encrypter(str_repeat('a', 16));
         $factory = new ApiTokenCookieFactory($config, $encrypter);


### PR DESCRIPTION
This PR makes sure that the cookies created by Passport use the same configuration as the session cookies. Currently they do not respect the `same_site` config option.