### PR TITLE
CSRF check can be disabled

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -165,8 +165,8 @@ class TokenGuard
         // We will compare the CSRF token in the decoded API token against the CSRF header
         // sent with the request. If the two don't match then this request is sent from
         // a valid source and we won't authenticate the request for further handling.
-        if (! $this->validCsrf($token, $request) ||
-            time() >= $token['expiry']) {
+        if (Passport::checkCsrfToken() && (! $this->validCsrf($token, $request) ||
+            time() >= $token['expiry'])) {
             return;
         }
 

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -69,6 +69,13 @@ class Passport
     public static $cookie = 'laravel_token';
 
     /**
+     * Indicates if Passport should check the CSRF header.
+     *
+     * @var bool
+     */
+    public static $checkCsrfToken = true;
+
+    /**
      * The storage location of the encryption keys.
      *
      * @var string
@@ -296,6 +303,23 @@ class Passport
         }
 
         static::$cookie = $cookie;
+
+        return new static;
+    }
+
+    /**
+     * Enable or disable checking the CRSF token.
+     *
+     * @param  boolean|null  $checkCsrfToken
+     * @return boolean|static
+     */
+    public static function checkCsrfToken($checkCsrfToken = null)
+    {
+        if (is_null($checkCsrfToken)) {
+            return static::$checkCsrfToken;
+        }
+
+        static::$checkCsrfToken = $checkCsrfToken;
 
         return new static;
     }


### PR DESCRIPTION
With my previous PR one can set a same-site attribute and thus CSRF checks can be unnecessary in those environments.