### PR TITLE
Adapt for laravel breaking change

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -187,7 +187,7 @@ class TokenGuard
     protected function decodeJwtTokenCookie($request)
     {
         return (array) JWT::decode(
-            $this->encrypter->decrypt($request->cookie(Passport::cookie())),
+            $this->encrypter->decrypt($request->cookie(Passport::cookie()), Passport::$unserializesCookies),
             $this->encrypter->getKey(), ['HS256']
         );
     }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -118,6 +118,13 @@ class Passport
     public static $runsMigrations = true;
 
     /**
+     * Indicates if Passport should unserializes cookies.
+     *
+     * @var bool
+     */
+    public static $unserializesCookies = true;
+
+    /**
      * Enable the implicit grant type.
      *
      * @return static
@@ -503,6 +510,18 @@ class Passport
     public static function ignoreMigrations()
     {
         static::$runsMigrations = false;
+
+        return new static;
+    }
+
+    /**
+     * Configure Passport to stop unserializing cookies.
+     *
+     * @return static
+     */
+    public static function dontUnserializeCookies()
+    {
+        static::$unserializesCookies = false;
 
         return new static;
     }


### PR DESCRIPTION
This PR adds the new option `Passport::dontUnserializeCookies();` that you can place it in `AuthServiceProvider` to instruct passport that tokens shouldn't be unserialized.