### PR TITLE
`Authcode` model should be used for persisting new authcode

### DIFF
--- a/src/AuthCode.php
+++ b/src/AuthCode.php
@@ -39,6 +39,13 @@ class AuthCode extends Model
     ];
 
     /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
      * Get the client that owns the authentication code.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
+use Laravel\Passport\Passport;
 use Illuminate\Database\Connection;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
@@ -41,14 +42,16 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity)
     {
-        $this->database->table('oauth_auth_codes')->insert([
+        $attributes = [
             'id' => $authCodeEntity->getIdentifier(),
             'user_id' => $authCodeEntity->getUserIdentifier(),
             'client_id' => $authCodeEntity->getClient()->getIdentifier(),
             'scopes' => $this->formatScopesForStorage($authCodeEntity->getScopes()),
             'revoked' => false,
             'expires_at' => $authCodeEntity->getExpiryDateTime(),
-        ]);
+        ];
+
+        Passport::authCode()->setRawAttributes($attributes)->save();
     }
 
     /**


### PR DESCRIPTION
There's a `Authcode` Model for the `oauth_auth_codes` table, but not used yet. 

Just like the [TokenRepository.php](https://github.com/laravel/passport/blob/7.0/src/TokenRepository.php#L18) does so, `Authcode` should be used to persisting new authcode.

Also, this can solve the problem that the table name `oauth_auth_codes` is hardcoded in `AuthCodeRepository.php`.

