### PR TITLE
use HTTPS links where appropriate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ Laravel Passport is an OAuth2 server and API authentication package that is simp
 
 ## Official Documentation
 
-Documentation for Passport can be found on the [Laravel website](http://laravel.com/docs/master/passport).
+Documentation for Passport can be found on the [Laravel website](https://laravel.com/docs/master/passport).
 
 ## License
 
-Laravel Passport is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).
+Laravel Passport is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
both of these links redirect to HTTPS sites, so let's just send them directly there.