### PR TITLE
Display clear message when personal access client is missing

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Passport;
 
+use Laravel\Passport\Exceptions\MissingPersonalAccessClientException;
+
 class ClientRepository
 {
     /**
@@ -77,6 +79,7 @@ class ClientRepository
      * Get the personal access token client for the application.
      *
      * @return \Laravel\Passport\Client
+     * @throws \Laravel\Passport\Exceptions\MissingPersonalAccessClientException
      */
     public function personalAccessClient()
     {
@@ -85,6 +88,10 @@ class ClientRepository
         }
 
         $client = Passport::personalAccessClient();
+
+        if (! $client->exists()) {
+            throw new MissingPersonalAccessClientException('Personal access client not found. Please create one first.');
+        }
 
         return $client->orderBy($client->getKeyName(), 'desc')->first()->client;
     }

--- a/src/Exceptions/MissingPersonalAccessClientException.php
+++ b/src/Exceptions/MissingPersonalAccessClientException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Passport\Exceptions;
+
+use RuntimeException;
+
+class MissingPersonalAccessClientException extends RuntimeException
+{
+    //
+}

--- a/tests/PassportTest.php
+++ b/tests/PassportTest.php
@@ -6,6 +6,7 @@ use Laravel\Passport\Passport;
 use Laravel\Passport\PersonalAccessClient;
 use Laravel\Passport\Token;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\ClientRepository;
 
 class PassportTest extends TestCase
 {
@@ -44,11 +45,30 @@ class PassportTest extends TestCase
         $this->assertInstanceOf(Passport::personalAccessClientModel(), $client);
     }
 
+    /**
+     * @expectedException \Laravel\Passport\Exceptions\MissingPersonalAccessClientException
+     */
+    public function test_missing_personal_access_client_is_reported()
+    {
+        Passport::usePersonalAccessClientModel('PersonalAccessClientStub');
+
+        $clientRepository = new ClientRepository;
+        $clientRepository->personalAccessClient();
+    }
+
     public function test_token_instance_can_be_created()
     {
         $token = Passport::token();
 
         $this->assertInstanceOf(Token::class, $token);
         $this->assertInstanceOf(Passport::tokenModel(), $token);
+    }
+}
+
+class PersonalAccessClientStub
+{
+    public function exists()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
As per [this issue](https://github.com/laravel/passport/issues/406), developers often forget to re-create personal access client after refreshing their migrations.

The error when they try to create a personal access token after that is quite vague: 'Trying to get property of non-object in ClientRepository.php'

This PR adds the code to throw an exception with the clear message in that case.