### PR TITLE
Set $timestamps to true as these are in the default migration

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -51,7 +51,7 @@ class Token extends Model
      *
      * @var bool
      */
-    public $timestamps = false;
+    public $timestamps = true;
 
     /**
      * Get the client that the token belongs to.


### PR DESCRIPTION
Sets timestamps to true in Token model as timestamps are present in the default migration.