### PR TITLE
[7.0] Tests; acting as client credentials grant client

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -351,6 +351,30 @@ class Passport
 
         return $user;
     }
+    
+    /**
+     * Ignore checking client credentials
+     * While setting the current user for the application with the given scopes.
+     *
+     * @uses Passport::actingAs()
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  array  $scopes
+     * @param  string  $guard
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public static function actingAsClient($user, $scopes = [], $guard = 'api')
+    {
+        $middleware = Http\Middleware\CheckClientCredentials::class;
+
+        app()->instance($middleware, new class {
+            public function handle($request, $next)
+            {
+                return $next($request);
+            }
+        });
+
+        return Passport::actingAs($user, $scopes, $guard);
+    }
 
     /**
      * Set the storage location of the encryption keys.


### PR DESCRIPTION
Laravel Passport Issues: #514, #680

Implement `actingAsClient()` for Client Credentials Authorization

**Usage**:

| Method | URI | Name | Action | Middleware |
| :----- | :----- | :----- | :----- | :----- |
| POST | api/v1/users | store | App\Http\Controllers\UserController@store | api,auth.client |

```php
/**
 * Register user.
 * @test
 */
public function createUser()
{
  $user = factory(User::class)->create();

  Passport::actingAsClient($user, [], 'api');

  $response = $this->actingAs($user, 'api')
    ->json('POST', 'api/v1/users', [
      'name' => 'John Doe',
      'email' => 'jdoe@example.com',
      'password' => '!B>z5RJ%dUE$F52_',
      'password_confirmation' => '!B>z5RJ%dUE$F52_',
   ]);

  $response->assertStatus(201);
}
```