### PR TITLE
[7.0] Add the ability to retrieve current client

### DIFF
--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -104,7 +104,9 @@ class TokenGuardTest extends TestCase
         $request->headers->set('X-CSRF-TOKEN', 'token');
         $request->cookies->set('laravel_token',
             $encrypter->encrypt(JWT::encode([
-                'sub' => 1, 'csrf' => 'token',
+                'sub' => 1,
+                'aud' => 1,
+                'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
             ], str_repeat('a', 16)), false)
         );
@@ -130,7 +132,9 @@ class TokenGuardTest extends TestCase
         $request->headers->set('X-CSRF-TOKEN', 'wrong_token');
         $request->cookies->set('laravel_token',
             $encrypter->encrypt(JWT::encode([
-                'sub' => 1, 'csrf' => 'token',
+                'sub' => 1,
+                'aud' => 1,
+                'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
             ], str_repeat('a', 16)))
         );
@@ -154,7 +158,9 @@ class TokenGuardTest extends TestCase
         $request->headers->set('X-CSRF-TOKEN', 'token');
         $request->cookies->set('laravel_token',
             $encrypter->encrypt(JWT::encode([
-                'sub' => 1, 'csrf' => 'token',
+                'sub' => 1,
+                'aud' => 1,
+                'csrf' => 'token',
                 'expiry' => Carbon::now()->subMinutes(10)->getTimestamp(),
             ], str_repeat('a', 16)))
         );
@@ -180,6 +186,7 @@ class TokenGuardTest extends TestCase
         $request->cookies->set('laravel_token',
             $encrypter->encrypt(JWT::encode([
                 'sub' => 1,
+                'aud' => 1,
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
             ], str_repeat('a', 16)), false)
         );
@@ -190,9 +197,111 @@ class TokenGuardTest extends TestCase
 
         $this->assertEquals($expectedUser, $user);
     }
+
+    public function test_client_can_be_pulled_via_bearer_token()
+    {
+        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
+        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
+        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $encrypter = Mockery::mock('Illuminate\Contracts\Encryption\Encrypter');
+
+        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $clients->shouldReceive('findActive')->with(1)->andReturn(new TokenGuardTestClient);
+
+        $client = $guard->client($request);
+
+        $this->assertInstanceOf('TokenGuardTestClient', $client);
+    }
+
+    public function test_no_client_is_returned_when_oauth_throws_exception()
+    {
+        $container = new Container;
+        Container::setInstance($container);
+        $container->instance('Illuminate\Contracts\Debug\ExceptionHandler', $handler = Mockery::mock());
+        $handler->shouldReceive('report')->once()->with(Mockery::type('League\OAuth2\Server\Exception\OAuthServerException'));
+
+        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
+        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
+        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $encrypter = Mockery::mock('Illuminate\Contracts\Encryption\Encrypter');
+
+        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
+            new League\OAuth2\Server\Exception\OAuthServerException('message', 500, 'error type')
+        );
+
+        $this->assertNull($guard->client($request));
+
+        // Assert that `validateAuthenticatedRequest` isn't called twice on failure.
+        $this->assertNull($guard->client($request));
+    }
+
+    public function test_null_is_returned_if_no_client_is_found()
+    {
+        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
+        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
+        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $encrypter = Mockery::mock('Illuminate\Contracts\Encryption\Encrypter');
+
+        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $clients->shouldReceive('findActive')->with(1)->andReturn(null);
+
+        $this->assertNull($guard->client($request));
+    }
+
+    public function test_clients_may_be_retrieved_from_cookies()
+    {
+        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $userProvider = Mockery::mock('Illuminate\Contracts\Auth\UserProvider');
+        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
+        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $encrypter = new Illuminate\Encryption\Encrypter(str_repeat('a', 16));
+
+        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+
+        $request = Request::create('/');
+        $request->headers->set('X-CSRF-TOKEN', 'token');
+        $request->cookies->set('laravel_token',
+            $encrypter->encrypt(JWT::encode([
+                'sub' => 1,
+                'aud' => 1,
+                'csrf' => 'token',
+                'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
+            ], str_repeat('a', 16)), false)
+        );
+
+        $clients->shouldReceive('findActive')->with(1)->andReturn($expectedClient = new TokenGuardTestClient);
+
+        $client = $guard->client($request);
+
+        $this->assertEquals($expectedClient, $client);
+    }
 }
 
 class TokenGuardTestUser
 {
     use Laravel\Passport\HasApiTokens;
+}
+
+class TokenGuardTestClient
+{
 }


### PR DESCRIPTION
This commit adds the ability to retrieve the current client from the request, just like the current user is retrieved. I chose to do this in the TokenGuard class since this class uses the same logic to retrieve the current active user.

Usage could be as follows:

    $client = $tokenGuard->client($request);

One of the biggest reasons for adding this is that there isn't any way at the moment to retrieve the current client from the request. By adding this, users can use the client to further perform authorization actions or check the creator of the client and subsequently limit resources bases on either one of those two.

This is especially helpful for client credentials grant requests where you simply don't have an active/authed user. This way you can still limit resources if you want based on either the client or its creator.

This commit is fully BC. No methods have been renamed, only added. The ones that have been modified still behave in the same way as before but only have some parts extracted to other methods so their code could be re-used.

This solves the following long outstanding issue: https://github.com/laravel/passport/issues/143

PS. I'm sorry if the changes are too long or confusing. Feel free to ask questions and I will gladly clarify and explain further.