### PR TITLE
Update TokenGuard.php

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -131,7 +131,7 @@ class TokenGuard
         // associated with the token. We will use the provider implementation which may
         // be used to retrieve users from Eloquent. Next, we'll be ready to continue.
         $user = $this->provider->retrieveById(
-            $psr->getAttribute('oauth_user_id')
+            $psr->getAttribute('oauth_user_id')?:null
         );
 
         if (! $user) {

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -131,7 +131,7 @@ class TokenGuard
         // associated with the token. We will use the provider implementation which may
         // be used to retrieve users from Eloquent. Next, we'll be ready to continue.
         $user = $this->provider->retrieveById(
-            $psr->getAttribute('oauth_user_id')?:null
+            $psr->getAttribute('oauth_user_id') ?: null
         );
 
         if (! $user) {


### PR DESCRIPTION
Prevent passing empty string variable to retrieveById method.
If use middleware 'auth:api' but pass BearerToken form 'grant_type' => 'client_credentials'. PostgreSql will throw exception:
"SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for integer: \"\" (SQL: select * from \"users\" where \"id\" =  limit 1)
It is preferable to transfer null to return 401 (Unauthenticated) in this case