### PR TITLE
[7.0] Fixed inconsistency of where('user_id', $userId)

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -45,7 +45,7 @@ class ClientRepository
 
         return $client
                     ->where($client->getKeyName(), $clientId)
-                    ->where('user_id', $userId)
+                    ->whereUserId($userId)
                     ->first();
     }
 
@@ -58,7 +58,7 @@ class ClientRepository
     public function forUser($userId)
     {
         return Passport::client()
-                    ->where('user_id', $userId)
+                    ->whereUserId($userId)
                     ->orderBy('name', 'asc')->get();
     }
 

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -38,7 +38,7 @@ class TokenRepository
      */
     public function findForUser($id, $userId)
     {
-        return Passport::token()->where('id', $id)->where('user_id', $userId)->first();
+        return Passport::token()->where('id', $id)->whereUserId($userId)->first();
     }
 
     /**
@@ -49,7 +49,7 @@ class TokenRepository
      */
     public function forUser($userId)
     {
-        return Passport::token()->where('user_id', $userId)->get();
+        return Passport::token()->whereUserId($userId)->get();
     }
 
     /**


### PR DESCRIPTION
- Changed the places that use `where('user_id', $userId)` to `whereUserId($userId)` to make the use consistent