### PR TITLE
[7.0] Support a default scope when no scope was requested by the client

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -48,6 +48,13 @@ class Passport
     ];
 
     /**
+     * The default scope given to a token when no scope was requested
+     *
+     * @var string
+     */
+    public static $defaultScope;
+
+    /**
      * The date when access tokens expire.
      *
      * @var \DateTimeInterface|null
@@ -257,6 +264,17 @@ class Passport
     public static function tokensCan(array $scopes)
     {
         static::$scopes = $scopes;
+    }
+
+    /**
+     * set the default scope as a space delimited list
+     *
+     * @param array|string $scope
+     * @return void
+     */
+    public static function setDefaultScope($scope)
+    {
+        static::$defaultScope = is_array($scope) ? implode(' ', $scope) : $scope;
     }
 
     /**

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -96,6 +96,9 @@ class PassportServiceProvider extends ServiceProvider
     {
         $this->app->singleton(AuthorizationServer::class, function () {
             return tap($this->makeAuthorizationServer(), function ($server) {
+
+                $server->setDefaultScope(Passport::$defaultScope);
+
                 $server->enableGrantType(
                     $this->makeAuthCodeGrant(), Passport::tokensExpireIn()
                 );

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -96,7 +96,6 @@ class PassportServiceProvider extends ServiceProvider
     {
         $this->app->singleton(AuthorizationServer::class, function () {
             return tap($this->makeAuthorizationServer(), function ($server) {
-
                 $server->setDefaultScope(Passport::$defaultScope);
 
                 $server->enableGrantType(


### PR DESCRIPTION
According to the RFC if a client omits a scope, the server can choose to use a default scope. League OAuth2 server supports setting a default scope, but Laravel does not.  This PR adds support for setting a default scope in Laravel. (see discussion on https://github.com/laravel/passport/issues/870). 

The scope can be passed as either an array or a space delimited list, and can be set in AuthServiceProvider

```
Passport::setDefaultScope('email username');
```

This PR should be fully backwards compatible with 7.0. If the user doesn't add a default scope, nothing changes.  