### PR TITLE
[8.0] TokenGuard::decodeJwtTokenCookie performing redundant decryption

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -187,7 +187,7 @@ class TokenGuard
     protected function decodeJwtTokenCookie($request)
     {
         return (array) JWT::decode(
-            $this->encrypter->decrypt($request->cookie(Passport::cookie()), Passport::$unserializesCookies),
+            $request->cookie(Passport::cookie()),
             $this->encrypter->getKey(), ['HS256']
         );
     }


### PR DESCRIPTION
I *think* this is a bug, but can someone with more experience please confirm? 

I believe`\App\Http\Middleware\EncryptCookies` covers cookie encryption/decryption and that decryption here is redundant. The `auth:api` guard works correctly after this fix.

