### PR TITLE
[8.0] auth:api 401 Unauthorized - TokenGuard::decodeJwtTokenCookie should not decrypt cookie values 

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -187,7 +187,7 @@ class TokenGuard
     protected function decodeJwtTokenCookie($request)
     {
         return (array) JWT::decode(
-            $this->encrypter->decrypt($request->cookie(Passport::cookie()), Passport::$unserializesCookies),
+            $request->cookie(Passport::cookie()),
             $this->encrypter->getKey(), ['HS256']
         );
     }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -118,13 +118,6 @@ class Passport
     public static $runsMigrations = true;
 
     /**
-     * Indicates if Passport should unserializes cookies.
-     *
-     * @var bool
-     */
-    public static $unserializesCookies = false;
-
-    /**
      * Enable the implicit grant type.
      *
      * @return static
@@ -510,30 +503,6 @@ class Passport
     public static function ignoreMigrations()
     {
         static::$runsMigrations = false;
-
-        return new static;
-    }
-
-    /**
-     * Instruct Passport to enable cookie serialization.
-     *
-     * @return static
-     */
-    public static function withCookieSerialization()
-    {
-        static::$unserializesCookies = true;
-
-        return new static;
-    }
-
-    /**
-     * Instruct Passport to disable cookie serialization.
-     *
-     * @return static
-     */
-    public static function withoutCookieSerialization()
-    {
-        static::$unserializesCookies = false;
 
         return new static;
     }

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -11,6 +11,11 @@ use Laravel\Passport\Passport;
 
 class TokenGuardTest extends TestCase
 {
+    public function setUp()
+    {
+        Passport::ignoreCsrfToken(false);
+    }
+
     public function tearDown()
     {
         Mockery::close();
@@ -160,8 +165,7 @@ class TokenGuardTest extends TestCase
 
         $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
-        $oldIgnore = Passport::$ignoreCsrfToken;
-        Passport::ignoreCsrfToken(true);
+        Passport::ignoreCsrfToken();
         $request = Request::create('/');
         $request->headers->set('X-CSRF-TOKEN', 'wrong_token');
         $request->cookies->set('laravel_token', $this->createAuthToken($encrypter));
@@ -171,11 +175,11 @@ class TokenGuardTest extends TestCase
         $user = $guard->user($request);
 
         $this->assertEquals($expectedUser, $user);
-        Passport::ignoreCsrfToken($oldIgnore);
     }
 
 
-    public function createAuthToken($encrypter, $lifetime=120) {
+    public function createAuthToken($encrypter, $lifetime=120)
+    {
         $config = Mockery::mock('Illuminate\Contracts\Config\Repository');
         $config->shouldReceive('get')->with('session')->andReturn([
             'lifetime' => $lifetime,

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -166,6 +166,7 @@ class TokenGuardTest extends TestCase
         $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
         Passport::ignoreCsrfToken();
+
         $request = Request::create('/');
         $request->headers->set('X-CSRF-TOKEN', 'wrong_token');
         $request->cookies->set('laravel_token', $this->createAuthToken($encrypter));


### PR DESCRIPTION
This PR has corrected passing tests to follow up #885 (discussion in #884), hopefully we can leave it open until the issue is resolved.

@driesvints See how I updated `TokenGuardTest` to consume real tokens from `ApiTokenCookieFactory` like it would in a full Laravel App. You can now see that the additional decryption when decoding JWTs in `TokenGuard` would fail.

I hope this better demonstrates the problem :)

One note: I didn't see any tests for unserializing cookies, and since the serialization option is no longer used, I removed it from the `Passport` class as well. I think this as well does not belong in Passport and should be handled by middleware. Cookie value encrypt/decrypt and serialize/unserialize are middleware tasks right?