### PR TITLE
[7.0] Namespace tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,11 @@
             "Laravel\\Passport\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Laravel\\Passport\\Tests\\": "tests/"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "6.0-dev"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/ApiTokenCookieFactoryTest.php
+++ b/tests/ApiTokenCookieFactoryTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Encryption\Encrypter;
 use Laravel\Passport\ApiTokenCookieFactory;
@@ -8,12 +11,12 @@ class ApiTokenCookieFactoryTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_cookie_can_be_successfully_created()
     {
-        $config = Mockery::mock('Illuminate\Contracts\Config\Repository');
+        $config = m::mock('Illuminate\Contracts\Config\Repository');
         $config->shouldReceive('get')->with('session')->andReturn([
             'lifetime' => 120,
             'path' => '/',

--- a/tests/ApproveAuthorizationControllerTest.php
+++ b/tests/ApproveAuthorizationControllerTest.php
@@ -1,34 +1,44 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
+use Zend\Diactoros\Response;
 use PHPUnit\Framework\TestCase;
 use League\OAuth2\Server\AuthorizationServer;
+use Laravel\Passport\Http\Controllers\ApproveAuthorizationController;
 
 class ApproveAuthorizationControllerTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_complete_authorization_request()
     {
-        $server = Mockery::mock(AuthorizationServer::class);
+        $server = m::mock(AuthorizationServer::class);
 
-        $controller = new Laravel\Passport\Http\Controllers\ApproveAuthorizationController($server);
+        $controller = new ApproveAuthorizationController($server);
 
-        $request = Mockery::mock('Illuminate\Http\Request');
-        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
-        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = Mockery::mock('League\OAuth2\Server\RequestTypes\AuthorizationRequest'));
+        $request = m::mock('Illuminate\Http\Request');
+        $request->shouldReceive('session')->andReturn($session = m::mock());
+        $session->shouldReceive('get')
+            ->once()
+            ->with('authRequest')
+            ->andReturn($authRequest = m::mock('League\OAuth2\Server\RequestTypes\AuthorizationRequest'));
         $request->shouldReceive('user')->andReturn(new ApproveAuthorizationControllerFakeUser);
         $authRequest->shouldReceive('getClient->getIdentifier')->andReturn(1);
         $authRequest->shouldReceive('getUser->getIdentifier')->andReturn(2);
         $authRequest->shouldReceive('setUser')->once();
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
 
-        $psrResponse = new Zend\Diactoros\Response();
+        $psrResponse = new Response();
         $psrResponse->getBody()->write('response');
 
-        $server->shouldReceive('completeAuthorizationRequest')->with($authRequest, Mockery::type('Psr\Http\Message\ResponseInterface'))->andReturn($psrResponse);
+        $server->shouldReceive('completeAuthorizationRequest')
+            ->with($authRequest, m::type('Psr\Http\Message\ResponseInterface'))
+            ->andReturn($psrResponse);
 
         $this->assertEquals('response', $controller->approve($request)->getContent());
     }
@@ -37,6 +47,7 @@ class ApproveAuthorizationControllerTest extends TestCase
 class ApproveAuthorizationControllerFakeUser
 {
     public $id = 1;
+
     public function getKey()
     {
         return $this->id;

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -1,38 +1,46 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Exception;
+use Mockery as m;
+use Zend\Diactoros\Response;
+use Laravel\Passport\Passport;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\Bridge\Scope;
 use Illuminate\Container\Container;
 use League\OAuth2\Server\AuthorizationServer;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Routing\ResponseFactory;
+use Laravel\Passport\Http\Controllers\AuthorizationController;
 
 class AuthorizationControllerTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_authorization_view_is_presented()
     {
-        Laravel\Passport\Passport::tokensCan([
+        Passport::tokensCan([
             'scope-1' => 'description',
         ]);
 
-        $server = Mockery::mock(AuthorizationServer::class);
-        $response = Mockery::mock(ResponseFactory::class);
+        $server = m::mock(AuthorizationServer::class);
+        $response = m::mock(ResponseFactory::class);
 
-        $controller = new Laravel\Passport\Http\Controllers\AuthorizationController($server, $response);
+        $controller = new AuthorizationController($server, $response);
 
-        $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest = Mockery::mock());
+        $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest = m::mock());
 
-        $request = Mockery::mock('Illuminate\Http\Request');
-        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request = m::mock('Illuminate\Http\Request');
+        $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('put')->with('authRequest', $authRequest);
         $request->shouldReceive('user')->andReturn('user');
 
         $authRequest->shouldReceive('getClient->getIdentifier')->andReturn(1);
-        $authRequest->shouldReceive('getScopes')->andReturn([new Laravel\Passport\Bridge\Scope('scope-1')]);
+        $authRequest->shouldReceive('getScopes')->andReturn([new Scope('scope-1')]);
 
         $response->shouldReceive('view')->once()->andReturnUsing(function ($view, $data) use ($authRequest) {
             $this->assertEquals('passport::authorize', $view);
@@ -43,38 +51,38 @@ class AuthorizationControllerTest extends TestCase
             return 'view';
         });
 
-        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clients = m::mock('Laravel\Passport\ClientRepository');
         $clients->shouldReceive('find')->with(1)->andReturn('client');
 
-        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
+        $tokens = m::mock('Laravel\Passport\TokenRepository');
         $tokens->shouldReceive('findValidToken')->with('user', 'client')->andReturnNull();
 
         $this->assertEquals('view', $controller->authorize(
-            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
+            m::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
         ));
     }
 
     public function test_authorization_exceptions_are_handled()
     {
-        Container::getInstance()->instance(ExceptionHandler::class, $exceptions = Mockery::mock());
+        Container::getInstance()->instance(ExceptionHandler::class, $exceptions = m::mock());
         $exceptions->shouldReceive('report')->once();
 
-        $server = Mockery::mock(AuthorizationServer::class);
-        $response = Mockery::mock(ResponseFactory::class);
+        $server = m::mock(AuthorizationServer::class);
+        $response = m::mock(ResponseFactory::class);
 
-        $controller = new Laravel\Passport\Http\Controllers\AuthorizationController($server, $response);
+        $controller = new AuthorizationController($server, $response);
 
         $server->shouldReceive('validateAuthorizationRequest')->andThrow(new Exception('whoops'));
 
-        $request = Mockery::mock('Illuminate\Http\Request');
-        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request = m::mock('Illuminate\Http\Request');
+        $request->shouldReceive('session')->andReturn($session = m::mock());
 
-        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clients = m::mock('Laravel\Passport\ClientRepository');
 
-        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
+        $tokens = m::mock('Laravel\Passport\TokenRepository');
 
         $this->assertEquals('whoops', $controller->authorize(
-            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
+            m::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
         )->getContent());
     }
 
@@ -83,38 +91,43 @@ class AuthorizationControllerTest extends TestCase
      */
     public function test_request_is_approved_if_valid_token_exists()
     {
-        Laravel\Passport\Passport::tokensCan([
+        Passport::tokensCan([
             'scope-1' => 'description',
         ]);
 
-        $server = Mockery::mock(AuthorizationServer::class);
-        $response = Mockery::mock(ResponseFactory::class);
+        $server = m::mock(AuthorizationServer::class);
+        $response = m::mock(ResponseFactory::class);
 
-        $controller = new Laravel\Passport\Http\Controllers\AuthorizationController($server, $response);
-        $psrResponse = new Zend\Diactoros\Response();
+        $controller = new AuthorizationController($server, $response);
+        $psrResponse = new Response();
         $psrResponse->getBody()->write('approved');
-        $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest = Mockery::mock('League\OAuth2\Server\RequestTypes\AuthorizationRequest'));
-        $server->shouldReceive('completeAuthorizationRequest')->with($authRequest, Mockery::type('Psr\Http\Message\ResponseInterface'))->andReturn($psrResponse);
+        $server->shouldReceive('validateAuthorizationRequest')
+            ->andReturn($authRequest = m::mock('League\OAuth2\Server\RequestTypes\AuthorizationRequest'));
+        $server->shouldReceive('completeAuthorizationRequest')
+            ->with($authRequest, m::type('Psr\Http\Message\ResponseInterface'))
+            ->andReturn($psrResponse);
 
-        $request = Mockery::mock('Illuminate\Http\Request');
-        $request->shouldReceive('user')->once()->andReturn($user = Mockery::mock());
+        $request = m::mock('Illuminate\Http\Request');
+        $request->shouldReceive('user')->once()->andReturn($user = m::mock());
         $user->shouldReceive('getKey')->andReturn(1);
         $request->shouldNotReceive('session');
 
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
-        $authRequest->shouldReceive('getScopes')->once()->andReturn([new Laravel\Passport\Bridge\Scope('scope-1')]);
+        $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
         $authRequest->shouldReceive('setUser')->once()->andReturnNull();
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
 
-        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clients = m::mock('Laravel\Passport\ClientRepository');
         $clients->shouldReceive('find')->with(1)->andReturn('client');
 
-        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
-        $tokens->shouldReceive('findValidToken')->with($user, 'client')->andReturn($token = Mockery::mock('Laravel\Passport\Token'));
+        $tokens = m::mock('Laravel\Passport\TokenRepository');
+        $tokens->shouldReceive('findValidToken')
+            ->with($user, 'client')
+            ->andReturn($token = m::mock('Laravel\Passport\Token'));
         $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['scope-1']);
 
         $this->assertEquals('approved', $controller->authorize(
-            Mockery::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
+            m::mock('Psr\Http\Message\ServerRequestInterface'), $request, $clients, $tokens
         )->getContent());
     }
 }

--- a/tests/AuthorizedAccessTokenControllerTest.php
+++ b/tests/AuthorizedAccessTokenControllerTest.php
@@ -1,6 +1,9 @@
 <?php
 
-use Mockery\Mock;
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
+use Laravel\Passport\Token;
 use Illuminate\Http\Request;
 use Laravel\Passport\Client;
 use PHPUnit\Framework\TestCase;
@@ -10,7 +13,7 @@ use Laravel\Passport\Http\Controllers\AuthorizedAccessTokenController;
 class AuthorizedAccessTokenControllerTest extends TestCase
 {
     /**
-     * @var Mock|TokenRepository
+     * @var \Mockery\Mock|\Laravel\Passport\TokenRepository
      */
     protected $tokenRepository;
 
@@ -21,13 +24,13 @@ class AuthorizedAccessTokenControllerTest extends TestCase
 
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function setUp()
     {
-        $this->tokenRepository = Mockery::mock(TokenRepository::class);
-        $this->controller = new Laravel\Passport\Http\Controllers\AuthorizedAccessTokenController(
+        $this->tokenRepository = m::mock(TokenRepository::class);
+        $this->controller = new AuthorizedAccessTokenController(
             $this->tokenRepository
         );
     }
@@ -36,10 +39,10 @@ class AuthorizedAccessTokenControllerTest extends TestCase
     {
         $request = Request::create('/', 'GET');
 
-        $token1 = new Laravel\Passport\Token;
-        $token2 = new Laravel\Passport\Token;
+        $token1 = new Token;
+        $token2 = new Token;
 
-        $userTokens = Mockery::mock();
+        $userTokens = m::mock();
         $client1 = new Client;
         $client1->personal_access_client = true;
         $client2 = new Client;
@@ -53,7 +56,7 @@ class AuthorizedAccessTokenControllerTest extends TestCase
         $this->tokenRepository->shouldReceive('forUser')->andReturn($userTokens);
 
         $request->setUserResolver(function () use ($token1, $token2) {
-            $user = Mockery::mock();
+            $user = m::mock();
             $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
@@ -69,14 +72,14 @@ class AuthorizedAccessTokenControllerTest extends TestCase
     {
         $request = Request::create('/', 'GET');
 
-        $token1 = Mockery::mock(Laravel\Passport\Token::class.'[revoke]');
+        $token1 = m::mock(Token::class.'[revoke]');
         $token1->id = 1;
         $token1->shouldReceive('revoke')->once();
 
         $this->tokenRepository->shouldReceive('findForUser')->andReturn($token1);
 
         $request->setUserResolver(function () {
-            $user = Mockery::mock();
+            $user = m::mock();
             $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
@@ -92,7 +95,7 @@ class AuthorizedAccessTokenControllerTest extends TestCase
         $this->tokenRepository->shouldReceive('findForUser')->with(3, 1)->andReturnNull();
 
         $request->setUserResolver(function () {
-            $user = Mockery::mock();
+            $user = m::mock();
             $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;

--- a/tests/BridgeAccessTokenRepositoryTest.php
+++ b/tests/BridgeAccessTokenRepositoryTest.php
@@ -1,22 +1,29 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
 use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\Bridge\Scope;
+use Laravel\Passport\Bridge\Client;
+use Laravel\Passport\Bridge\AccessToken;
+use Laravel\Passport\Bridge\AccessTokenRepository;
 
 class BridgeAccessTokenRepositoryTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_access_tokens_can_be_persisted()
     {
         $expiration = Carbon::now();
 
-        $tokenRepository = Mockery::mock('Laravel\Passport\TokenRepository');
+        $tokenRepository = m::mock('Laravel\Passport\TokenRepository');
 
-        $events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
+        $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
 
         $tokenRepository->shouldReceive('create')->once()->andReturnUsing(function ($array) use ($expiration) {
             $this->assertEquals(1, $array['id']);
@@ -31,12 +38,12 @@ class BridgeAccessTokenRepositoryTest extends TestCase
 
         $events->shouldReceive('dispatch')->once();
 
-        $accessToken = new Laravel\Passport\Bridge\AccessToken(2, [new Laravel\Passport\Bridge\Scope('scopes')]);
+        $accessToken = new AccessToken(2, [new Scope('scopes')]);
         $accessToken->setIdentifier(1);
         $accessToken->setExpiryDateTime($expiration);
-        $accessToken->setClient(new Laravel\Passport\Bridge\Client('client-id', 'name', 'redirect'));
+        $accessToken->setClient(new Client('client-id', 'name', 'redirect'));
 
-        $repository = new Laravel\Passport\Bridge\AccessTokenRepository($tokenRepository, $events);
+        $repository = new AccessTokenRepository($tokenRepository, $events);
 
         $repository->persistNewAccessToken($accessToken);
     }

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -1,22 +1,38 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Laravel\Passport\Bridge\ClientRepository;
+use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Bridge\ClientRepository as BridgeClientRepository;
 
 class BridgeClientRepositoryTest extends TestCase
 {
+    /**
+     * @var \Laravel\Passport\ClientRepository
+     */
+    private $clientModelRepository;
+
+    /**
+     * @var \Laravel\Passport\Bridge\ClientRepository
+     */
+    private $repository;
+
     public function setUp()
     {
-        $clientModelRepository = Mockery::mock(Laravel\Passport\ClientRepository::class);
-        $clientModelRepository->shouldReceive('findActive')->with(1)->andReturn(new BridgeClientRepositoryTestClientStub);
+        $clientModelRepository = m::mock(ClientRepository::class);
+        $clientModelRepository->shouldReceive('findActive')
+            ->with(1)
+            ->andReturn(new BridgeClientRepositoryTestClientStub);
 
         $this->clientModelRepository = $clientModelRepository;
-        $this->repository = new Laravel\Passport\Bridge\ClientRepository($clientModelRepository);
+        $this->repository = new BridgeClientRepository($clientModelRepository);
     }
 
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_can_get_client_for_auth_code_grant()
@@ -109,10 +125,15 @@ class BridgeClientRepositoryTest extends TestCase
 class BridgeClientRepositoryTestClientStub
 {
     public $name = 'Client';
+
     public $redirect = 'http://localhost';
+
     public $secret = 'secret';
+
     public $personal_access_client = false;
+
     public $password_client = false;
+
     public $grant_types;
 
     public function firstParty()

--- a/tests/BridgeScopeRepositoryTest.php
+++ b/tests/BridgeScopeRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
 use Laravel\Passport\Passport;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Bridge\Scope;

--- a/tests/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/CheckClientCredentialsForAnyScopeTest.php
@@ -1,20 +1,24 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
 
 class CheckClientCredentialsForAnyScopeTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_request_is_passed_along_if_token_is_valid()
     {
-        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
-        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $resourceServer = m::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
@@ -34,8 +38,8 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
 
     public function test_request_is_passed_along_if_token_has_any_required_scope()
     {
-        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
-        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $resourceServer = m::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
@@ -54,13 +58,13 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
     }
 
     /**
-     * @expectedException Illuminate\Auth\AuthenticationException
+     * @expectedException \Illuminate\Auth\AuthenticationException
      */
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
-        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer = m::mock('League\OAuth2\Server\ResourceServer');
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
-            new League\OAuth2\Server\Exception\OAuthServerException('message', 500, 'error type')
+            new OAuthServerException('message', 500, 'error type')
         );
 
         $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
@@ -78,8 +82,8 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
      */
     public function test_exception_is_thrown_if_token_does_not_have_required_scope()
     {
-        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
-        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $resourceServer = m::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Mockery as m;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
@@ -8,13 +12,13 @@ class CheckClientCredentialsTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_request_is_passed_along_if_token_is_valid()
     {
-        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
-        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $resourceServer = m::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
@@ -34,8 +38,8 @@ class CheckClientCredentialsTest extends TestCase
 
     public function test_request_is_passed_along_if_token_and_scope_are_valid()
     {
-        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
-        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $resourceServer = m::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
@@ -54,13 +58,13 @@ class CheckClientCredentialsTest extends TestCase
     }
 
     /**
-     * @expectedException Illuminate\Auth\AuthenticationException
+     * @expectedException \Illuminate\Auth\AuthenticationException
      */
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
-        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer = m::mock('League\OAuth2\Server\ResourceServer');
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
-            new League\OAuth2\Server\Exception\OAuthServerException('message', 500, 'error type')
+            new OAuthServerException('message', 500, 'error type')
         );
 
         $middleware = new CheckClientCredentials($resourceServer);
@@ -78,8 +82,8 @@ class CheckClientCredentialsTest extends TestCase
      */
     public function test_exception_is_thrown_if_token_does_not_have_required_scopes()
     {
-        $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
-        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = Mockery::mock());
+        $resourceServer = m::mock('League\OAuth2\Server\ResourceServer');
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');

--- a/tests/CheckForAnyScopeTest.php
+++ b/tests/CheckForAnyScopeTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Http\Middleware\CheckForAnyScope as CheckScopes;
 
@@ -7,15 +10,15 @@ class CheckForAnyScopesTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_request_is_passed_along_if_scopes_are_present_on_token()
     {
         $middleware = new CheckScopes;
-        $request = Mockery::mock();
-        $request->shouldReceive('user')->andReturn($user = Mockery::mock());
-        $user->shouldReceive('token')->andReturn($token = Mockery::mock());
+        $request = m::mock();
+        $request->shouldReceive('user')->andReturn($user = m::mock());
+        $user->shouldReceive('token')->andReturn($token = m::mock());
         $user->shouldReceive('tokenCan')->with('foo')->andReturn(true);
         $user->shouldReceive('tokenCan')->with('bar')->andReturn(false);
 
@@ -27,14 +30,14 @@ class CheckForAnyScopesTest extends TestCase
     }
 
     /**
-     * @expectedException Laravel\Passport\Exceptions\MissingScopeException
+     * @expectedException \Laravel\Passport\Exceptions\MissingScopeException
      */
     public function test_exception_is_thrown_if_token_doesnt_have_scope()
     {
         $middleware = new CheckScopes;
-        $request = Mockery::mock();
-        $request->shouldReceive('user')->andReturn($user = Mockery::mock());
-        $user->shouldReceive('token')->andReturn($token = Mockery::mock());
+        $request = m::mock();
+        $request->shouldReceive('user')->andReturn($user = m::mock());
+        $user->shouldReceive('token')->andReturn($token = m::mock());
         $user->shouldReceive('tokenCan')->with('foo')->andReturn(false);
         $user->shouldReceive('tokenCan')->with('bar')->andReturn(false);
 
@@ -44,12 +47,12 @@ class CheckForAnyScopesTest extends TestCase
     }
 
     /**
-     * @expectedException Illuminate\Auth\AuthenticationException
+     * @expectedException \Illuminate\Auth\AuthenticationException
      */
     public function test_exception_is_thrown_if_no_authenticated_user()
     {
         $middleware = new CheckScopes;
-        $request = Mockery::mock();
+        $request = m::mock();
         $request->shouldReceive('user')->once()->andReturn(null);
 
         $middleware->handle($request, function () {
@@ -58,13 +61,13 @@ class CheckForAnyScopesTest extends TestCase
     }
 
     /**
-     * @expectedException Illuminate\Auth\AuthenticationException
+     * @expectedException \Illuminate\Auth\AuthenticationException
      */
     public function test_exception_is_thrown_if_no_token()
     {
         $middleware = new CheckScopes;
-        $request = Mockery::mock();
-        $request->shouldReceive('user')->andReturn($user = Mockery::mock());
+        $request = m::mock();
+        $request->shouldReceive('user')->andReturn($user = m::mock());
         $user->shouldReceive('token')->andReturn(null);
 
         $middleware->handle($request, function () {

--- a/tests/CheckScopesTest.php
+++ b/tests/CheckScopesTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Http\Middleware\CheckScopes;
 
@@ -7,15 +10,15 @@ class CheckScopesTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_request_is_passed_along_if_scopes_are_present_on_token()
     {
         $middleware = new CheckScopes;
-        $request = Mockery::mock();
-        $request->shouldReceive('user')->andReturn($user = Mockery::mock());
-        $user->shouldReceive('token')->andReturn($token = Mockery::mock());
+        $request = m::mock();
+        $request->shouldReceive('user')->andReturn($user = m::mock());
+        $user->shouldReceive('token')->andReturn($token = m::mock());
         $user->shouldReceive('tokenCan')->with('foo')->andReturn(true);
         $user->shouldReceive('tokenCan')->with('bar')->andReturn(true);
 
@@ -27,14 +30,14 @@ class CheckScopesTest extends TestCase
     }
 
     /**
-     * @expectedException Laravel\Passport\Exceptions\MissingScopeException
+     * @expectedException \Laravel\Passport\Exceptions\MissingScopeException
      */
     public function test_exception_is_thrown_if_token_doesnt_have_scope()
     {
         $middleware = new CheckScopes;
-        $request = Mockery::mock();
-        $request->shouldReceive('user')->andReturn($user = Mockery::mock());
-        $user->shouldReceive('token')->andReturn($token = Mockery::mock());
+        $request = m::mock();
+        $request->shouldReceive('user')->andReturn($user = m::mock());
+        $user->shouldReceive('token')->andReturn($token = m::mock());
         $user->shouldReceive('tokenCan')->with('foo')->andReturn(false);
 
         $middleware->handle($request, function () {
@@ -43,12 +46,12 @@ class CheckScopesTest extends TestCase
     }
 
     /**
-     * @expectedException Illuminate\Auth\AuthenticationException
+     * @expectedException \Illuminate\Auth\AuthenticationException
      */
     public function test_exception_is_thrown_if_no_authenticated_user()
     {
         $middleware = new CheckScopes;
-        $request = Mockery::mock();
+        $request = m::mock();
         $request->shouldReceive('user')->once()->andReturn(null);
 
         $middleware->handle($request, function () {
@@ -57,13 +60,13 @@ class CheckScopesTest extends TestCase
     }
 
     /**
-     * @expectedException Illuminate\Auth\AuthenticationException
+     * @expectedException \Illuminate\Auth\AuthenticationException
      */
     public function test_exception_is_thrown_if_no_token()
     {
         $middleware = new CheckScopes;
-        $request = Mockery::mock();
-        $request->shouldReceive('user')->andReturn($user = Mockery::mock());
+        $request = m::mock();
+        $request->shouldReceive('user')->andReturn($user = m::mock());
         $user->shouldReceive('token')->andReturn(null);
 
         $middleware->handle($request, function () {

--- a/tests/ClientControllerTest.php
+++ b/tests/ClientControllerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Laravel\Passport\Client;
+use Laravel\Passport\Http\Controllers\ClientController;
+use Mockery as m;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
 
@@ -7,20 +12,20 @@ class ClientControllerTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_all_the_clients_for_the_current_user_can_be_retrieved()
     {
-        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
-        $clients->shouldReceive('activeForUser')->once()->with(1)->andReturn($client = Mockery::mock());
+        $clients = m::mock('Laravel\Passport\ClientRepository');
+        $clients->shouldReceive('activeForUser')->once()->with(1)->andReturn($client = m::mock());
         $client->shouldReceive('makeVisible')->with('secret')->andReturn($client);
 
-        $request = Mockery::mock('Illuminate\Http\Request');
+        $request = m::mock('Illuminate\Http\Request');
         $request->shouldReceive('user')->andReturn(new ClientControllerFakeUser);
 
-        $controller = new Laravel\Passport\Http\Controllers\ClientController(
-            $clients, Mockery::mock('Illuminate\Contracts\Validation\Factory')
+        $controller = new ClientController(
+            $clients, m::mock('Illuminate\Contracts\Validation\Factory')
         );
 
         $this->assertEquals($client, $controller->forUser($request));
@@ -28,16 +33,19 @@ class ClientControllerTest extends TestCase
 
     public function test_clients_can_be_stored()
     {
-        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clients = m::mock('Laravel\Passport\ClientRepository');
 
         $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
         $request->setUserResolver(function () {
             return new ClientControllerFakeUser;
         });
 
-        $clients->shouldReceive('create')->once()->with(1, 'client name', 'http://localhost')->andReturn($client = new Laravel\Passport\Client);
+        $clients->shouldReceive('create')
+            ->once()
+            ->with(1, 'client name', 'http://localhost')
+            ->andReturn($client = new Client);
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
+        $validator = m::mock('Illuminate\Contracts\Validation\Factory');
         $validator->shouldReceive('make')->once()->with([
             'name' => 'client name',
             'redirect' => 'http://localhost',
@@ -47,33 +55,31 @@ class ClientControllerTest extends TestCase
         ])->andReturn($validator);
         $validator->shouldReceive('validate')->once();
 
-        $controller = new Laravel\Passport\Http\Controllers\ClientController(
-            $clients, $validator
-        );
+        $controller = new ClientController($clients, $validator);
 
         $this->assertEquals($client, $controller->store($request));
     }
 
     public function test_clients_can_be_updated()
     {
-        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
-        $client = Mockery::mock('Laravel\Passport\Client');
+        $clients = m::mock('Laravel\Passport\ClientRepository');
+        $client = m::mock('Laravel\Passport\Client');
         $clients->shouldReceive('findForUser')->with(1, 1)->andReturn($client);
 
         $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
 
         $request->setUserResolver(function () {
-            $user = Mockery::mock();
+            $user = m::mock();
             $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
         $clients->shouldReceive('update')->once()->with(
-            Mockery::type('Laravel\Passport\Client'), 'client name', 'http://localhost'
+            m::type('Laravel\Passport\Client'), 'client name', 'http://localhost'
         )->andReturn('response');
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
+        $validator = m::mock('Illuminate\Contracts\Validation\Factory');
         $validator->shouldReceive('make')->once()->with([
             'name' => 'client name',
             'redirect' => 'http://localhost',
@@ -83,22 +89,20 @@ class ClientControllerTest extends TestCase
         ])->andReturn($validator);
         $validator->shouldReceive('validate')->once();
 
-        $controller = new Laravel\Passport\Http\Controllers\ClientController(
-            $clients, $validator
-        );
+        $controller = new ClientController($clients, $validator);
 
         $this->assertEquals('response', $controller->update($request, 1));
     }
 
     public function test_404_response_if_client_doesnt_belong_to_user()
     {
-        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clients = m::mock('Laravel\Passport\ClientRepository');
         $clients->shouldReceive('findForUser')->with(1, 1)->andReturnNull();
 
         $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
 
         $request->setUserResolver(function () {
-            $user = Mockery::mock();
+            $user = m::mock();
             $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
@@ -106,52 +110,48 @@ class ClientControllerTest extends TestCase
 
         $clients->shouldReceive('update')->never();
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
+        $validator = m::mock('Illuminate\Contracts\Validation\Factory');
 
-        $controller = new Laravel\Passport\Http\Controllers\ClientController(
-            $clients, $validator
-        );
+        $controller = new ClientController($clients, $validator);
 
         $this->assertEquals(404, $controller->update($request, 1)->status());
     }
 
     public function test_clients_can_be_deleted()
     {
-        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
-        $client = Mockery::mock('Laravel\Passport\Client');
+        $clients = m::mock('Laravel\Passport\ClientRepository');
+        $client = m::mock('Laravel\Passport\Client');
         $clients->shouldReceive('findForUser')->with(1, 1)->andReturn($client);
 
         $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
 
         $request->setUserResolver(function () {
-            $user = Mockery::mock();
+            $user = m::mock();
             $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
         $clients->shouldReceive('delete')->once()->with(
-            Mockery::type('Laravel\Passport\Client')
+            m::type('Laravel\Passport\Client')
         )->andReturn('response');
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
+        $validator = m::mock('Illuminate\Contracts\Validation\Factory');
 
-        $controller = new Laravel\Passport\Http\Controllers\ClientController(
-            $clients, $validator
-        );
+        $controller = new ClientController($clients, $validator);
 
         $controller->destroy($request, 1);
     }
 
     public function test_404_response_if_client_doesnt_belong_to_user_on_delete()
     {
-        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
+        $clients = m::mock('Laravel\Passport\ClientRepository');
         $clients->shouldReceive('findForUser')->with(1, 1)->andReturnNull();
 
         $request = Request::create('/', 'GET', ['name' => 'client name', 'redirect' => 'http://localhost']);
 
         $request->setUserResolver(function () {
-            $user = Mockery::mock();
+            $user = m::mock();
             $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
@@ -159,11 +159,9 @@ class ClientControllerTest extends TestCase
 
         $clients->shouldReceive('delete')->never();
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
+        $validator = m::mock('Illuminate\Contracts\Validation\Factory');
 
-        $controller = new Laravel\Passport\Http\Controllers\ClientController(
-            $clients, $validator
-        );
+        $controller = new ClientController($clients, $validator);
 
         $this->assertEquals(404, $controller->destroy($request, 1)->status());
     }
@@ -172,6 +170,7 @@ class ClientControllerTest extends TestCase
 class ClientControllerFakeUser
 {
     public $id = 1;
+
     public function getKey()
     {
         return $this->id;

--- a/tests/CreateFreshApiTokenTest.php
+++ b/tests/CreateFreshApiTokenTest.php
@@ -1,34 +1,39 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Laravel\Passport\Http\Middleware\CreateFreshApiToken;
 use Laravel\Passport\Passport;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\ApiTokenCookieFactory;
+use Laravel\Passport\Http\Middleware\CreateFreshApiToken;
+use Symfony\Component\HttpFoundation\Cookie;
 
 class CreateFreshApiTokenTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function testShouldReceiveAFreshToken()
     {
-        $cookieFactory = Mockery::mock(\Laravel\Passport\ApiTokenCookieFactory::class);
+        $cookieFactory = m::mock(ApiTokenCookieFactory::class);
 
         $middleware = new CreateFreshApiToken($cookieFactory);
-        $request = Mockery::mock(Request::class)->makePartial();
+        $request = m::mock(Request::class)->makePartial();
 
         $response = new Response;
 
         $guard = 'guard';
-        $user = Mockery::mock()
+        $user = m::mock()
             ->shouldReceive('getKey')
             ->andReturn($userKey = 1)
             ->getMock();
 
-        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request->shouldReceive('session')->andReturn($session = m::mock());
         $request->shouldReceive('isMethod')->with('GET')->once()->andReturn(true);
         $request->shouldReceive('user')->with($guard)->twice()->andReturn($user);
         $session->shouldReceive('token')->withNoArgs()->once()->andReturn($token = 't0k3n');
@@ -36,7 +41,7 @@ class CreateFreshApiTokenTest extends TestCase
         $cookieFactory->shouldReceive('make')
             ->with($userKey, $token)
             ->once()
-            ->andReturn(new \Symfony\Component\HttpFoundation\Cookie(Passport::cookie()));
+            ->andReturn(new Cookie(Passport::cookie()));
 
         $result = $middleware->handle($request, function () use ($response) {
             return $response;
@@ -48,7 +53,7 @@ class CreateFreshApiTokenTest extends TestCase
 
     public function testShouldNotReceiveAFreshTokenForOtherHttpVerbs()
     {
-        $cookieFactory = Mockery::mock(\Laravel\Passport\ApiTokenCookieFactory::class);
+        $cookieFactory = m::mock(ApiTokenCookieFactory::class);
 
         $middleware = new CreateFreshApiToken($cookieFactory);
         $request = Request::create('/', 'POST');
@@ -64,7 +69,7 @@ class CreateFreshApiTokenTest extends TestCase
 
     public function testShouldNotReceiveAFreshTokenForAnInvalidUser()
     {
-        $cookieFactory = Mockery::mock(\Laravel\Passport\ApiTokenCookieFactory::class);
+        $cookieFactory = m::mock(ApiTokenCookieFactory::class);
 
         $middleware = new CreateFreshApiToken($cookieFactory);
         $request = Request::create('/', 'GET');
@@ -82,17 +87,17 @@ class CreateFreshApiTokenTest extends TestCase
 
     public function testShouldNotReceiveAFreshTokenForResponseThatAlreadyHasToken()
     {
-        $cookieFactory = Mockery::mock(\Laravel\Passport\ApiTokenCookieFactory::class);
+        $cookieFactory = m::mock(ApiTokenCookieFactory::class);
 
         $middleware = new CreateFreshApiToken($cookieFactory);
         $request = Request::create('/', 'GET');
 
         $response = (new Response)->withCookie(
-            new \Symfony\Component\HttpFoundation\Cookie(Passport::cookie())
+            new Cookie(Passport::cookie())
         );
 
         $request->setUserResolver(function () {
-            return Mockery::mock()
+            return m::mock()
                 ->shouldReceive('getKey')
                 ->andReturn(1)
                 ->getMock();

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -1,29 +1,34 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Routing\ResponseFactory;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use Laravel\Passport\Http\Controllers\DenyAuthorizationController;
 
 class DenyAuthorizationControllerTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_authorization_can_be_denied()
     {
-        $response = Mockery::mock(ResponseFactory::class);
+        $response = m::mock(ResponseFactory::class);
 
-        $controller = new Laravel\Passport\Http\Controllers\DenyAuthorizationController($response);
+        $controller = new DenyAuthorizationController($response);
 
-        $request = Mockery::mock('Illuminate\Http\Request');
+        $request = m::mock('Illuminate\Http\Request');
 
-        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request->shouldReceive('session')->andReturn($session = m::mock());
         $request->shouldReceive('user')->andReturn(new DenyAuthorizationControllerFakeUser);
         $request->shouldReceive('input')->with('state')->andReturn('state');
 
-        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = Mockery::mock(
-            'League\OAuth2\Server\RequestTypes\AuthorizationRequest'
+        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = m::mock(
+            AuthorizationRequest::class
         ));
 
         $authRequest->shouldReceive('setUser')->once();
@@ -41,18 +46,18 @@ class DenyAuthorizationControllerTest extends TestCase
 
     public function test_authorization_can_be_denied_with_multiple_redirect_uris()
     {
-        $response = Mockery::mock(ResponseFactory::class);
+        $response = m::mock(ResponseFactory::class);
 
-        $controller = new Laravel\Passport\Http\Controllers\DenyAuthorizationController($response);
+        $controller = new DenyAuthorizationController($response);
 
-        $request = Mockery::mock('Illuminate\Http\Request');
+        $request = m::mock('Illuminate\Http\Request');
 
-        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request->shouldReceive('session')->andReturn($session = m::mock());
         $request->shouldReceive('user')->andReturn(new DenyAuthorizationControllerFakeUser);
         $request->shouldReceive('input')->with('state')->andReturn('state');
 
-        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = Mockery::mock(
-            'League\OAuth2\Server\RequestTypes\AuthorizationRequest'
+        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = m::mock(
+            AuthorizationRequest::class
         ));
 
         $authRequest->shouldReceive('setUser')->once();
@@ -70,18 +75,18 @@ class DenyAuthorizationControllerTest extends TestCase
 
     public function test_authorization_can_be_denied_implicit()
     {
-        $response = Mockery::mock(ResponseFactory::class);
+        $response = m::mock(ResponseFactory::class);
 
-        $controller = new Laravel\Passport\Http\Controllers\DenyAuthorizationController($response);
+        $controller = new DenyAuthorizationController($response);
 
-        $request = Mockery::mock('Illuminate\Http\Request');
+        $request = m::mock('Illuminate\Http\Request');
 
-        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request->shouldReceive('session')->andReturn($session = m::mock());
         $request->shouldReceive('user')->andReturn(new DenyAuthorizationControllerFakeUser);
         $request->shouldReceive('input')->with('state')->andReturn('state');
 
-        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = Mockery::mock(
-            'League\OAuth2\Server\RequestTypes\AuthorizationRequest'
+        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = m::mock(
+            AuthorizationRequest::class
         ));
 
         $authRequest->shouldReceive('setUser')->once();
@@ -99,18 +104,18 @@ class DenyAuthorizationControllerTest extends TestCase
     
     public function test_authorization_can_be_denied_with_existing_query_string()
     {
-        $response = Mockery::mock(ResponseFactory::class);
+        $response = m::mock(ResponseFactory::class);
 
-        $controller = new Laravel\Passport\Http\Controllers\DenyAuthorizationController($response);
+        $controller = new DenyAuthorizationController($response);
 
-        $request = Mockery::mock('Illuminate\Http\Request');
+        $request = m::mock('Illuminate\Http\Request');
 
-        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request->shouldReceive('session')->andReturn($session = m::mock());
         $request->shouldReceive('user')->andReturn(new DenyAuthorizationControllerFakeUser);
         $request->shouldReceive('input')->with('state')->andReturn('state');
 
-        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = Mockery::mock(
-            'League\OAuth2\Server\RequestTypes\AuthorizationRequest'
+        $session->shouldReceive('get')->once()->with('authRequest')->andReturn($authRequest = m::mock(
+            AuthorizationRequest::class
         ));
 
         $authRequest->shouldReceive('setUser')->once();
@@ -127,18 +132,18 @@ class DenyAuthorizationControllerTest extends TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      * @expectedExceptionMessage Authorization request was not present in the session.
      */
     public function test_auth_request_should_exist()
     {
-        $response = Mockery::mock(ResponseFactory::class);
+        $response = m::mock(ResponseFactory::class);
 
-        $controller = new Laravel\Passport\Http\Controllers\DenyAuthorizationController($response);
+        $controller = new DenyAuthorizationController($response);
 
-        $request = Mockery::mock('Illuminate\Http\Request');
+        $request = m::mock('Illuminate\Http\Request');
 
-        $request->shouldReceive('session')->andReturn($session = Mockery::mock());
+        $request->shouldReceive('session')->andReturn($session = m::mock());
         $request->shouldReceive('user')->never();
         $request->shouldReceive('input')->never();
 
@@ -153,6 +158,7 @@ class DenyAuthorizationControllerTest extends TestCase
 class DenyAuthorizationControllerFakeUser
 {
     public $id = 1;
+
     public function getKey()
     {
         return $this->id;

--- a/tests/HandlesOAuthErrorsTest.php
+++ b/tests/HandlesOAuthErrorsTest.php
@@ -1,15 +1,23 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Error;
+use Exception;
+use Mockery as m;
+use RuntimeException;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Laravel\Passport\Http\Controllers\HandlesOAuthErrors;
 
 class HandlesOAuthErrorsTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function testShouldReturnCallbackResultIfNoErrorIsThrown()
@@ -26,10 +34,10 @@ class HandlesOAuthErrorsTest extends TestCase
 
     public function testShouldHandleOAuthServerException()
     {
-        Container::getInstance()->instance(ExceptionHandler::class, $handler = Mockery::mock());
+        Container::getInstance()->instance(ExceptionHandler::class, $handler = m::mock());
 
         $controller = new HandlesOAuthErrorsStubController;
-        $exception = new \League\OAuth2\Server\Exception\OAuthServerException('Error', 1, 'fatal');
+        $exception = new OAuthServerException('Error', 1, 'fatal');
 
         $handler->shouldReceive('report')->once()->with($exception);
 
@@ -43,7 +51,7 @@ class HandlesOAuthErrorsTest extends TestCase
 
     public function testShouldHandleOtherExceptions()
     {
-        Container::getInstance()->instance(ExceptionHandler::class, $handler = Mockery::mock());
+        Container::getInstance()->instance(ExceptionHandler::class, $handler = m::mock());
 
         $controller = new HandlesOAuthErrorsStubController;
         $exception = new RuntimeException('Exception occurred', 1);
@@ -60,14 +68,14 @@ class HandlesOAuthErrorsTest extends TestCase
 
     public function testShouldHandleThrowables()
     {
-        Container::getInstance()->instance(ExceptionHandler::class, $handler = Mockery::mock());
+        Container::getInstance()->instance(ExceptionHandler::class, $handler = m::mock());
 
         $controller = new HandlesOAuthErrorsStubController;
         $exception = new Error('Fatal Error', 1);
 
         $handler->shouldReceive('report')
             ->once()
-            ->with(Mockery::type(Exception::class));
+            ->with(m::type(Exception::class));
 
         $result = $controller->test(function () use ($exception) {
             throw $exception;
@@ -80,7 +88,7 @@ class HandlesOAuthErrorsTest extends TestCase
 
 class HandlesOAuthErrorsStubController
 {
-    use \Laravel\Passport\Http\Controllers\HandlesOAuthErrors;
+    use HandlesOAuthErrors;
 
     public function test($callback)
     {

--- a/tests/HasApiTokensTest.php
+++ b/tests/HasApiTokensTest.php
@@ -1,19 +1,24 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\HasApiTokens;
 use Illuminate\Container\Container;
+use Laravel\Passport\PersonalAccessTokenFactory;
 
 class HasApiTokensTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_token_can_indicates_if_token_has_given_scope()
     {
         $user = new HasApiTokensTestStub;
-        $token = Mockery::mock();
+        $token = m::mock();
         $token->shouldReceive('can')->with('scope')->andReturn(true);
         $token->shouldReceive('can')->with('another-scope')->andReturn(false);
 
@@ -25,7 +30,7 @@ class HasApiTokensTest extends TestCase
     {
         $container = new Container;
         Container::setInstance($container);
-        $container->instance(Laravel\Passport\PersonalAccessTokenFactory::class, $factory = Mockery::mock());
+        $container->instance(PersonalAccessTokenFactory::class, $factory = m::mock());
         $factory->shouldReceive('make')->once()->with(1, 'name', ['scopes']);
         $user = new HasApiTokensTestStub;
 
@@ -35,7 +40,8 @@ class HasApiTokensTest extends TestCase
 
 class HasApiTokensTestStub
 {
-    use Laravel\Passport\HasApiTokens;
+    use HasApiTokens;
+
     public function getKey()
     {
         return 1;

--- a/tests/KeysCommandTest.php
+++ b/tests/KeysCommandTest.php
@@ -1,11 +1,12 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
+namespace Laravel\Passport\Tests;
 
-function storage_path($file = null)
-{
-    return __DIR__.DIRECTORY_SEPARATOR.$file;
-}
+use Mockery as m;
+use phpseclib\Crypt\RSA;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\TestCase;
+use Laravel\Passport\Console\KeysCommand;
 
 function custom_path($file = null)
 {
@@ -16,7 +17,7 @@ class KeysCommandTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
 
         @unlink(storage_path('oauth-private.key'));
         @unlink(storage_path('oauth-public.key'));
@@ -26,13 +27,13 @@ class KeysCommandTest extends TestCase
 
     public function testPrivateAndPublicKeysAreGenerated()
     {
-        $command = Mockery::mock(Laravel\Passport\Console\KeysCommand::class)
+        $command = m::mock(KeysCommand::class)
             ->makePartial()
             ->shouldReceive('info')
             ->with('Encryption keys generated successfully.')
             ->getMock();
 
-        $rsa = new phpseclib\Crypt\RSA();
+        $rsa = new RSA();
 
         $command->handle($rsa);
 
@@ -42,15 +43,15 @@ class KeysCommandTest extends TestCase
 
     public function testPrivateAndPublicKeysAreGeneratedInCustomPath()
     {
-        \Laravel\Passport\Passport::loadKeysFrom(custom_path());
+        Passport::loadKeysFrom(custom_path());
 
-        $command = Mockery::mock(Laravel\Passport\Console\KeysCommand::class)
+        $command = m::mock(KeysCommand::class)
             ->makePartial()
             ->shouldReceive('info')
             ->with('Encryption keys generated successfully.')
             ->getMock();
 
-        $command->handle(new phpseclib\Crypt\RSA);
+        $command->handle(new RSA);
 
         $this->assertFileExists(custom_path('oauth-private.key'));
         $this->assertFileExists(custom_path('oauth-public.key'));
@@ -70,6 +71,6 @@ class KeysCommandTest extends TestCase
         $command->shouldReceive('error')
             ->with('Encryption keys already exist. Use the --force option to overwrite them.');
 
-        $command->handle(new phpseclib\Crypt\RSA);
+        $command->handle(new RSA);
     }
 }

--- a/tests/PassportServiceProviderTest.php
+++ b/tests/PassportServiceProviderTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
 use Laravel\Passport\Passport;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Config\Repository as Config;
@@ -10,14 +13,14 @@ class PassportServiceProviderTest extends TestCase
 {
     public function test_can_use_crypto_keys_from_config()
     {
-        $config = Mockery::mock(Config::class, function ($config) {
+        $config = m::mock(Config::class, function ($config) {
             $config->shouldReceive('get')
                 ->with('passport.private_key')
                 ->andReturn('-----BEGIN RSA PRIVATE KEY-----\nconfig\n-----END RSA PRIVATE KEY-----');
         });
 
         $provider = new PassportServiceProvider(
-            Mockery::mock(App::class, ['make' => $config])
+            m::mock(App::class, ['make' => $config])
         );
 
         // Call protected makeCryptKey method
@@ -40,12 +43,12 @@ class PassportServiceProviderTest extends TestCase
             "-----BEGIN RSA PRIVATE KEY-----\ndisk\n-----END RSA PRIVATE KEY-----"
         );
 
-        $config = Mockery::mock(Config::class, function ($config) {
+        $config = m::mock(Config::class, function ($config) {
             $config->shouldReceive('get')->with('passport.private_key')->andReturn(null);
         });
 
         $provider = new PassportServiceProvider(
-            Mockery::mock(App::class, ['make' => $config])
+            m::mock(App::class, ['make' => $config])
         );
 
         // Call protected makeCryptKey method

--- a/tests/PassportTest.php
+++ b/tests/PassportTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use Laravel\Passport\AuthCode;
-use Laravel\Passport\Client;
-use Laravel\Passport\Passport;
-use Laravel\Passport\PersonalAccessClient;
 use Laravel\Passport\Token;
+use Laravel\Passport\Client;
+use Laravel\Passport\AuthCode;
+use Laravel\Passport\Passport;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\PersonalAccessClient;
 
 class PassportTest extends TestCase
 {

--- a/tests/PersonalAccessTokenControllerTest.php
+++ b/tests/PersonalAccessTokenControllerTest.php
@@ -1,43 +1,48 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
+use Laravel\Passport\Token;
 use Illuminate\Http\Request;
 use Laravel\Passport\Passport;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\TokenRepository;
+use Laravel\Passport\Http\Controllers\PersonalAccessTokenController;
 
 class PersonalAccessTokenControllerTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_tokens_can_be_retrieved_for_users()
     {
         $request = Request::create('/', 'GET');
 
-        $token1 = new Laravel\Passport\Token;
-        $token2 = new Laravel\Passport\Token;
+        $token1 = new Token;
+        $token2 = new Token;
 
-        $userTokens = Mockery::mock();
+        $userTokens = m::mock();
         $token1->client = (object) ['personal_access_client' => true];
         $token2->client = (object) ['personal_access_client' => false];
         $userTokens->shouldReceive('load')->with('client')->andReturn(collect([
             $token1, $token2,
         ]));
 
-        $tokenRepository = Mockery::mock(TokenRepository::class);
+        $tokenRepository = m::mock(TokenRepository::class);
         $tokenRepository->shouldReceive('forUser')->andReturn($userTokens);
 
         $request->setUserResolver(function () use ($token1, $token2) {
-            $user = Mockery::mock();
+            $user = m::mock();
             $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
-        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($tokenRepository, $validator);
+        $validator = m::mock('Illuminate\Contracts\Validation\Factory');
+        $controller = new PersonalAccessTokenController($tokenRepository, $validator);
 
         $this->assertCount(1, $controller->forUser($request));
         $this->assertEquals($token1, $controller->forUser($request)[0]);
@@ -53,13 +58,16 @@ class PersonalAccessTokenControllerTest extends TestCase
         $request = Request::create('/', 'GET', ['name' => 'token name', 'scopes' => ['user', 'user-admin']]);
 
         $request->setUserResolver(function () {
-            $user = Mockery::mock();
-            $user->shouldReceive('createToken')->once()->with('token name', ['user', 'user-admin'])->andReturn('response');
+            $user = m::mock();
+            $user->shouldReceive('createToken')
+                ->once()
+                ->with('token name', ['user', 'user-admin'])
+                ->andReturn('response');
 
             return $user;
         });
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
+        $validator = m::mock('Illuminate\Contracts\Validation\Factory');
         $validator->shouldReceive('make')->once()->with([
             'name' => 'token name',
             'scopes' => ['user', 'user-admin'],
@@ -69,8 +77,8 @@ class PersonalAccessTokenControllerTest extends TestCase
         ])->andReturn($validator);
         $validator->shouldReceive('validate')->once();
 
-        $tokenRepository = Mockery::mock(TokenRepository::class);
-        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($tokenRepository, $validator);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $controller = new PersonalAccessTokenController($tokenRepository, $validator);
 
         $this->assertEquals('response', $controller->store($request));
     }
@@ -79,22 +87,22 @@ class PersonalAccessTokenControllerTest extends TestCase
     {
         $request = Request::create('/', 'GET');
 
-        $token1 = Mockery::mock(Laravel\Passport\Token::class.'[revoke]');
+        $token1 = m::mock(Token::class.'[revoke]');
         $token1->id = 1;
         $token1->shouldReceive('revoke')->once();
 
-        $tokenRepository = Mockery::mock(TokenRepository::class);
+        $tokenRepository = m::mock(TokenRepository::class);
         $tokenRepository->shouldReceive('findForUser')->andReturn($token1);
 
         $request->setUserResolver(function () {
-            $user = Mockery::mock();
+            $user = m::mock();
             $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
-        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($tokenRepository, $validator);
+        $validator = m::mock('Illuminate\Contracts\Validation\Factory');
+        $controller = new PersonalAccessTokenController($tokenRepository, $validator);
 
         $controller->destroy($request, 1);
     }
@@ -103,18 +111,18 @@ class PersonalAccessTokenControllerTest extends TestCase
     {
         $request = Request::create('/', 'GET');
 
-        $tokenRepository = Mockery::mock(TokenRepository::class);
+        $tokenRepository = m::mock(TokenRepository::class);
         $tokenRepository->shouldReceive('findForUser')->with(3, 1)->andReturnNull();
 
         $request->setUserResolver(function () {
-            $user = Mockery::mock();
+            $user = m::mock();
             $user->shouldReceive('getKey')->andReturn(1);
 
             return $user;
         });
 
-        $validator = Mockery::mock('Illuminate\Contracts\Validation\Factory');
-        $controller = new Laravel\Passport\Http\Controllers\PersonalAccessTokenController($tokenRepository, $validator);
+        $validator = m::mock('Illuminate\Contracts\Validation\Factory');
+        $controller = new PersonalAccessTokenController($tokenRepository, $validator);
 
         $this->assertEquals(404, $controller->destroy($request, 3)->status());
     }

--- a/tests/PersonalAccessTokenFactoryTest.php
+++ b/tests/PersonalAccessTokenFactoryTest.php
@@ -1,32 +1,39 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
+use Laravel\Passport\Token;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\PersonalAccessTokenFactory;
 
 class PersonalAccessTokenFactoryTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_access_token_can_be_created()
     {
-        $server = Mockery::mock('League\OAuth2\Server\AuthorizationServer');
-        $clients = Mockery::mock('Laravel\Passport\ClientRepository');
-        $tokens = Mockery::mock('Laravel\Passport\TokenRepository');
-        $jwt = Mockery::mock('Lcobucci\JWT\Parser');
+        $server = m::mock('League\OAuth2\Server\AuthorizationServer');
+        $clients = m::mock('Laravel\Passport\ClientRepository');
+        $tokens = m::mock('Laravel\Passport\TokenRepository');
+        $jwt = m::mock('Lcobucci\JWT\Parser');
 
-        $factory = new Laravel\Passport\PersonalAccessTokenFactory($server, $clients, $tokens, $jwt);
+        $factory = new PersonalAccessTokenFactory($server, $clients, $tokens, $jwt);
 
         $clients->shouldReceive('personalAccessClient')->andReturn($client = new PersonalAccessTokenFactoryTestClientStub);
-        $server->shouldReceive('respondToAccessTokenRequest')->andReturn($response = Mockery::mock());
+        $server->shouldReceive('respondToAccessTokenRequest')->andReturn($response = m::mock());
         $response->shouldReceive('getBody->__toString')->andReturn(json_encode([
             'access_token' => 'foo',
         ]));
 
-        $jwt->shouldReceive('parse')->with('foo')->andReturn($parsedToken = Mockery::mock());
+        $jwt->shouldReceive('parse')->with('foo')->andReturn($parsedToken = m::mock());
         $parsedToken->shouldReceive('getClaim')->with('jti')->andReturn('token');
-        $tokens->shouldReceive('find')->with('token')->andReturn($foundToken = new PersonalAccessTokenFactoryTestModelStub);
+        $tokens->shouldReceive('find')
+            ->with('token')
+            ->andReturn($foundToken = new PersonalAccessTokenFactoryTestModelStub);
         $tokens->shouldReceive('save')->with($foundToken);
 
         $result = $factory->make(1, 'token', ['scopes']);
@@ -38,11 +45,13 @@ class PersonalAccessTokenFactoryTest extends TestCase
 class PersonalAccessTokenFactoryTestClientStub
 {
     public $id = 1;
+
     public $secret = 'something';
 }
 
-class PersonalAccessTokenFactoryTestModelStub extends Laravel\Passport\Token
+class PersonalAccessTokenFactoryTestModelStub extends Token
 {
     public $id = 1;
+
     public $secret = 'something';
 }

--- a/tests/ScopeControllerTest.php
+++ b/tests/ScopeControllerTest.php
@@ -1,14 +1,19 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Laravel\Passport\Scope;
+use Laravel\Passport\Passport;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\Http\Controllers\ScopeController;
 
 class ScopeControllerTest extends TestCase
 {
     public function testShouldGetScopes()
     {
-        $controller = new \Laravel\Passport\Http\Controllers\ScopeController;
+        $controller = new ScopeController;
 
-        \Laravel\Passport\Passport::tokensCan($scopes = [
+        Passport::tokensCan($scopes = [
             'place-orders' => 'Place orders',
             'check-status' => 'Check order status',
         ]);
@@ -16,7 +21,7 @@ class ScopeControllerTest extends TestCase
         $result = $controller->all();
 
         $this->assertCount(2, $result);
-        $this->assertContainsOnlyInstancesOf(\Laravel\Passport\Scope::class, $result);
+        $this->assertContainsOnlyInstancesOf(Scope::class, $result);
         $this->assertSame(['id' => 'place-orders', 'description' => 'Place orders'], $result[0]->toArray());
         $this->assertSame(['id' => 'check-status', 'description' => 'Check order status'], $result[1]->toArray());
     }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -1,12 +1,15 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Laravel\Passport\Scope;
 use PHPUnit\Framework\TestCase;
 
 class ScopeTest extends TestCase
 {
     public function test_scope_can_be_converted_to_array()
     {
-        $scope = new Laravel\Passport\Scope('user', 'get user information');
+        $scope = new Scope('user', 'get user information');
         $this->assertEquals([
             'id' => 'user',
             'description' => 'get user information',
@@ -15,7 +18,7 @@ class ScopeTest extends TestCase
 
     public function test_scope_can_be_converted_to_json()
     {
-        $scope = new Laravel\Passport\Scope('user', 'get user information');
+        $scope = new Scope('user', 'get user information');
         $this->assertEquals(json_encode([
             'id' => 'user',
             'description' => 'get user information',

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -1,19 +1,22 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Laravel\Passport\Token;
 use PHPUnit\Framework\TestCase;
 
 class TokenTest extends TestCase
 {
     public function test_token_can_determine_if_it_has_scopes()
     {
-        $token = new Laravel\Passport\Token(['scopes' => ['user']]);
+        $token = new Token(['scopes' => ['user']]);
 
         $this->assertTrue($token->can('user'));
         $this->assertFalse($token->can('something'));
         $this->assertTrue($token->cant('something'));
         $this->assertFalse($token->cant('user'));
 
-        $token = new Laravel\Passport\Token(['scopes' => ['*']]);
+        $token = new Token(['scopes' => ['*']]);
         $this->assertTrue($token->can('user'));
         $this->assertTrue($token->can('something'));
     }

--- a/tests/TransientTokenControllerTest.php
+++ b/tests/TransientTokenControllerTest.php
@@ -1,26 +1,31 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
+use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
+use Laravel\Passport\Http\Controllers\TransientTokenController;
 
 class TransientTokenControllerTest extends TestCase
 {
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
 
     public function test_token_can_be_refreshed()
     {
-        $cookieFactory = Mockery::mock('Laravel\Passport\ApiTokenCookieFactory');
+        $cookieFactory = m::mock('Laravel\Passport\ApiTokenCookieFactory');
         $cookieFactory->shouldReceive('make')->once()->with(1, 'token')->andReturn(new Cookie('cookie'));
 
-        $request = Mockery::mock(Illuminate\Http\Request::class);
-        $request->shouldReceive('user')->andReturn($user = Mockery::mock());
+        $request = m::mock(Request::class);
+        $request->shouldReceive('user')->andReturn($user = m::mock());
         $user->shouldReceive('getKey')->andReturn(1);
         $request->shouldReceive('session->token')->andReturn('token');
 
-        $controller = new Laravel\Passport\Http\Controllers\TransientTokenController($cookieFactory);
+        $controller = new TransientTokenController($cookieFactory);
 
         $response = $controller->refresh($request);
 

--- a/tests/TransientTokenTest.php
+++ b/tests/TransientTokenTest.php
@@ -1,12 +1,15 @@
 <?php
 
+namespace Laravel\Passport\Tests;
+
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\TransientToken;
 
 class TransientTokenTest extends TestCase
 {
     public function test_transient_token_can_do_anything()
     {
-        $token = new Laravel\Passport\TransientToken;
+        $token = new TransientToken;
         $this->assertTrue($token->can('foo'));
         $this->assertFalse($token->cant('foo'));
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+function storage_path($file = null)
+{
+    return __DIR__.DIRECTORY_SEPARATOR.$file;
+}


### PR DESCRIPTION
Had to move the mocked `storage_path` function to a bootstrap file because otherwise it was in the test namespace and couldn't picked up in the `Passport` class anymore.