### PR TITLE
[8.0] Use unsignedInteger column type for client_id columns

### DIFF
--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -16,7 +16,7 @@ class CreateOauthAuthCodesTable extends Migration
         Schema::create('oauth_auth_codes', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->integer('user_id');
-            $table->integer('client_id');
+            $table->unsignedInteger('client_id');
             $table->text('scopes')->nullable();
             $table->boolean('revoked');
             $table->dateTime('expires_at')->nullable();

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -16,7 +16,7 @@ class CreateOauthAccessTokensTable extends Migration
         Schema::create('oauth_access_tokens', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->integer('user_id')->index()->nullable();
-            $table->integer('client_id');
+            $table->unsignedInteger('client_id');
             $table->string('name')->nullable();
             $table->text('scopes')->nullable();
             $table->boolean('revoked');

--- a/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -15,7 +15,7 @@ class CreateOauthPersonalAccessClientsTable extends Migration
     {
         Schema::create('oauth_personal_access_clients', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('client_id')->index();
+            $table->unsignedInteger('client_id')->index();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
This is because the client id autoincrements. We don't add foreign key indexes ourselves but if you try to add them afterwards you'll have to first change the column type of the client_id columns because otherwise they don't match the increments column. We can immediately use the proper type in the migrations here.

Sending this to the 8.0 branch because I wasn't too sure if this would be breaking or not so better play it safe.

Fixes https://github.com/laravel/passport/issues/912