### PR TITLE
[7.0] Added redirect_uri and user_id options to cli

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -17,6 +17,8 @@ class ClientCommand extends Command
             {--personal : Create a personal access token client}
             {--password : Create a password grant client}
             {--client : Create a client credentials grant client}
+            {--redirect_uri= : Redirect URI after authorization request }
+            {--user_id= : User ID the client is assigned to }
             {--name= : The name of the client}';
 
     /**
@@ -118,7 +120,7 @@ class ClientCommand extends Command
      */
     protected function createAuthCodeClient(ClientRepository $clients)
     {
-        $userId = $this->ask(
+        $userId = $this->option('user_id') ?: $this->ask(
             'Which user ID should the client be assigned to?'
         );
 
@@ -126,7 +128,7 @@ class ClientCommand extends Command
             'What should we name the client?'
         );
 
-        $redirect = $this->ask(
+        $redirect = $this->option('redirect_uri') ?: $this->ask(
             'Where should we redirect the request after authorization?',
             url('/auth/callback')
         );


### PR DESCRIPTION
When using `passport:client` commands, add `redirect_uri` and `user_id` options. Useful for automated builds.