### PR TITLE
[7.0] Make name an optional question

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -100,7 +100,8 @@ class ClientCommand extends Command
     protected function createClientCredentialsClient(ClientRepository $clients)
     {
         $name = $this->option('name') ?: $this->ask(
-            'What should we name the client?'
+            'What should we name the client?',
+            config('app.name').' ClientCredentials Grant Client'
         );
 
         $client = $clients->create(


### PR DESCRIPTION
The command ask a required question  but allows user to skip; which cause failure in mysql insert query.
Just press enter when the command asks
"What should we name the client?:"

```
php artisan passport:client --client
```

This PR will auto guess the name when no name is specified or input by user.