### PR TITLE
[7.0] Fix revoked refresh token check

### DIFF
--- a/src/Bridge/RefreshTokenRepository.php
+++ b/src/Bridge/RefreshTokenRepository.php
@@ -11,13 +11,6 @@ use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 class RefreshTokenRepository implements RefreshTokenRepositoryInterface
 {
     /**
-     * The access token repository instance.
-     *
-     * @var \Laravel\Passport\Bridge\AccessTokenRepository
-     */
-    protected $tokens;
-
-    /**
      * The database connection.
      *
      * @var \Illuminate\Database\Connection
@@ -34,17 +27,13 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
     /**
      * Create a new repository instance.
      *
-     * @param  \Laravel\Passport\Bridge\AccessTokenRepository  $tokens
      * @param  \Illuminate\Database\Connection  $database
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @return void
      */
-    public function __construct(AccessTokenRepository $tokens,
-                                Connection $database,
-                                Dispatcher $events)
+    public function __construct(Connection $database, Dispatcher $events)
     {
         $this->events = $events;
-        $this->tokens = $tokens;
         $this->database = $database;
     }
 
@@ -88,12 +77,6 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
         $refreshToken = $this->database->table('oauth_refresh_tokens')
                     ->where('id', $tokenId)->first();
 
-        if ($refreshToken === null || $refreshToken->revoked) {
-            return true;
-        }
-
-        return $this->tokens->isAccessTokenRevoked(
-            $refreshToken->access_token_id
-        );
+        return $refreshToken === null || $refreshToken->revoked;
     }
 }

--- a/tests/BridgeRefreshTokenRepositoryTest.php
+++ b/tests/BridgeRefreshTokenRepositoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Laravel\Passport\Tests;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Passport\Bridge\RefreshTokenRepository;
+
+class BridgeRefreshTokenRepositoryTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function test_it_can_determine_if_a_refresh_token_is_revoked()
+    {
+        $refreshToken = new RevokedRefreshToken;
+        $repository = $this->repository($refreshToken);
+
+        $this->assertTrue($repository->isRefreshTokenRevoked('tokenId'));
+    }
+
+    public function test_a_refresh_token_is_also_revoked_if_it_cannot_be_found()
+    {
+        $refreshToken = null;
+        $repository = $this->repository($refreshToken);
+
+        $this->assertTrue($repository->isRefreshTokenRevoked('tokenId'));
+    }
+
+    public function test_it_can_determine_if_a_refresh_token_is_not_revoked()
+    {
+        $refreshToken = new ActiveRefreshToken;
+        $repository = $this->repository($refreshToken);
+
+        $this->assertFalse($repository->isRefreshTokenRevoked('tokenId'));
+    }
+
+    private function repository($refreshToken): RefreshTokenRepository
+    {
+        $queryBuilder = m::mock(Builder::class);
+        $queryBuilder->shouldReceive('first')->andReturn($refreshToken);
+        $queryBuilder->shouldReceive('where')->andReturn($queryBuilder);
+
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('table')->andReturn($queryBuilder);
+
+        $events = m::mock(Dispatcher::class);
+
+        return new RefreshTokenRepository($connection, $events);
+    }
+}
+
+class ActiveRefreshToken
+{
+    public $revoked = false;
+}
+
+class RevokedRefreshToken
+{
+    public $revoked = true;
+}


### PR DESCRIPTION
When a check if performed to determine if a refresh token is revoked or not, it's unnecessary to also check if its corresponding access token is revoked. It's perfectly possible to issue a new access token if the old access token is either revoked or pruned as long as the refresh token is valid.

Fixes https://github.com/laravel/passport/issues/917