### PR TITLE
[7.0] Allow multiple redirects when creating clients

### DIFF
--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Http\Rules\RedirectRule;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 
 class ClientController
@@ -24,17 +25,28 @@ class ClientController
     protected $validation;
 
     /**
+     * The redirect validation rule.
+     *
+     * @var \Laravel\Passport\Http\Rules\RedirectRule
+     */
+    protected $redirectRule;
+
+    /**
      * Create a client controller instance.
      *
      * @param  \Laravel\Passport\ClientRepository  $clients
      * @param  \Illuminate\Contracts\Validation\Factory  $validation
+     * @param  \Laravel\Passport\Http\Rules\RedirectRule  $redirectRule
      * @return void
      */
-    public function __construct(ClientRepository $clients,
-                                ValidationFactory $validation)
-    {
+    public function __construct(
+        ClientRepository $clients,
+        ValidationFactory $validation,
+        RedirectRule $redirectRule
+    ) {
         $this->clients = $clients;
         $this->validation = $validation;
+        $this->redirectRule = $redirectRule;
     }
 
     /**
@@ -60,7 +72,7 @@ class ClientController
     {
         $this->validation->make($request->all(), [
             'name' => 'required|max:255',
-            'redirect' => 'required|url',
+            'redirect' => ['required', $this->redirectRule],
         ])->validate();
 
         return $this->clients->create(
@@ -85,7 +97,7 @@ class ClientController
 
         $this->validation->make($request->all(), [
             'name' => 'required|max:255',
-            'redirect' => 'required|url',
+            'redirect' => ['required', $this->redirectRule],
         ])->validate();
 
         return $this->clients->update(

--- a/src/Http/Rules/RedirectRule.php
+++ b/src/Http/Rules/RedirectRule.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Passport\Http\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\Factory;
+
+class RedirectRule implements Rule
+{
+    /**
+     * @var \Illuminate\Contracts\Validation\Factory
+     */
+    private $validator;
+
+    public function __construct(Factory $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function passes($attribute, $value)
+    {
+        foreach (explode(',', $value) as $redirect) {
+            $validator = $this->validator->make(['redirect' => $redirect], ['redirect' => 'url']);
+
+            if ($validator->fails()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function message()
+    {
+        return 'One or more redirects have an invalid url format.';
+    }
+}

--- a/tests/RedirectRuleTest.php
+++ b/tests/RedirectRuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Laravel\Passport\Tests;
+
+use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Contracts\Validation\Validator;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Laravel\Passport\Http\Rules\RedirectRule;
+
+class RedirectRuleTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function test_it_passes_with_a_single_valid_url()
+    {
+        $rule = $this->rule($fails = false);
+
+        $this->assertTrue($rule->passes('redirect', 'https://example.com'));
+    }
+
+    public function test_it_passes_with_multiple_valid_urls()
+    {
+        $rule = $this->rule($fails = false);
+
+        $this->assertTrue($rule->passes('redirect', 'https://example.com,https://example2.com'));
+    }
+
+    public function test_it_fails_with_a_single_invalid_url()
+    {
+        $rule = $this->rule($fails = true);
+
+        $this->assertFalse($rule->passes('redirect', 'https://example.com,invalid'));
+    }
+
+    private function rule(bool $fails): RedirectRule
+    {
+        $validator = m::mock(Validator::class);
+        $validator->shouldReceive('fails')->andReturn($fails);
+
+        $factory = m::mock(Factory::class);
+        $factory->shouldReceive('make')->andReturn($validator);
+
+        return new RedirectRule($factory);
+    }
+}


### PR DESCRIPTION
This change allows for multiple redirects in a comma separated list when adding them through the ClientController. It makes use of a custom validation rule which will separate the urls by the comma and run the url validator rule over each one individually.

Except for `https://example.com` individually, the value of `https://example.com,https://example2.com` would be allowed as well.

I took the approach of a custom validation rule because it seemed the most flexible in terms of implementing the custom logic. It allows for re-using Laravel's url validation rule.

Fixes https://github.com/laravel/passport/issues/897