### PR TITLE
[7.0] Do not auto increment AuthCode ID

### DIFF
--- a/src/AuthCode.php
+++ b/src/AuthCode.php
@@ -14,6 +14,13 @@ class AuthCode extends Model
     protected $table = 'oauth_auth_codes';
 
     /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
      * The guarded attributes on the model.
      *
      * @var array


### PR DESCRIPTION
This follows the same rule as the Token model. Both don't have auto incrementing IDs so we should set this to false.

Fixes https://github.com/laravel/passport/issues/895