### PR TITLE
[7.0] Add responses for destroy methods

### DIFF
--- a/src/Http/Controllers/AuthorizedAccessTokenController.php
+++ b/src/Http/Controllers/AuthorizedAccessTokenController.php
@@ -60,6 +60,6 @@ class AuthorizedAccessTokenController
 
         $token->revoke();
 
-        return new Response('Token successfully revoked.', Response::HTTP_NO_CONTENT);
+        return new Response('', Response::HTTP_NO_CONTENT);
     }
 }

--- a/src/Http/Controllers/AuthorizedAccessTokenController.php
+++ b/src/Http/Controllers/AuthorizedAccessTokenController.php
@@ -59,5 +59,7 @@ class AuthorizedAccessTokenController
         }
 
         $token->revoke();
+
+        return new Response('Token successfully revoked.', Response::HTTP_NO_CONTENT);
     }
 }

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -122,6 +122,6 @@ class ClientController
 
         $this->clients->delete($client);
 
-        return new Response('Client successfully deleted.', Response::HTTP_NO_CONTENT);
+        return new Response('', Response::HTTP_NO_CONTENT);
     }
 }

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -108,7 +108,7 @@ class ClientController
     /**
      * Delete the given client.
      *
-     * @param  Request  $request
+     * @param  \Illuminate\Http\Request  $request
      * @param  string  $clientId
      * @return \Illuminate\Http\Response
      */
@@ -120,8 +120,8 @@ class ClientController
             return new Response('', 404);
         }
 
-        $this->clients->delete(
-            $client
-        );
+        $this->clients->delete($client);
+
+        return new Response('Client successfully deleted.', Response::HTTP_NO_CONTENT);
     }
 }

--- a/src/Http/Controllers/PersonalAccessTokenController.php
+++ b/src/Http/Controllers/PersonalAccessTokenController.php
@@ -73,7 +73,7 @@ class PersonalAccessTokenController
     /**
      * Delete the given token.
      *
-     * @param  Request  $request
+     * @param  \Illuminate\Http\Request  $request
      * @param  string  $tokenId
      * @return \Illuminate\Http\Response
      */
@@ -88,5 +88,7 @@ class PersonalAccessTokenController
         }
 
         $token->revoke();
+
+        return new Response('Token successfully revoked.', Response::HTTP_NO_CONTENT);
     }
 }

--- a/src/Http/Controllers/PersonalAccessTokenController.php
+++ b/src/Http/Controllers/PersonalAccessTokenController.php
@@ -89,6 +89,6 @@ class PersonalAccessTokenController
 
         $token->revoke();
 
-        return new Response('Token successfully revoked.', Response::HTTP_NO_CONTENT);
+        return new Response('', Response::HTTP_NO_CONTENT);
     }
 }

--- a/tests/AuthorizedAccessTokenControllerTest.php
+++ b/tests/AuthorizedAccessTokenControllerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Laravel\Passport\Client;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\TokenRepository;
+use Symfony\Component\HttpFoundation\Response;
 use Laravel\Passport\Http\Controllers\AuthorizedAccessTokenController;
 
 class AuthorizedAccessTokenControllerTest extends TestCase
@@ -85,7 +86,9 @@ class AuthorizedAccessTokenControllerTest extends TestCase
             return $user;
         });
 
-        $this->controller->destroy($request, 1);
+        $response = $this->controller->destroy($request, 1);
+
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->status());
     }
 
     public function test_not_found_response_is_returned_if_user_doesnt_have_token()

--- a/tests/ClientControllerTest.php
+++ b/tests/ClientControllerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Laravel\Passport\Client;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\Http\Rules\RedirectRule;
+use Symfony\Component\HttpFoundation\Response;
 use Laravel\Passport\Http\Controllers\ClientController;
 
 class ClientControllerTest extends TestCase
@@ -155,7 +156,9 @@ class ClientControllerTest extends TestCase
             $clients, $validator, m::mock(RedirectRule::class)
         );
 
-        $controller->destroy($request, 1);
+        $response = $controller->destroy($request, 1);
+
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->status());
     }
 
     public function test_404_response_if_client_doesnt_belong_to_user_on_delete()

--- a/tests/PersonalAccessTokenControllerTest.php
+++ b/tests/PersonalAccessTokenControllerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Laravel\Passport\Passport;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\TokenRepository;
+use Symfony\Component\HttpFoundation\Response;
 use Laravel\Passport\Http\Controllers\PersonalAccessTokenController;
 
 class PersonalAccessTokenControllerTest extends TestCase
@@ -104,7 +105,9 @@ class PersonalAccessTokenControllerTest extends TestCase
         $validator = m::mock('Illuminate\Contracts\Validation\Factory');
         $controller = new PersonalAccessTokenController($tokenRepository, $validator);
 
-        $controller->destroy($request, 1);
+        $response = $controller->destroy($request, 1);
+
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->status());
     }
 
     public function test_not_found_response_is_returned_if_user_doesnt_have_token()


### PR DESCRIPTION
This adds proper responses and HTTP statuses for the destroy methods on success.

Fixes https://github.com/laravel/passport/issues/687