### PR TITLE
Make refresh tokens configurable

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -125,6 +125,13 @@ class Passport
     public static $tokenModel = 'Laravel\Passport\Token';
 
     /**
+     * The refresh token model class name.
+     *
+     * @var string
+     */
+    public static $refreshTokenModel = 'Laravel\Passport\RefreshToken';
+
+    /**
      * Indicates if Passport migrations will be run.
      *
      * @var bool
@@ -545,6 +552,38 @@ class Passport
     {
         return new static::$tokenModel;
     }
+
+    /**
+     * Set the refresh token model class name.
+     *
+     * @param  string  $refreshTokenModel
+     * @return void
+     */
+    public static function useRefreshTokenModel($refreshTokenModel)
+    {
+        static::$refreshTokenModel = $refreshTokenModel;
+    }
+
+    /**
+     * Get the refresh token model class name.
+     *
+     * @return string
+     */
+    public static function refreshTokenModel()
+    {
+        return static::$refreshTokenModel;
+    }
+
+    /**
+     * Get a new refresh token model instance.
+     *
+     * @return \Laravel\Passport\RefreshToken
+     */
+    public static function refreshToken()
+    {
+        return new static::$refreshTokenModel;
+    }
+
 
     /**
      * Configure Passport to not register its migrations.

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Passport;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RefreshToken extends Model
+{
+    /**
+     * The database table used by the model.
+     *
+     * @var string
+     */
+    protected $table = 'oauth_refresh_tokens';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The guarded attributes on the model.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'revoked' => 'bool',
+    ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'expires_at',
+    ];
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * Get the access token that the refresh token belongs to..
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function accessToken()
+    {
+        return $this->belongsTo(Passport::tokenModel());
+    }
+
+    /**
+     * Revoke the token instance.
+     *
+     * @return bool
+     */
+    public function revoke()
+    {
+        return $this->forceFill(['revoked' => true])->save();
+    }
+
+    /**
+     * Determine if the token is a transient JWT token.
+     *
+     * @return bool
+     */
+    public function transient()
+    {
+        return false;
+    }
+}

--- a/src/RefreshTokenRepository.php
+++ b/src/RefreshTokenRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Laravel\Passport;
+
+class RefreshTokenRepository
+{
+    /**
+     * Creates a new refresh token.
+     *
+     * @param  array  $attributes
+     * @return \Laravel\Passport\RefreshToken
+     */
+    public function create($attributes)
+    {
+        return Passport::refreshToken()->create($attributes);
+    }
+
+    /**
+     * Gets a refresh token by the given ID.
+     *
+     * @param  string  $id
+     * @return \Laravel\Passport\RefreshToken
+     */
+    public function find($id)
+    {
+        return Passport::refreshToken()->where('id', $id)->first();
+    }
+
+    /**
+     * Stores the given token instance.
+     *
+     * @param  \Laravel\Passport\RefreshToken  $token
+     * @return void
+     */
+    public function save(RefreshToken $token)
+    {
+        $token->save();
+    }
+
+    /**
+     * Revokes the refresh token.
+     *
+     * @param  string  $id
+     * @return mixed
+     */
+    public function revokeRefreshToken($id)
+    {
+        return Passport::refreshToken()->where('id', $id)->update(['revoked' => true]);
+    }
+
+    /**
+     * Checks if the refresh token has been revoked.
+     *
+     * @param  string  $id
+     * @return bool
+     */
+    public function isRefreshTokenRevoked($id)
+    {
+        if ($token = $this->find($id)) {
+            return $token->revoked;
+        }
+
+        return true;
+    }
+}

--- a/tests/BridgeRefreshTokenRepositoryTest.php
+++ b/tests/BridgeRefreshTokenRepositoryTest.php
@@ -4,10 +4,8 @@ namespace Laravel\Passport\Tests;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Database\Connection;
-use Illuminate\Database\Query\Builder;
-use Illuminate\Contracts\Events\Dispatcher;
-use Laravel\Passport\Bridge\RefreshTokenRepository;
+use Laravel\Passport\RefreshTokenRepository;
+use Laravel\Passport\Bridge\RefreshTokenRepository as BridgeRefreshTokenRepository;
 
 class BridgeRefreshTokenRepositoryTest extends TestCase
 {
@@ -40,18 +38,16 @@ class BridgeRefreshTokenRepositoryTest extends TestCase
         $this->assertFalse($repository->isRefreshTokenRevoked('tokenId'));
     }
 
-    private function repository($refreshToken): RefreshTokenRepository
+    private function repository($refreshToken): BridgeRefreshTokenRepository
     {
-        $queryBuilder = m::mock(Builder::class);
-        $queryBuilder->shouldReceive('first')->andReturn($refreshToken);
-        $queryBuilder->shouldReceive('where')->andReturn($queryBuilder);
+        $refreshTokenRepository = m::mock(RefreshTokenRepository::class)->makePartial();
+        $refreshTokenRepository->shouldReceive('find')
+            ->with('tokenId')
+            ->andReturn($refreshToken);
 
-        $connection = m::mock(Connection::class);
-        $connection->shouldReceive('table')->andReturn($queryBuilder);
+        $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
 
-        $events = m::mock(Dispatcher::class);
-
-        return new RefreshTokenRepository($connection, $events);
+        return new BridgeRefreshTokenRepository($refreshTokenRepository, $events);
     }
 }
 


### PR DESCRIPTION
This adds a configurable `RefreshToken` model and a new repository. The changes hopefully bring the same flexibility access tokens, clients, authcodes etc. enjoy, making refresh tokens easier to tinker with.

These changes are particularly helpful when you want to use eloquent to query the refresh token table from your application or if you change the refresh token table name.

Let me know if you would like anything else changed.