### PR TITLE
[7.0] Allow '*' scope to be used with Client Credentials

### DIFF
--- a/src/Bridge/ScopeRepository.php
+++ b/src/Bridge/ScopeRepository.php
@@ -25,7 +25,7 @@ class ScopeRepository implements ScopeRepositoryInterface
         array $scopes, $grantType,
         ClientEntityInterface $clientEntity, $userIdentifier = null)
     {
-        if (! in_array($grantType, ['password', 'personal_access'])) {
+        if (! in_array($grantType, ['password', 'personal_access', 'client_credentials'])) {
             $scopes = collect($scopes)->reject(function ($scope) {
                 return trim($scope->getIdentifier()) === '*';
             })->values()->all();

--- a/tests/BridgeScopeRepositoryTest.php
+++ b/tests/BridgeScopeRepositoryTest.php
@@ -34,7 +34,7 @@ class BridgeScopeRepositoryTest extends TestCase
         $repository = new ScopeRepository;
 
         $scopes = $repository->finalizeScopes(
-            [$scope1 = new Scope('*')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
+            [$scope1 = new Scope('*')], 'refresh_token', new Client('id', 'name', 'http://localhost'), 1
         );
 
         $this->assertEquals([], $scopes);


### PR DESCRIPTION
As mentioned in https://github.com/laravel/passport/issues/516, using the `*` character to request all scopes for the Client Credentials grant type is valid.

This PR will allow the character to be used when requesting an access token with the Client Credentials Grant.