### PR TITLE
[7.0] Changed the way to get action path from url() to route()

### DIFF
--- a/resources/views/authorize.blade.php
+++ b/resources/views/authorize.blade.php
@@ -64,7 +64,7 @@
 
                         <div class="buttons">
                             <!-- Authorize Button -->
-                            <form method="post" action="{{ url('/oauth/authorize') }}">
+                            <form method="post" action="{{ route('passport.authorizations.approve') }}">
                                 {{ csrf_field() }}
 
                                 <input type="hidden" name="state" value="{{ $request->state }}">
@@ -73,7 +73,7 @@
                             </form>
 
                             <!-- Cancel Button -->
-                            <form method="post" action="{{ url('/oauth/authorize') }}">
+                            <form method="post" action="{{ route('passport.authorizations.deny') }}">
                                 {{ csrf_field() }}
                                 {{ method_field('DELETE') }}
 


### PR DESCRIPTION
If we use second parameter for register routes default views are broken
Passport::routes(false, ["prefix" => "something"]);