### PR TITLE
Replace fire() with dispatch()

### DIFF
--- a/src/Bridge/RefreshTokenRepository.php
+++ b/src/Bridge/RefreshTokenRepository.php
@@ -57,7 +57,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
             'expires_at' => $refreshTokenEntity->getExpiryDateTime(),
         ]);
 
-        $this->events->fire(new RefreshTokenCreated($id, $accessTokenId));
+        $this->events->dispatch(new RefreshTokenCreated($id, $accessTokenId));
     }
 
     /**


### PR DESCRIPTION
`fire()` was deprecated and `dispatch()` should be used. Also `\Illuminate\Contracts\Events\Dispatcher` has `dispatch()` but not `fire()`