### PR TITLE
[8.0] Customize RefreshToken

### DIFF
--- a/src/Bridge/RefreshTokenRepository.php
+++ b/src/Bridge/RefreshTokenRepository.php
@@ -4,6 +4,7 @@ namespace Laravel\Passport\Bridge;
 
 use Illuminate\Database\Connection;
 use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Passport\RefreshTokenRepository as PassportRefreshTokenRepository;
 use Laravel\Passport\Events\RefreshTokenCreated;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
@@ -11,11 +12,11 @@ use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 class RefreshTokenRepository implements RefreshTokenRepositoryInterface
 {
     /**
-     * The database connection.
+     * The refresh token repository instance.
      *
      * @var \Illuminate\Database\Connection
      */
-    protected $database;
+    protected $refreshTokenRepository;
 
     /**
      * The event dispatcher instance.
@@ -27,14 +28,14 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
     /**
      * Create a new repository instance.
      *
-     * @param  \Illuminate\Database\Connection  $database
+     * @param  \Laravel\Passport\RefreshTokenRepository  $refreshTokenRepository
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @return void
      */
-    public function __construct(Connection $database, Dispatcher $events)
+    public function __construct(PassportRefreshTokenRepository $refreshTokenRepository, Dispatcher $events)
     {
         $this->events = $events;
-        $this->database = $database;
+        $this->refreshTokenRepository = $refreshTokenRepository;
     }
 
     /**
@@ -50,7 +51,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
      */
     public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity)
     {
-        $this->database->table('oauth_refresh_tokens')->insert([
+        $this->refreshTokenRepository->create([
             'id' => $id = $refreshTokenEntity->getIdentifier(),
             'access_token_id' => $accessTokenId = $refreshTokenEntity->getAccessToken()->getIdentifier(),
             'revoked' => false,
@@ -65,8 +66,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
      */
     public function revokeRefreshToken($tokenId)
     {
-        $this->database->table('oauth_refresh_tokens')
-                    ->where('id', $tokenId)->update(['revoked' => true]);
+        $this->refreshTokenRepository->revokeRefreshToken($tokenId);
     }
 
     /**
@@ -74,9 +74,6 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
      */
     public function isRefreshTokenRevoked($tokenId)
     {
-        $refreshToken = $this->database->table('oauth_refresh_tokens')
-                    ->where('id', $tokenId)->first();
-
-        return $refreshToken === null || $refreshToken->revoked;
+        return $this->refreshTokenRepository->isRefreshTokenRevoked($tokenId);
     }
 }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -125,6 +125,13 @@ class Passport
     public static $tokenModel = 'Laravel\Passport\Token';
 
     /**
+     * The refresh token model class name.
+     *
+     * @var string
+     */
+    public static $refreshTokenModel = 'Laravel\Passport\RefreshToken';
+
+    /**
      * Indicates if Passport migrations will be run.
      *
      * @var bool
@@ -545,6 +552,38 @@ class Passport
     {
         return new static::$tokenModel;
     }
+
+    /**
+     * Set the refresh token model class name.
+     *
+     * @param  string  $refreshTokenModel
+     * @return void
+     */
+    public static function useRefreshTokenModel($refreshTokenModel)
+    {
+        static::$refreshTokenModel = $refreshTokenModel;
+    }
+
+    /**
+     * Get the refresh token model class name.
+     *
+     * @return string
+     */
+    public static function refreshTokenModel()
+    {
+        return static::$refreshTokenModel;
+    }
+
+    /**
+     * Get a new refresh token model instance.
+     *
+     * @return \Laravel\Passport\RefreshToken
+     */
+    public static function refreshToken()
+    {
+        return new static::$refreshTokenModel;
+    }
+
 
     /**
      * Configure Passport to not register its migrations.

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -584,7 +584,6 @@ class Passport
         return new static::$refreshTokenModel;
     }
 
-
     /**
      * Configure Passport to not register its migrations.
      *

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Passport;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RefreshToken extends Model
+{
+    /**
+     * The database table used by the model.
+     *
+     * @var string
+     */
+    protected $table = 'oauth_refresh_tokens';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The guarded attributes on the model.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'revoked' => 'bool',
+    ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'expires_at',
+    ];
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * Get the access token that the refresh token belongs to..
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function accessToken()
+    {
+        return $this->belongsTo(Passport::tokenModel());
+    }
+
+    /**
+     * Revoke the token instance.
+     *
+     * @return bool
+     */
+    public function revoke()
+    {
+        return $this->forceFill(['revoked' => true])->save();
+    }
+
+    /**
+     * Determine if the token is a transient JWT token.
+     *
+     * @return bool
+     */
+    public function transient()
+    {
+        return false;
+    }
+}

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -53,7 +53,7 @@ class RefreshToken extends Model
     public $timestamps = false;
 
     /**
-     * Get the access token that the refresh token belongs to..
+     * Get the access token that the refresh token belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */

--- a/src/RefreshTokenRepository.php
+++ b/src/RefreshTokenRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Laravel\Passport;
+
+class RefreshTokenRepository
+{
+    /**
+     * Creates a new refresh token.
+     *
+     * @param  array  $attributes
+     * @return \Laravel\Passport\RefreshToken
+     */
+    public function create($attributes)
+    {
+        return Passport::refreshToken()->create($attributes);
+    }
+
+    /**
+     * Gets a refresh token by the given ID.
+     *
+     * @param  string  $id
+     * @return \Laravel\Passport\RefreshToken
+     */
+    public function find($id)
+    {
+        return Passport::refreshToken()->where('id', $id)->first();
+    }
+
+    /**
+     * Stores the given token instance.
+     *
+     * @param  \Laravel\Passport\RefreshToken  $token
+     * @return void
+     */
+    public function save(RefreshToken $token)
+    {
+        $token->save();
+    }
+
+    /**
+     * Revokes the refresh token.
+     *
+     * @param  string  $id
+     * @return mixed
+     */
+    public function revokeRefreshToken($id)
+    {
+        return Passport::refreshToken()->where('id', $id)->update(['revoked' => true]);
+    }
+
+    /**
+     * Checks if the refresh token has been revoked.
+     *
+     * @param  string  $id
+     * @return bool
+     */
+    public function isRefreshTokenRevoked($id)
+    {
+        if ($token = $this->find($id)) {
+            return $token->revoked;
+        }
+
+        return true;
+    }
+}

--- a/tests/BridgeRefreshTokenRepositoryTest.php
+++ b/tests/BridgeRefreshTokenRepositoryTest.php
@@ -4,10 +4,8 @@ namespace Laravel\Passport\Tests;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Database\Connection;
-use Illuminate\Database\Query\Builder;
-use Illuminate\Contracts\Events\Dispatcher;
-use Laravel\Passport\Bridge\RefreshTokenRepository;
+use Laravel\Passport\RefreshTokenRepository;
+use Laravel\Passport\Bridge\RefreshTokenRepository as BridgeRefreshTokenRepository;
 
 class BridgeRefreshTokenRepositoryTest extends TestCase
 {
@@ -40,18 +38,16 @@ class BridgeRefreshTokenRepositoryTest extends TestCase
         $this->assertFalse($repository->isRefreshTokenRevoked('tokenId'));
     }
 
-    private function repository($refreshToken): RefreshTokenRepository
+    private function repository($refreshToken): BridgeRefreshTokenRepository
     {
-        $queryBuilder = m::mock(Builder::class);
-        $queryBuilder->shouldReceive('first')->andReturn($refreshToken);
-        $queryBuilder->shouldReceive('where')->andReturn($queryBuilder);
+        $refreshTokenRepository = m::mock(RefreshTokenRepository::class)->makePartial();
+        $refreshTokenRepository->shouldReceive('find')
+            ->with('tokenId')
+            ->andReturn($refreshToken);
 
-        $connection = m::mock(Connection::class);
-        $connection->shouldReceive('table')->andReturn($queryBuilder);
+        $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
 
-        $events = m::mock(Dispatcher::class);
-
-        return new RefreshTokenRepository($connection, $events);
+        return new BridgeRefreshTokenRepository($refreshTokenRepository, $events);
     }
 }
 

--- a/tests/PassportTest.php
+++ b/tests/PassportTest.php
@@ -7,6 +7,7 @@ use Laravel\Passport\Client;
 use Laravel\Passport\AuthCode;
 use Laravel\Passport\Passport;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\RefreshToken;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\PersonalAccessClient;
 
@@ -65,6 +66,24 @@ class PassportTest extends TestCase
         $this->assertInstanceOf(Token::class, $token);
         $this->assertInstanceOf(Passport::tokenModel(), $token);
     }
+
+    public function test_refresh_token_instance_can_be_created()
+    {
+        $refreshToken = Passport::refreshToken();
+
+        $this->assertInstanceOf(RefreshToken::class, $refreshToken);
+        $this->assertInstanceOf(Passport::refreshTokenModel(), $refreshToken);
+    }
+
+    public function test_refresh_token_model_can_be_changed()
+    {
+        Passport::useRefreshTokenModel(RefreshTokenStub::class);
+
+        $refreshToken = Passport::refreshToken();
+
+        $this->assertInstanceOf(RefreshTokenStub::class, $refreshToken);
+        $this->assertInstanceOf(Passport::refreshTokenModel(), $refreshToken);
+    }
 }
 
 class PersonalAccessClientStub
@@ -73,4 +92,9 @@ class PersonalAccessClientStub
     {
         return false;
     }
+}
+
+class RefreshTokenStub
+{
+
 }


### PR DESCRIPTION
This is a resend for https://github.com/laravel/passport/pull/946

@donovanhare was already so kind to add additional tests.

The main purpose of this PR is to provide a way to customize the refresh tokens table which is currently hardcoded. This PR converts the functionality in the same way as done for all the other tables and thus brings along more consistency across the codebase.

Fixes https://github.com/laravel/passport/issues/864