### PR TITLE
[7.0] Change wasRecentlyCreated to false in actingAs

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -389,6 +389,8 @@ class Passport
 
         $user->withAccessToken($token);
 
+        $user->wasRecentlyCreated = false;
+
         app('auth')->guard($guard)->setUser($user);
 
         app('auth')->shouldUse($guard);


### PR DESCRIPTION
The core framework fixed this same bug with the core actingAs method but it seems it was missed for Passport! Check this PR for more details:

https://github.com/laravel/framework/pull/25873