### PR TITLE
[7.0] Change wasRecentlyCreated to false

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -389,6 +389,10 @@ class Passport
 
         $user->withAccessToken($token);
 
+        if (isset($user->wasRecentlyCreated) && $user->wasRecentlyCreated) {
+            $user->wasRecentlyCreated = false;
+        }
+
         app('auth')->guard($guard)->setUser($user);
 
         app('auth')->shouldUse($guard);


### PR DESCRIPTION
Resubmitting with explanation as requested by @driesvints in #975 

The core framework fixed this same bug with the core actingAs method but
it seems it was missed for Passport! Check this PR for more details:
https://github.com/laravel/framework/pull/25873

I don't think we need the conditional, and certainly not the truthy check of it on the right side. Setting something to false that's already false won't have any negative effects. The `User` that's passed to the auth guard is expecting an `Authenticatable` which also extends `Model`, which should always have `wasRecentlyCreated`.

I look at this as "Hey look we need this to be false, why do we care if it's true first?"