### PR TITLE
[7.0] Clear the container between tests & bind necessary mocks

### DIFF
--- a/tests/AccessTokenControllerTest.php
+++ b/tests/AccessTokenControllerTest.php
@@ -21,6 +21,7 @@ class AccessTokenControllerTest extends TestCase
     public function tearDown()
     {
         m::close();
+        Container::getInstance()->flush();
     }
 
     public function test_a_token_can_be_issued()

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -14,6 +14,7 @@ use Illuminate\Container\Container;
 use Laravel\Passport\TokenRepository;
 use Laravel\Passport\ClientRepository;
 use Psr\Http\Message\ResponseInterface;
+use Illuminate\Contracts\Config\Repository;
 use Psr\Http\Message\ServerRequestInterface;
 use League\OAuth2\Server\AuthorizationServer;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -26,6 +27,7 @@ class AuthorizationControllerTest extends TestCase
     public function tearDown()
     {
         m::close();
+        Container::getInstance()->flush();
     }
 
     public function test_authorization_view_is_presented()
@@ -72,7 +74,9 @@ class AuthorizationControllerTest extends TestCase
     public function test_authorization_exceptions_are_handled()
     {
         Container::getInstance()->instance(ExceptionHandler::class, $exceptions = m::mock());
+        Container::getInstance()->instance(Repository::class, $config = m::mock());
         $exceptions->shouldReceive('report')->once();
+        $config->shouldReceive('get')->once()->andReturn(true);
 
         $server = m::mock(AuthorizationServer::class);
         $response = m::mock(ResponseFactory::class);

--- a/tests/HasApiTokensTest.php
+++ b/tests/HasApiTokensTest.php
@@ -13,6 +13,7 @@ class HasApiTokensTest extends TestCase
     public function tearDown()
     {
         m::close();
+        Container::getInstance()->flush();
     }
 
     public function test_token_can_indicates_if_token_has_given_scope()

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -24,6 +24,7 @@ class TokenGuardTest extends TestCase
     public function tearDown()
     {
         m::close();
+        Container::getInstance()->flush();
     }
 
     public function test_user_can_be_pulled_via_bearer_token()


### PR DESCRIPTION
These tests were only passing if you ran the entire test suite.  If you ran an individual test it would fail with this message:

```
./vendor/bin/phpunit ./tests/AuthorizationControllerTest.php
PHPUnit 7.5.9 by Sebastian Bergmann and contributors.

.E.                                                                 3 / 3 (100%)

Time: 118 ms, Memory: 10.00 MB

There was 1 error:

1) Laravel\Passport\Tests\AuthorizationControllerTest::test_authorization_exceptions_are_handled
Illuminate\Contracts\Container\BindingResolutionException: Target [Illuminate\Contracts\Config\Repository] is not instantiable.

/Users/matt/code/laravel/passport/vendor/illuminate/container/Container.php:962
/Users/matt/code/laravel/passport/vendor/illuminate/container/Container.php:800
/Users/matt/code/laravel/passport/vendor/illuminate/container/Container.php:671
/Users/matt/code/laravel/passport/vendor/illuminate/container/Container.php:619
/Users/matt/code/laravel/passport/src/Http/Controllers/HandlesOAuthErrors.php:53
/Users/matt/code/laravel/passport/src/Http/Controllers/HandlesOAuthErrors.php:38
/Users/matt/code/laravel/passport/src/Http/Controllers/AuthorizationController.php:82
/Users/matt/code/laravel/passport/tests/AuthorizationControllerTest.php:91

ERRORS!
Tests: 3, Assertions: 6, Errors: 1.
```

To prevent this we can flush the container after each test case and bind the necessary mocks in the container for the tests that require them.