### PR TITLE
[7.0] Created access token revoked events

### DIFF
--- a/src/Events/AccessTokenRevoked.php
+++ b/src/Events/AccessTokenRevoked.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Laravel\Passport\Events;
+
+class AccessTokenRevoked
+{
+    /**
+     * The revoked token ID.
+     *
+     * @var string
+     */
+    public $tokenId;
+
+    /**
+     * The ID of the user associated with the token.
+     *
+     * @var string
+     */
+    public $userId;
+
+    /**
+     * The ID of the client associated with the token.
+     *
+     * @var string
+     */
+    public $clientId;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $tokenId
+     * @param  string  $userId
+     * @param  string  $clientId
+     * @return void
+     */
+    public function __construct($tokenId, $userId, $clientId)
+    {
+        $this->userId = $userId;
+        $this->tokenId = $tokenId;
+        $this->clientId = $clientId;
+    }
+}

--- a/src/Http/Controllers/AuthorizedAccessTokenController.php
+++ b/src/Http/Controllers/AuthorizedAccessTokenController.php
@@ -4,12 +4,21 @@ namespace Laravel\Passport\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Events\Dispatcher;
+use Laravel\Passport\Events\AccessTokenRevoked;
 use Laravel\Passport\TokenRepository;
 
 class AuthorizedAccessTokenController
 {
     /**
      * The token repository implementation.
+     *
+     * @var use Illuminate\Events\Dispatcher;
+     */
+    protected $events;
+
+    /**
+     * The events dispatcher
      *
      * @var \Laravel\Passport\TokenRepository
      */
@@ -21,9 +30,10 @@ class AuthorizedAccessTokenController
      * @param  \Laravel\Passport\TokenRepository  $tokenRepository
      * @return void
      */
-    public function __construct(TokenRepository $tokenRepository)
+    public function __construct(TokenRepository $tokenRepository, Dispatcher $events)
     {
         $this->tokenRepository = $tokenRepository;
+        $this->events = $events;
     }
 
     /**
@@ -59,6 +69,13 @@ class AuthorizedAccessTokenController
         }
 
         $token->revoke();
+
+        $this->events->dispatch(new AccessTokenRevoked(
+            $token->id,
+            $token->user_id,
+            $token->client_id
+        )
+    );
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }

--- a/src/Http/Controllers/AuthorizedAccessTokenController.php
+++ b/src/Http/Controllers/AuthorizedAccessTokenController.php
@@ -4,8 +4,8 @@ namespace Laravel\Passport\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Events\Dispatcher;
 use Laravel\Passport\TokenRepository;
+use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Passport\Events\AccessTokenRevoked;
 
 class AuthorizedAccessTokenController
@@ -13,7 +13,7 @@ class AuthorizedAccessTokenController
     /**
      * The token repository implementation.
      *
-     * @var use Illuminate\Events\Dispatcher;
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
     protected $events;
 
@@ -71,11 +71,11 @@ class AuthorizedAccessTokenController
         $token->revoke();
 
         $this->events->dispatch(new AccessTokenRevoked(
-            $token->id,
-            $token->user_id,
-            $token->client_id
-        )
-    );
+                $token->id,
+                $token->user_id,
+                $token->client_id
+            )
+        );
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }

--- a/src/Http/Controllers/AuthorizedAccessTokenController.php
+++ b/src/Http/Controllers/AuthorizedAccessTokenController.php
@@ -5,8 +5,8 @@ namespace Laravel\Passport\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Events\Dispatcher;
-use Laravel\Passport\Events\AccessTokenRevoked;
 use Laravel\Passport\TokenRepository;
+use Laravel\Passport\Events\AccessTokenRevoked;
 
 class AuthorizedAccessTokenController
 {
@@ -18,7 +18,7 @@ class AuthorizedAccessTokenController
     protected $events;
 
     /**
-     * The events dispatcher
+     * The events dispatcher.
      *
      * @var \Laravel\Passport\TokenRepository
      */

--- a/tests/AuthorizedAccessTokenControllerTest.php
+++ b/tests/AuthorizedAccessTokenControllerTest.php
@@ -7,6 +7,7 @@ use Laravel\Passport\Token;
 use Illuminate\Http\Request;
 use Laravel\Passport\Client;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Events\Dispatcher;
 use Laravel\Passport\TokenRepository;
 use Symfony\Component\HttpFoundation\Response;
 use Laravel\Passport\Http\Controllers\AuthorizedAccessTokenController;
@@ -19,6 +20,11 @@ class AuthorizedAccessTokenControllerTest extends TestCase
     protected $tokenRepository;
 
     /**
+     * @var \Mockery\Mock|Illuminate\Events\Dispatcher
+     */
+    protected $events;
+
+    /**
      * @var AuthorizedAccessTokenController
      */
     protected $controller;
@@ -26,7 +32,11 @@ class AuthorizedAccessTokenControllerTest extends TestCase
     public function setUp()
     {
         $this->tokenRepository = m::mock(TokenRepository::class);
-        $this->controller = new AuthorizedAccessTokenController($this->tokenRepository);
+        $this->events = m::mock(Dispatcher::class);
+        $this->controller = new AuthorizedAccessTokenController(
+            $this->tokenRepository,
+            $this->events
+        );
     }
 
     public function tearDown()
@@ -72,6 +82,8 @@ class AuthorizedAccessTokenControllerTest extends TestCase
     public function test_tokens_can_be_deleted()
     {
         $request = Request::create('/', 'GET');
+
+        $this->events->shouldReceive('dispatch')->once();
 
         $token1 = m::mock(Token::class.'[revoke]');
         $token1->id = 1;


### PR DESCRIPTION
When the access token is revoked on AuthorizedAccessTokenController an event is dispatched to every listener of this event. 

* Correcting the PR #977 