### PR TITLE
[7.0] Allow first party clients to skip the authorization prompt

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -82,4 +82,14 @@ class Client extends Model
     {
         return $this->personal_access_client || $this->password_client;
     }
+
+    /**
+     * Determine if the client should skip the authorization prompt.
+     *
+     * @return bool
+     */
+    public function skipsAuthorization()
+    {
+        return false;
+    }
 }

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -67,7 +67,8 @@ class AuthorizationController
                 $client = $clients->find($authRequest->getClient()->getIdentifier())
             );
 
-            if ($token && $token->scopes === collect($scopes)->pluck('id')->all()) {
+            if (($token && $token->scopes === collect($scopes)->pluck('id')->all()) ||
+                $client->skipsAuthorization()) {
                 return $this->approveRequest($authRequest, $user);
             }
 

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -3,10 +3,10 @@
 namespace Laravel\Passport\Tests;
 
 use Exception;
-use Laravel\Passport\Client;
 use Mockery as m;
 use Laravel\Passport\Token;
 use Illuminate\Http\Request;
+use Laravel\Passport\Client;
 use Zend\Diactoros\Response;
 use Laravel\Passport\Passport;
 use PHPUnit\Framework\TestCase;
@@ -54,6 +54,8 @@ class AuthorizationControllerTest extends TestCase
 
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
+
+        $client->shouldReceive('skipsAuthorization')->andReturn(false);
 
         $response->shouldReceive('view')->once()->andReturnUsing(function ($view, $data) use ($authRequest, $client, $user) {
             $this->assertEquals('passport::authorize', $view);
@@ -133,6 +135,49 @@ class AuthorizationControllerTest extends TestCase
             ->with($user, 'client')
             ->andReturn($token = m::mock(Token::class));
         $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['scope-1']);
+
+        $this->assertEquals('approved', $controller->authorize(
+            m::mock(ServerRequestInterface::class), $request, $clients, $tokens
+        )->getContent());
+    }
+
+    public function test_request_is_approved_if_client_can_skip_authorization()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+        ]);
+
+        $server = m::mock(AuthorizationServer::class);
+        $response = m::mock(ResponseFactory::class);
+
+        $controller = new AuthorizationController($server, $response);
+        $psrResponse = new Response();
+        $psrResponse->getBody()->write('approved');
+        $server->shouldReceive('validateAuthorizationRequest')
+            ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
+        $server->shouldReceive('completeAuthorizationRequest')
+            ->with($authRequest, m::type(ResponseInterface::class))
+            ->andReturn($psrResponse);
+
+        $request = m::mock(Request::class);
+        $request->shouldReceive('user')->once()->andReturn($user = m::mock());
+        $user->shouldReceive('getKey')->andReturn(1);
+        $request->shouldNotReceive('session');
+
+        $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
+        $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
+        $authRequest->shouldReceive('setUser')->once()->andReturnNull();
+        $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
+
+        $clients = m::mock(ClientRepository::class);
+        $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
+
+        $client->shouldReceive('skipsAuthorization')->andReturn(true);
+
+        $tokens = m::mock(TokenRepository::class);
+        $tokens->shouldReceive('findValidToken')
+            ->with($user, $client)
+            ->andReturnNull();
 
         $this->assertEquals('approved', $controller->authorize(
             m::mock(ServerRequestInterface::class), $request, $clients, $tokens


### PR DESCRIPTION
## Overview

This PR adds a new method `Client::skipsAuthorization()`. If the method returns true the client is allowed to skip the authorization prompt.

## Rationale

It's considered best practice to use the Authorization code grant for first party mobile apps and SPAs but Passport currently requires you to show an authorization prompt to the user ("{client} is requesting permission...") with this grant type.

It doesn't really make sense to show the authorization prompt for first party clients.  If Google asked you to grant permission to Google every time you logged in to gmail it would be pretty confusing.

Allowing first party clients to skip the authorization prompt is supported by the majority of OAuth servers: Auth0, Otka, Doorkeeper, Django OAuth Toolkit, IdentityServer, Keycloak, Ory Hydra, and others.  It's also explicitly allowed by the OAuth specification.

It's difficult to add this feature yourself.  You have to override the Authorization controller which requires copying ~30 lines of code.  You then need to register the route override in the `AuthServiceProvider` after the `Passport::routes()` call and make sure to add the same middleware.

There is some more background info in #1010.

## Usage

To use this feature you need to extend the `Client` and override the `skipsAuthorization` method. You also need to tell Passport to use your extended model in the `AuthServiceProvider`.

How you implement `skipsAuthorization` is up to you. For example, you may add a `first_party` boolean column to the database and check the value.  Alternatively you might want to check the redirect URL and allow any client for a given domain.

```php
use App\Models\Passport\Client;
use App\Models\Passport\Token;
use App\Models\Passport\AuthCode;
use App\Models\Passport\PersonalAccessClient;

/**
 * Register any authentication / authorization services.
 *
 * @return void
 */
public function boot()
{
    $this->registerPolicies();

    Passport::routes();

    Passport::useClientModel(Client::class);
}
```

```php
namespace App\Passport;

use Laravel\Passport\Client as BaseClient;

class Client extends BaseClient
{
    /**
     * Determine if the client should skip the authorization prompt.
     *
     * @return bool
     */
    public function skipsAuthorization()
    {
        return $this->first_party;
    }
}
```

## Backwards Compatibility

This feature is opt-in and does not do anything unless you override the `skipsAuthorization` method to return true.