### PR TITLE
Added the ability for finer route definition

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -51,6 +51,10 @@ class RouteRegistrar
                         $options['middleware'] = explode('|', $options['middleware']);
                     }
 
+                    if (!is_array($subOptions['middleware'])) {
+                        $subOptions['middleware'] = explode('|', $subOptions['middleware']);
+                    }
+
                     $options['middleware'] = array_merge($options['middleware'], $subOptions['middleware']);
 
                     unset($subOptions['middleware']);

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -25,6 +25,45 @@ class RouteRegistrar
     }
 
     /**
+     * Retrieve the router.
+     * 
+     * @return \Illuminate\Contracts\Routing\Registrar
+     */
+    public function router()
+    {
+      return $this->router;
+    }
+
+    /**
+     * Merge the options specified for a route.
+     * 
+     * @return Array
+     */
+    protected function mergeRouteOptions($options = [], $merge = [])
+    {
+        foreach ($merge as $as => $subOptions) {
+            if ($as == $options['as'] && is_array($subOptions)) {
+                unset($subOptions['uses']);
+                unset($subOptions['as']);
+
+                if (array_key_exists('middleware', $options)) {
+                    if (!is_array($options['middleware'])) {
+                        $options['middleware'] = explode('|', $options['middleware']);
+                    }
+
+                    $options['middleware'] = array_merge($options['middleware'], $subOptions['middleware']);
+
+                    unset($subOptions['middleware']);
+                }
+
+                $options = array_merge($options, $subOptions);
+            }
+        }
+
+        return $options;
+    }
+
+    /**
      * Register routes for transient tokens, clients, and personal access tokens.
      *
      * @return void
@@ -41,125 +80,147 @@ class RouteRegistrar
     /**
      * Register the routes needed for authorization.
      *
+     * @param  \Illuminate\Contracts\Routing\Registrar  $router
+     * @param  Array  $options
      * @return void
      */
-    public function forAuthorization()
+    public function forAuthorization($router = null, $options = [])
     {
-        $this->router->group(['middleware' => ['web', 'auth']], function ($router) {
-            $router->get('/authorize', [
+        $router = $router ?: $this->router;
+
+        $router->group(['middleware' => ['web', 'auth']], function ($r) {
+            $r->get('/authorize', $this->mergeRouteOptions([
                 'uses' => 'AuthorizationController@authorize',
                 'as' => 'passport.authorizations.authorize',
-            ]);
+            ], $options));
 
-            $router->post('/authorize', [
+            $r->post('/authorize', $this->mergeRouteOptions([
                 'uses' => 'ApproveAuthorizationController@approve',
                 'as' => 'passport.authorizations.approve',
-            ]);
+            ], $options));
 
-            $router->delete('/authorize', [
+            $r->delete('/authorize', $this->mergeRouteOptions([
                 'uses' => 'DenyAuthorizationController@deny',
                 'as' => 'passport.authorizations.deny',
-            ]);
+            ], $options));
         });
     }
 
     /**
      * Register the routes for retrieving and issuing access tokens.
      *
+     * @param  \Illuminate\Contracts\Routing\Registrar  $router
+     * @param  Array  $options
      * @return void
      */
-    public function forAccessTokens()
+    public function forAccessTokens($router = null, $options = [])
     {
-        $this->router->post('/token', [
+        $router = $router ?: $this->router;
+
+        $router->post('/token', $this->mergeRouteOptions([
             'uses' => 'AccessTokenController@issueToken',
             'as' => 'passport.token',
-            'middleware' => 'throttle',
-        ]);
+            'middleware' => [
+              'throttle'
+            ],
+        ], $options));
 
-        $this->router->group(['middleware' => ['web', 'auth']], function ($router) {
-            $router->get('/tokens', [
+        $router->group(['middleware' => ['web', 'auth']], function ($r) {
+            $r->get('/tokens', $this->mergeRouteOptions([
                 'uses' => 'AuthorizedAccessTokenController@forUser',
                 'as' => 'passport.tokens.index',
-            ]);
+            ], $options));
 
-            $router->delete('/tokens/{token_id}', [
+            $r->delete('/tokens/{token_id}', $this->mergeRouteOptions([
                 'uses' => 'AuthorizedAccessTokenController@destroy',
                 'as' => 'passport.tokens.destroy',
-            ]);
+            ], $options));
         });
     }
 
     /**
      * Register the routes needed for refreshing transient tokens.
      *
+     * @param  \Illuminate\Contracts\Routing\Registrar  $router
+     * @param  Array  $options
      * @return void
      */
-    public function forTransientTokens()
+    public function forTransientTokens($router = null, $options = [])
     {
-        $this->router->post('/token/refresh', [
+        $router = $router ?: $this->router;
+
+        $router->post('/token/refresh', $this->mergeRouteOptions([
             'middleware' => ['web', 'auth'],
             'uses' => 'TransientTokenController@refresh',
             'as' => 'passport.token.refresh',
-        ]);
+        ], $options));
     }
 
     /**
      * Register the routes needed for managing clients.
      *
+     * @param  \Illuminate\Contracts\Routing\Registrar  $router
+     * @param  Array  $options
      * @return void
      */
-    public function forClients()
+    public function forClients($router = null, $options = [])
     {
-        $this->router->group(['middleware' => ['web', 'auth']], function ($router) {
-            $router->get('/clients', [
+        $router = $router ?: $this->router;
+
+        $router->group(['middleware' => ['web', 'auth']], function ($r) {
+            $r->get('/clients', $this->mergeRouteOptions([
                 'uses' => 'ClientController@forUser',
                 'as' => 'passport.clients.index',
-            ]);
+            ], $options));
 
-            $router->post('/clients', [
+            $r->post('/clients', $this->mergeRouteOptions([
                 'uses' => 'ClientController@store',
                 'as' => 'passport.clients.store',
-            ]);
+            ], $options));
 
-            $router->put('/clients/{client_id}', [
+            $r->put('/clients/{client_id}', $this->mergeRouteOptions([
                 'uses' => 'ClientController@update',
                 'as' => 'passport.clients.update',
-            ]);
+            ], $options));
 
-            $router->delete('/clients/{client_id}', [
+            $r->delete('/clients/{client_id}', $this->mergeRouteOptions([
                 'uses' => 'ClientController@destroy',
                 'as' => 'passport.clients.destroy',
-            ]);
+            ], $options));
         });
     }
 
     /**
      * Register the routes needed for managing personal access tokens.
      *
+     * @param  \Illuminate\Contracts\Routing\Registrar  $router
+     * @param  Array  $options
      * @return void
      */
-    public function forPersonalAccessTokens()
+    public function forPersonalAccessTokens($router = null, $options = [])
     {
-        $this->router->group(['middleware' => ['web', 'auth']], function ($router) {
-            $router->get('/scopes', [
+        $router = $router ?: $this->router;
+
+        $router->group(['middleware' => ['web', 'auth']], function ($r) {
+            $r->get('/scopes', $this->mergeRouteOptions([
                 'uses' => 'ScopeController@all',
                 'as' => 'passport.scopes.index',
-            ]);
+            ], $options));
 
-            $router->get('/personal-access-tokens', [
+            $r->get('/personal-access-tokens', $this->mergeRouteOptions([
                 'uses' => 'PersonalAccessTokenController@forUser',
                 'as' => 'passport.personal.tokens.index',
-            ]);
+            ], $options));
 
-            $router->post('/personal-access-tokens', [
+            $r->post('/personal-access-tokens', $this->mergeRouteOptions([
                 'uses' => 'PersonalAccessTokenController@store',
                 'as' => 'passport.personal.tokens.store',
-            ]);
+            ], $options));
 
-            $router->delete('/personal-access-tokens/{token_id}', [
+            $r->delete('/personal-access-tokens/{token_id}', $this->mergeRouteOptions([
                 'uses' => 'PersonalAccessTokenController@destroy',
                 'as' => 'passport.personal.tokens.destroy',
-            ]);
+            ], $options));
         });
     }
 }


### PR DESCRIPTION
Now it is possible to pass a `\Illuminate\Contracts\Routing\Registrar` instance through to each method which allows you to group middleware as you see fit. Below is an example of how passing the registrar is useful.

```php
Passport::routes(function ($registrar) {
    $registrar->router()->group(['middleware' => 'role:developer'], function ($router) use ($registrar) {
        $registrar->forClients($router); // pass the sub-router
    });
});
```

You can additionally pass through options which can include middleware to each route which is done as shown below:

```php
Passport::routes(function ($registrar) {
    $registrar->forClients(null, [
        'passport.clients.store' => [
            'middleware' => 'role:developer'
        ]
    ]);
// or
    $registrar->router()->group(['middleware' => 'role:developer'], function ($router) use ($registrar) {
        $registrar->forClients($router, [
            'passport.clients.store' => [
                'middleware' => 'role:even-bigger-developer'
            ]
        ]);
    });
});
```

This added functionality doesn't break any of the current functionality as the new functionality assumes the old methods if the specified parameters are not passed.
