### PR TITLE
[7.0] Change server Property type in CheckClientCredentialForAnyScope

### DIFF
--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -16,7 +16,7 @@ class CheckClientCredentialsForAnyScope
      *
      * @var \League\OAuth2\Server\ResourceServer
      */
-    private $server;
+    protected $server;
 
     /**
      * Create a new middleware instance.


### PR DESCRIPTION
I change declaration $server property in CheckClientCredentialForAnyScope from __private__ to __protected__, this is useful if anyone wants to extends this middleware.