### PR TITLE
[7.0] Fix exception will thrown if token belongs to first party clients

### DIFF
--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
+use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\ResourceServer;
 use Illuminate\Auth\AuthenticationException;
 use Laravel\Passport\Exceptions\MissingScopeException;
@@ -19,14 +20,23 @@ class CheckClientCredentials
     protected $server;
 
     /**
+     * Token Repository.
+     *
+     * @var \Laravel\Passport\TokenRepository
+     */
+    protected $repository;
+
+    /**
      * Create a new middleware instance.
      *
      * @param  \League\OAuth2\Server\ResourceServer  $server
+     * @param  \Laravel\Passport\TokenRepository  $repository
      * @return void
      */
-    public function __construct(ResourceServer $server)
+    public function __construct(ResourceServer $server, TokenRepository $repository)
     {
         $this->server = $server;
+        $this->repository = $repository;
     }
 
     /**
@@ -48,9 +58,27 @@ class CheckClientCredentials
             throw new AuthenticationException;
         }
 
+        $this->validateToken($psr);
         $this->validateScopes($psr, $scopes);
 
         return $next($request);
+    }
+
+    /**
+     * Validate the token on the incoming request.
+     * Check token doesn't belongs to first party clients.
+     *
+     * @param  \Psr\Http\Message\ServerRequestInterface $psr
+     * @return void
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    protected function validateToken($psr)
+    {
+        $token = $this->repository->find($psr->getAttribute('oauth_access_token_id'));
+
+        if (! $token || $token->client->firstParty()) {
+            throw new AuthenticationException;
+        }
     }
 
     /**

--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -19,7 +19,6 @@ class CheckClientCredentialsForAnyScope
      */
     protected $server;
 
-
     /**
      * Token Repository.
      *

--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
+use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\ResourceServer;
 use Illuminate\Auth\AuthenticationException;
 use Laravel\Passport\Exceptions\MissingScopeException;
@@ -18,15 +19,25 @@ class CheckClientCredentialsForAnyScope
      */
     protected $server;
 
+
+    /**
+     * Token Repository.
+     *
+     * @var \Laravel\Passport\TokenRepository
+     */
+    protected $repository;
+
     /**
      * Create a new middleware instance.
      *
      * @param  \League\OAuth2\Server\ResourceServer  $server
+     * @param  \Laravel\Passport\TokenRepository  $repository
      * @return void
      */
-    public function __construct(ResourceServer $server)
+    public function __construct(ResourceServer $server, TokenRepository $repository)
     {
         $this->server = $server;
+        $this->repository = $repository;
     }
 
     /**
@@ -48,11 +59,30 @@ class CheckClientCredentialsForAnyScope
             throw new AuthenticationException;
         }
 
+        $this->validateToken($psr);
+
         if ($this->validateScopes($psr, $scopes)) {
             return $next($request);
         }
 
         throw new MissingScopeException($scopes);
+    }
+
+    /**
+     * Validate the token on the incoming request.
+     * Check token doesn't belongs to first party clients.
+     *
+     * @param  \Psr\Http\Message\ServerRequestInterface $psr
+     * @return void
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    protected function validateToken($psr)
+    {
+        $token = $this->repository->find($psr->getAttribute('oauth_access_token_id'));
+
+        if (! $token || $token->client->firstParty()) {
+            throw new AuthenticationException;
+        }
     }
 
     /**

--- a/tests/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/CheckClientCredentialsForAnyScopeTest.php
@@ -9,7 +9,6 @@ use Laravel\Passport\Client;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\ResourceServer;
-use Illuminate\Auth\AuthenticationException;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
 

--- a/tests/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/CheckClientCredentialsForAnyScopeTest.php
@@ -3,9 +3,13 @@
 namespace Laravel\Passport\Tests;
 
 use Mockery as m;
+use Laravel\Passport\Token;
 use Illuminate\Http\Request;
+use Laravel\Passport\Client;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\ResourceServer;
+use Illuminate\Auth\AuthenticationException;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
 
@@ -25,7 +29,12 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
 
-        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token = m::mock(Token::class));
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client = m::mock(Client::class));
+        $client->shouldReceive('firstParty')->andReturn(false);
+
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -46,7 +55,12 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'bar', 'baz']);
 
-        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token = m::mock(Token::class));
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client = m::mock(Client::class));
+        $client->shouldReceive('firstParty')->andReturn(false);
+
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -63,12 +77,13 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
      */
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
+        $tokenRepository = m::mock(TokenRepository::class);
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
             new OAuthServerException('message', 500, 'error type')
         );
 
-        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -90,7 +105,39 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'bar']);
 
-        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token = m::mock(Token::class));
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client = m::mock(Client::class));
+        $client->shouldReceive('firstParty')->andReturn(false);
+
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $response = $middleware->handle($request, function () {
+            return 'response';
+        }, 'baz', 'notbar');
+    }
+
+    /**
+     * @expectedException \Illuminate\Auth\AuthenticationException
+     */
+    public function test_exception_is_thrown_if_token_belongs_to_first_party_client()
+    {
+        $resourceServer = m::mock(ResourceServer::class);
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
+        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
+        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'bar']);
+
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token = m::mock(Token::class));
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client = m::mock(Client::class));
+        $client->shouldReceive('firstParty')->andReturn(true);
+
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -9,7 +9,6 @@ use Laravel\Passport\Client;
 use PHPUnit\Framework\TestCase;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\ResourceServer;
-use Illuminate\Auth\AuthenticationException;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
 

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -3,9 +3,13 @@
 namespace Laravel\Passport\Tests;
 
 use Mockery as m;
+use Laravel\Passport\Token;
 use Illuminate\Http\Request;
+use Laravel\Passport\Client;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\ResourceServer;
+use Illuminate\Auth\AuthenticationException;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
 
@@ -25,7 +29,12 @@ class CheckClientCredentialsTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
 
-        $middleware = new CheckClientCredentials($resourceServer);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token = m::mock(Token::class));
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client = m::mock(Client::class));
+        $client->shouldReceive('firstParty')->andReturn(false);
+
+        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -46,7 +55,12 @@ class CheckClientCredentialsTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['see-profile']);
 
-        $middleware = new CheckClientCredentials($resourceServer);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token = m::mock(Token::class));
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client = m::mock(Client::class));
+        $client->shouldReceive('firstParty')->andReturn(false);
+
+        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -63,12 +77,13 @@ class CheckClientCredentialsTest extends TestCase
      */
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
+        $tokenRepository = m::mock(TokenRepository::class);
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
             new OAuthServerException('message', 500, 'error type')
         );
 
-        $middleware = new CheckClientCredentials($resourceServer);
+        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -90,7 +105,39 @@ class CheckClientCredentialsTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'notbar']);
 
-        $middleware = new CheckClientCredentials($resourceServer);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token = m::mock(Token::class));
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client = m::mock(Client::class));
+        $client->shouldReceive('firstParty')->andReturn(false);
+
+        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $response = $middleware->handle($request, function () {
+            return 'response';
+        }, 'foo', 'bar');
+    }
+
+    /**
+     * @expectedException \Illuminate\Auth\AuthenticationException
+     */
+    public function test_exception_is_thrown_if_token_belongs_to_first_party_client()
+    {
+        $resourceServer = m::mock(ResourceServer::class);
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
+        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
+        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'notbar']);
+
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token = m::mock(Token::class));
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client = m::mock(Client::class));
+        $client->shouldReceive('firstParty')->andReturn(true);
+
+        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');


### PR DESCRIPTION
I made a pull request for issue [#691](https://github.com/laravel/passport/issues/691).

So when someone passes a token in their request which belongs to first party clients (such as `Password Credentials`), our middlewares will throw an `Illuminate\Auth\AuthenticationException` Exception.

So only those who have issued access token with `Client Credentials` grant type can go through `CheckClientCredential` & `CheckClientCredentialForAnyScope` Middlewares.