### PR TITLE
[7.0] Merge default Passport configuration

### DIFF
--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -78,6 +78,8 @@ class PassportServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/passport.php', 'passport');
+
         $this->registerAuthorizationServer();
 
         $this->registerResourceServer();


### PR DESCRIPTION
The PassportServiceProvider is lacking a `mergeConfigFrom` call, which breaks the key check in `makeCryptKey` unless one first copies the default `config/passport.php` into their app's config directory.  Copying the config should only be required when one wants to override the default values.  I ran into this issue when trying to set my keys [using environment variables](https://laravel.com/docs/5.8/passport#deploying-passport) in a new project.