### PR TITLE
[8.0] Fix auth codes table customization

### DIFF
--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -3,7 +3,6 @@
 namespace Laravel\Passport\Bridge;
 
 use Laravel\Passport\Passport;
-use Illuminate\Database\Connection;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 

--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -12,24 +12,6 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
     use FormatsScopesForStorage;
 
     /**
-     * The database connection.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    protected $database;
-
-    /**
-     * Create a new repository instance.
-     *
-     * @param  \Illuminate\Database\Connection  $database
-     * @return void
-     */
-    public function __construct(Connection $database)
-    {
-        $this->database = $database;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getNewAuthCode()
@@ -59,8 +41,7 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function revokeAuthCode($codeId)
     {
-        $this->database->table(Passport::authCode()->getTable())
-                    ->where('id', $codeId)->update(['revoked' => true]);
+        Passport::authCode()->where('id', $codeId)->update(['revoked' => true]);
     }
 
     /**
@@ -68,7 +49,6 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function isAuthCodeRevoked($codeId)
     {
-        return $this->database->table(Passport::authCode()->getTable())
-                    ->where('id', $codeId)->where('revoked', 1)->exists();
+        return Passport::authCode()->where('id', $codeId)->where('revoked', 1)->exists();
     }
 }


### PR DESCRIPTION
Current implementation does not respect `$connection` property in custom AuthCode model and always use Laravel's default connection.