### PR TITLE
[7.0] Make passport:keys only generate keys when needed.

### DIFF
--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -33,8 +33,6 @@ class KeysCommand extends Command
      */
     public function handle(RSA $rsa)
     {
-        $keys = $rsa->createKey($this->input ? (int) $this->option('length') : 4096);
-
         [$publicKey, $privateKey] = [
             Passport::keyPath('oauth-public.key'),
             Passport::keyPath('oauth-private.key'),
@@ -43,6 +41,8 @@ class KeysCommand extends Command
         if ((file_exists($publicKey) || file_exists($privateKey)) && ! $this->option('force')) {
             $this->error('Encryption keys already exist. Use the --force option to overwrite them.');
         } else {
+            $keys = $rsa->createKey($this->input ? (int) $this->option('length') : 4096);
+
             file_put_contents($publicKey, Arr::get($keys, 'publickey'));
             file_put_contents($privateKey, Arr::get($keys, 'privatekey'));
 


### PR DESCRIPTION
Benefit: This can significantly speed up tests that call `artisan passport:install` by avoiding work whose results will be discarded anyway (see https://stackoverflow.com/a/50243105/153354 for an example where this is recommended).

No changes in observable behavior, we only avoid unnecessary work.

I guess this should also be forward-ported to 8.0 once merged, or will 7.0 automatically be merged into 8.0?