### PR TITLE
[5.8] Support public clients

### DIFF
--- a/database/migrations/2019_07_17_000001_make_client_secret_nullable.php
+++ b/database/migrations/2019_07_17_000001_make_client_secret_nullable.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeClientSecretNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->string('secret', 100)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->string('secret', 100)->change();
+        });
+    }
+}

--- a/resources/js/components/Clients.vue
+++ b/resources/js/components/Clients.vue
@@ -125,6 +125,22 @@
                                     </span>
                                 </div>
                             </div>
+
+                            <!-- Confidential -->
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label">Confidential</label>
+
+                                <div class="col-md-9">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" v-model="createForm.confidential">
+                                        </label>
+                                    </div>
+                                    <span class="form-text text-muted">
+                                        Require the client to authenticate with a secret.
+                                    </span>
+                                </div>
+                            </div>
                         </form>
                     </div>
 
@@ -222,7 +238,8 @@
                 createForm: {
                     errors: [],
                     name: '',
-                    redirect: ''
+                    redirect: '',
+                    confidential: true
                 },
 
                 editForm: {

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -37,7 +37,7 @@ class ClientRepository implements ClientRepositoryInterface
         }
 
         return new Client(
-            $clientIdentifier, $record->name, $record->redirect, ! is_null($record->secret)
+            $clientIdentifier, $record->name, $record->redirect, $record->confidential()
         );
     }
 
@@ -52,7 +52,7 @@ class ClientRepository implements ClientRepositoryInterface
             return false;
         }
 
-        return hash_equals($record->secret, (string) $clientSecret);
+        return $record->confidential() && hash_equals($record->secret, (string) $clientSecret);
     }
 
     /**
@@ -75,8 +75,6 @@ class ClientRepository implements ClientRepositoryInterface
                 return $record->personal_access_client;
             case 'password':
                 return $record->password_client;
-            case 'client_credentials':
-                return ! empty($record->secret);
             default:
                 return true;
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -82,4 +82,14 @@ class Client extends Model
     {
         return $this->personal_access_client || $this->password_client;
     }
+
+    /**
+     * Determine if the client is a confidential client.
+     *
+     * @return bool
+     */
+    public function confidential()
+    {
+        return ! empty($this->secret);
+    }
 }

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -106,14 +106,19 @@ class ClientRepository
      * @param  string  $redirect
      * @param  bool  $personalAccess
      * @param  bool  $password
+     * @param  bool  $confidential
      * @return \Laravel\Passport\Client
      */
-    public function create($userId, $name, $redirect, $personalAccess = false, $password = false)
+    public function create($userId, $name, $redirect, $personalAccess = false, $password = false, $confidential = true)
     {
+        if ($personalAccess) {
+            $confidential = true;
+        }
+
         $client = Passport::client()->forceFill([
             'user_id' => $userId,
             'name' => $name,
-            'secret' => Str::random(40),
+            'secret' => $confidential ? Str::random(40) : null,
             'redirect' => $redirect,
             'personal_access_client' => $personalAccess,
             'password_client' => $password,

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -73,10 +73,12 @@ class ClientController
         $this->validation->make($request->all(), [
             'name' => 'required|max:255',
             'redirect' => ['required', $this->redirectRule],
+            'confidential' => 'boolean',
         ])->validate();
 
         return $this->clients->create(
-            $request->user()->getKey(), $request->name, $request->redirect
+            $request->user()->getKey(), $request->name, $request->redirect,
+            false, false, (bool) $request->input('confidential', true)
         )->makeVisible('secret');
     }
 

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -153,4 +153,9 @@ class BridgeClientRepositoryTestClientStub
     {
         return $this->personal_access_client || $this->password_client;
     }
+
+    public function confidential()
+    {
+        return ! empty($this->secret);
+    }
 }


### PR DESCRIPTION
This pull request adds support for public clients.

The league/oauth2-server now supports using both public and confidential clients with the authorization code grant. The recommended flow for single page applications and native apps is the auth code grant with a public client and PKCE. Supporting public clients makes it possible for developers to use the authorization code grant with PKCE instead of the insecure implicit grant.

Previously all clients were required to have a secret. If you used the implicit grant the secret just wasn't checked. We can't just skip checking the secret for the auth code grant like we were doing with the implicit grant because we need to check the secret if it was issued.

Instead we need to offer the ability to create public clients, and only check the credentials if the client is confidential.

The UI looks like this:

![Screenshot from 2019-07-17 16-28-13](https://user-images.githubusercontent.com/9440455/61662115-b2222000-ac9b-11e9-925a-aa46805c0a83.png)

The `oauth_clients.secret` column was updated to be nullable and the `POST /clients` endpoint was updated to allow passing a `confidential` param (defaults to true).

A public client can only be used with the implicit grant and the authorization code grant. The client credentials and personal access grants are only usable with a confidential client.

The password grant is supposed to be usable by public clients and this used to be possible but it's currently not working in league/oauth2-server, see https://github.com/thephpleague/oauth2-server/issues/889#issuecomment-512554693.g

If you attempt to use the auth code grant with a client was assigned a secret and don't provide the secret it will fail, because the League server [calls `ClientRepository::validateClient` if `Client::isConfidential` returns `true`](https://github.com/thephpleague/oauth2-server/blob/e1dc4d708c56fcfa205be4bb1862b6d525b4baac/src/Grant/AuthCodeGrant.php#L103).