### PR TITLE
Update RefreshTokenRepository.php

### DIFF
--- a/src/Bridge/RefreshTokenRepository.php
+++ b/src/Bridge/RefreshTokenRepository.php
@@ -74,9 +74,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
      */
     public function isRefreshTokenRevoked($tokenId)
     {
-        $refreshToken = $this->database->table('oauth_refresh_tokens')
-                    ->where('id', $tokenId)->first();
-
-        return $refreshToken === null || $refreshToken->revoked;
+        return $this->database->table('oauth_refresh_tokens')
+                    ->where('id', $tokenId)->where('revoked', true)->exists();
     }
 }


### PR DESCRIPTION
Return the bool instead of a `$refreshToken->revoked`

This method supports multiple databases, including document db structures such as MongoDB.

Otherwise it will throw this error:
```
Trying to get property 'revoked' of non-object at /var/www/vendor/laravel/passport/src/Bridge/RefreshTokenRepository.php:80)
```