### PR TITLE
[8.0] Allow public clients

### DIFF
--- a/database/migrations/2019_07_17_000001_make_client_secret_nullable.php
+++ b/database/migrations/2019_07_17_000001_make_client_secret_nullable.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeClientSecretNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->string('secret', 100)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->string('secret', 100)->change();
+        });
+    }
+}

--- a/resources/js/components/Clients.vue
+++ b/resources/js/components/Clients.vue
@@ -125,6 +125,22 @@
                                     </span>
                                 </div>
                             </div>
+
+                            <!-- Confidential -->
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label">Confidential</label>
+
+                                <div class="col-md-9">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" v-model="createForm.confidential">
+                                        </label>
+                                    </div>
+                                    <span class="form-text text-muted">
+                                        Require the client to authenticate with a secret.
+                                    </span>
+                                </div>
+                            </div>
                         </form>
                     </div>
 
@@ -222,7 +238,8 @@
                 createForm: {
                     errors: [],
                     name: '',
-                    redirect: ''
+                    redirect: '',
+                    confidential: true
                 },
 
                 editForm: {

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -37,7 +37,7 @@ class ClientRepository implements ClientRepositoryInterface
         }
 
         return new Client(
-            $clientIdentifier, $record->name, $record->redirect, ! is_null($record->secret)
+            $clientIdentifier, $record->name, $record->redirect, $record->confidential()
         );
     }
 
@@ -52,7 +52,7 @@ class ClientRepository implements ClientRepositoryInterface
             return false;
         }
 
-        return hash_equals($record->secret, (string) $clientSecret);
+        return ! $record->confidential() || hash_equals($record->secret, (string) $clientSecret);
     }
 
     /**
@@ -72,11 +72,11 @@ class ClientRepository implements ClientRepositoryInterface
             case 'authorization_code':
                 return ! $record->firstParty();
             case 'personal_access':
-                return $record->personal_access_client;
+                return $record->personal_access_client && $record->confidential();
             case 'password':
                 return $record->password_client;
             case 'client_credentials':
-                return ! empty($record->secret);
+                return $record->confidential();
             default:
                 return true;
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -92,4 +92,14 @@ class Client extends Model
     {
         return false;
     }
+
+    /**
+     * Determine if the client is a confidential client.
+     *
+     * @return bool
+     */
+    public function confidential()
+    {
+        return ! empty($this->secret);
+    }
 }

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -106,14 +106,15 @@ class ClientRepository
      * @param  string  $redirect
      * @param  bool  $personalAccess
      * @param  bool  $password
+     * @param  bool  $confidential
      * @return \Laravel\Passport\Client
      */
-    public function create($userId, $name, $redirect, $personalAccess = false, $password = false)
+    public function create($userId, $name, $redirect, $personalAccess = false, $password = false, $confidential = true)
     {
         $client = Passport::client()->forceFill([
             'user_id' => $userId,
             'name' => $name,
-            'secret' => Str::random(40),
+            'secret' => ($confidential || $personalAccess) ? Str::random(40) : null,
             'redirect' => $redirect,
             'personal_access_client' => $personalAccess,
             'password_client' => $password,

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -73,10 +73,12 @@ class ClientController
         $this->validation->make($request->all(), [
             'name' => 'required|max:255',
             'redirect' => ['required', $this->redirectRule],
+            'confidential' => 'boolean',
         ])->validate();
 
         return $this->clients->create(
-            $request->user()->getKey(), $request->name, $request->redirect
+            $request->user()->getKey(), $request->name, $request->redirect,
+            false, false, (bool) $request->input('confidential', true)
         )->makeVisible('secret');
     }
 

--- a/tests/AccessTokenControllerTest.php
+++ b/tests/AccessTokenControllerTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 use Lcobucci\JWT\Parser;
 use Zend\Diactoros\Response;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
 use Laravel\Passport\TokenRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -14,7 +14,6 @@ use Illuminate\Container\Container;
 use Laravel\Passport\TokenRepository;
 use Laravel\Passport\ClientRepository;
 use Psr\Http\Message\ResponseInterface;
-use Illuminate\Contracts\Config\Repository;
 use Psr\Http\Message\ServerRequestInterface;
 use League\OAuth2\Server\AuthorizationServer;
 use Illuminate\Contracts\Routing\ResponseFactory;
@@ -70,31 +69,6 @@ class AuthorizationControllerTest extends TestCase
         $this->assertEquals('view', $controller->authorize(
             m::mock(ServerRequestInterface::class), $request, $clients, $tokens
         ));
-    }
-
-    public function test_authorization_exceptions_are_handled()
-    {
-        Container::getInstance()->instance(ExceptionHandler::class, $exceptions = m::mock());
-        Container::getInstance()->instance(Repository::class, $config = m::mock());
-        $exceptions->shouldReceive('report')->once();
-        $config->shouldReceive('get')->once()->andReturn(true);
-
-        $server = m::mock(AuthorizationServer::class);
-        $response = m::mock(ResponseFactory::class);
-
-        $controller = new AuthorizationController($server, $response);
-
-        $server->shouldReceive('validateAuthorizationRequest')->andThrow(new Exception('whoops'));
-
-        $request = m::mock(Request::class);
-        $request->shouldReceive('session')->andReturn($session = m::mock());
-
-        $clients = m::mock(ClientRepository::class);
-        $tokens = m::mock(TokenRepository::class);
-
-        $this->assertEquals('whoops', $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request, $clients, $tokens
-        )->getContent());
     }
 
     public function test_request_is_approved_if_valid_token_exists()

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -74,6 +74,15 @@ class BridgeClientRepositoryTest extends TestCase
         $this->assertTrue($this->repository->validateClient(1, 'secret', 'password'));
     }
 
+    public function test_public_client_password_grant_is_permitted()
+    {
+        $client = $this->clientModelRepository->findActive(1);
+        $client->password_client = true;
+        $client->secret = null;
+
+        $this->assertTrue($this->repository->validateClient(1, null, 'password'));
+    }
+
     public function test_password_grant_is_prevented()
     {
         $this->assertFalse($this->repository->validateClient(1, 'secret', 'password'));
@@ -82,6 +91,14 @@ class BridgeClientRepositoryTest extends TestCase
     public function test_authorization_code_grant_is_permitted()
     {
         $this->assertTrue($this->repository->validateClient(1, 'secret', 'authorization_code'));
+    }
+
+    public function test_public_client_authorization_code_grant_is_permitted()
+    {
+        $client = $this->clientModelRepository->findActive(1);
+        $client->secret = null;
+
+        $this->assertTrue($this->repository->validateClient(1, null, 'authorization_code'));
     }
 
     public function test_authorization_code_grant_is_prevented()
@@ -103,6 +120,15 @@ class BridgeClientRepositoryTest extends TestCase
     public function test_personal_access_grant_is_prevented()
     {
         $this->assertFalse($this->repository->validateClient(1, 'secret', 'personal_access'));
+    }
+
+    public function test_public_client_personal_access_grant_is_prevented()
+    {
+        $client = $this->clientModelRepository->findActive(1);
+        $client->personal_access_client = true;
+        $client->secret = null;
+
+        $this->assertFalse($this->repository->validateClient(1, null, 'personal_access'));
     }
 
     public function test_client_credentials_grant_is_permitted()
@@ -133,6 +159,24 @@ class BridgeClientRepositoryTest extends TestCase
 
         $this->assertFalse($this->repository->validateClient(1, 'secret', 'authorization_code'));
     }
+
+    public function test_refresh_grant_is_permitted()
+    {
+        $this->assertTrue($this->repository->validateClient(1, 'secret', 'refresh_token'));
+    }
+
+    public function test_public_refresh_grant_is_permitted()
+    {
+        $client = $this->clientModelRepository->findActive(1);
+        $client->secret = null;
+
+        $this->assertTrue($this->repository->validateClient(1, null, 'refresh_token'));
+    }
+
+    public function test_refresh_grant_is_prevented()
+    {
+        $this->assertFalse($this->repository->validateClient(1, 'wrong-secret', 'refresh_token'));
+    }
 }
 
 class BridgeClientRepositoryTestClientStub
@@ -152,5 +196,10 @@ class BridgeClientRepositoryTestClientStub
     public function firstParty()
     {
         return $this->personal_access_client || $this->password_client;
+    }
+
+    public function confidential()
+    {
+        return ! empty($this->secret);
     }
 }


### PR DESCRIPTION
This pull request adds support for public clients.

The league/oauth2-server now supports using both public and confidential clients with the authorization code grant. The recommended flow for single page applications and native apps is the auth code grant with a public client and PKCE. Supporting public clients makes it possible for developers to use the authorization code grant with PKCE instead of the insecure implicit grant.

Previously all clients were required to have a secret. If you used the implicit grant the secret just wasn't checked. We can't just skip checking the secret for the auth code grant like we were doing with the implicit grant because we need to check the secret if it was issued.

Instead we need to offer the ability to create public clients, and only check the credentials if the client is confidential.

The UI looks like this:

![public-client](https://user-images.githubusercontent.com/9440455/62828558-eb252480-bbb7-11e9-8038-eeba07a36ea8.png)

The oauth_clients.secret column was updated to be nullable and the POST /clients endpoint was updated to allow passing a confidential param (defaults to true).

A public client can only be used with the implicit grant, the authorization code grant, and the password grant. The client credentials and personal access grants are only usable with a confidential client.

I pulled in changes from #1064 so the tests would pass. This may need to be rebased once that is merged.