### PR TITLE
[7.0] Let Passport support inherited parent scopes.

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -139,6 +139,13 @@ class Passport
     public static $unserializesCookies = false;
 
     /**
+     * Indicates the scope should inherit its parent scope.
+     *
+     * @var bool
+     */
+    public static $withInheritedScopes = false;
+
+    /**
      * Enable the implicit grant type.
      *
      * @return static

--- a/src/Token.php
+++ b/src/Token.php
@@ -83,8 +83,40 @@ class Token extends Model
      */
     public function can($scope)
     {
-        return in_array('*', $this->scopes) ||
-               array_key_exists($scope, array_flip($this->scopes));
+        if (in_array('*', $this->scopes)) {
+            return true;
+        }
+
+        $scopes = Passport::$withInheritedScopes
+            ? $this->resolveInheritedScopes($scope)
+            : [$scope];
+
+        foreach ($scopes as $scope) {
+            if (array_key_exists($scope, array_flip($this->scopes))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve all possible scopes.
+     *
+     * @param  string  $scope
+     * @return array
+     */
+    protected function resolveInheritedScopes($scope)
+    {
+        $parts = explode(':', $scope);
+
+        $scopes = [];
+
+        for ($i = 0; $i <= count($parts); $i++) {
+            $scopes[] = implode(':', array_slice($parts, 0, $i));
+        }
+
+        return $scopes;
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR introduces the concept of inherited scopes.

By setting `Passport::$withInheritedScopes = true;` in your `AppServiceProvider.php` file you can enable this new feature (which is disabled by default).

Once enabled it allows the access to be granted or not depending on the presence of parent scopes.

This is a common pattern which is used by [Github](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes) for their API scopes - but not only.

A user will have the possibility to *also* execute an action requiring the `admin:webhooks:create` scope, if he already has already been granted the following scopes `admin:webhooks`, `admin`.

---

Note:

If merged, additional documentation should be added to https://laravel.com/docs/5.8/passport.