### PR TITLE
[7.0] Accept requests with the encrypted X-XSRF-TOKEN HTTP header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "illuminate/console": "~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/container": "~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/contracts": "~5.6.0|~5.7.0|~5.8.0|^6.0",
+        "illuminate/cookie": "~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/database": "~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/encryption": "~5.6.0|~5.7.0|~5.8.0|^6.0",
         "illuminate/http": "~5.6.0|~5.7.0|~5.8.0|^6.0",

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -14,6 +14,7 @@ use League\OAuth2\Server\ResourceServer;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Cookie\Middleware\EncryptCookies;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 
@@ -254,7 +255,34 @@ class TokenGuard
     protected function validCsrf($token, $request)
     {
         return isset($token['csrf']) && hash_equals(
-            $token['csrf'], (string) $request->header('X-CSRF-TOKEN')
+            $token['csrf'], (string) $this->getTokenFromRequest($request)
         );
+    }
+
+    /**
+     * Get the CSRF token from the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     */
+    protected function getTokenFromRequest($request)
+    {
+        $token = $request->input('_token') ?: $request->header('X-CSRF-TOKEN');
+
+        if (! $token && $header = $request->header('X-XSRF-TOKEN')) {
+            $token = $this->encrypter->decrypt($header, static::serialized());
+        }
+
+        return $token;
+    }
+
+    /**
+     * Determine if the cookie contents should be serialized.
+     *
+     * @return bool
+     */
+    public static function serialized()
+    {
+        return EncryptCookies::serialized('XSRF-TOKEN');
     }
 }

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -267,7 +267,7 @@ class TokenGuard
      */
     protected function getTokenFromRequest($request)
     {
-        $token = $request->input('_token') ?: $request->header('X-CSRF-TOKEN');
+        $token = $request->header('X-CSRF-TOKEN');
 
         if (! $token && $header = $request->header('X-XSRF-TOKEN')) {
             $token = $this->encrypter->decrypt($header, static::serialized());

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -102,7 +102,7 @@ class TokenGuardTest extends TestCase
         $this->assertNull($guard->user($request));
     }
 
-    public function test_users_may_be_retrieved_from_cookies()
+    public function test_users_may_be_retrieved_from_cookies_with_csrf_token_header()
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(UserProvider::class);
@@ -130,7 +130,35 @@ class TokenGuardTest extends TestCase
         $this->assertEquals($expectedUser, $user);
     }
 
-    public function test_cookie_xsrf_is_verified_against_header()
+    public function test_users_may_be_retrieved_from_cookies_with_xsrf_token_header()
+    {
+        $resourceServer = m::mock(ResourceServer::class);
+        $userProvider = m::mock(UserProvider::class);
+        $tokens = m::mock(TokenRepository::class);
+        $clients = m::mock(ClientRepository::class);
+        $encrypter = new Encrypter(str_repeat('a', 16));
+
+        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+
+        $request = Request::create('/');
+        $request->headers->set('X-XSRF-TOKEN', $encrypter->encrypt('token', false));
+        $request->cookies->set('laravel_token',
+            $encrypter->encrypt(JWT::encode([
+                'sub' => 1,
+                'aud' => 1,
+                'csrf' => 'token',
+                'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
+            ], str_repeat('a', 16)), false)
+        );
+
+        $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
+
+        $user = $guard->user($request);
+
+        $this->assertEquals($expectedUser, $user);
+    }
+
+    public function test_cookie_xsrf_is_verified_against_csrf_token_header()
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(UserProvider::class);
@@ -142,6 +170,58 @@ class TokenGuardTest extends TestCase
 
         $request = Request::create('/');
         $request->headers->set('X-CSRF-TOKEN', 'wrong_token');
+        $request->cookies->set('laravel_token',
+            $encrypter->encrypt(JWT::encode([
+                'sub' => 1,
+                'aud' => 1,
+                'csrf' => 'token',
+                'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
+            ], str_repeat('a', 16)))
+        );
+
+        $userProvider->shouldReceive('retrieveById')->never();
+
+        $this->assertNull($guard->user($request));
+    }
+
+    public function test_cookie_xsrf_is_verified_against_xsrf_token_header()
+    {
+        $resourceServer = m::mock(ResourceServer::class);
+        $userProvider = m::mock(UserProvider::class);
+        $tokens = m::mock(TokenRepository::class);
+        $clients = m::mock(ClientRepository::class);
+        $encrypter = new Encrypter(str_repeat('a', 16));
+
+        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+
+        $request = Request::create('/');
+        $request->headers->set('X-XSRF-TOKEN', $encrypter->encrypt('wrong_token', false));
+        $request->cookies->set('laravel_token',
+            $encrypter->encrypt(JWT::encode([
+                'sub' => 1,
+                'aud' => 1,
+                'csrf' => 'token',
+                'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
+            ], str_repeat('a', 16)))
+        );
+
+        $userProvider->shouldReceive('retrieveById')->never();
+
+        $this->assertNull($guard->user($request));
+    }
+
+    public function test_xsrf_token_cookie_without_a_token_header_is_not_accepted()
+    {
+        $resourceServer = m::mock(ResourceServer::class);
+        $userProvider = m::mock(UserProvider::class);
+        $tokens = m::mock(TokenRepository::class);
+        $clients = m::mock(ClientRepository::class);
+        $encrypter = new Encrypter(str_repeat('a', 16));
+
+        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
+
+        $request = Request::create('/');
+        $request->cookies->set('XSRF-TOKEN', $encrypter->encrypt('token', false));
         $request->cookies->set('laravel_token',
             $encrypter->encrypt(JWT::encode([
                 'sub' => 1,


### PR DESCRIPTION
This updates `TokenGuard` to accept requests with a valid encrypted `X-XSRF-TOKEN` HTTP header in the same way as Laravel's [`VerifyCsrfToken` middleware](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php#L152).

Amongst other things, this would allow us to simplify Laravel's `bootstrap.js` by taking advantage of Axios's default functionality to automatically send the `X-XSRF-TOKEN` header on same-origin requests using the contents of the `XSRF-TOKEN` cookie.

I note that this feature has been requested and rejected several times, often because of concerns it opens a CSRF vulnerability. I believe this is not the case because we are only opening it to accept requests with a valid `X-XSRF-TOKEN` *HTTP header*, which will never be automatically sent by the browser (on first party initiated requests _or_ third party initiated requests), unlike the `XSRF-TOKEN` *cookie* which is always sent.

A valid `X-XSRF-TOKEN` HTTP header can only added by JavaScript with access to our cookies in the same way that a valid `X-CSRF-TOKEN` header can only be added by JavaScript with access to our DOM. It has to be running on our domain. An XSS vulnerability could bypass CSRF using either header, but that's always going to be the case and thankfully Laravel has great tools for protecting against XSS.

This is also no different to what is already happening in the `VerifyCsrfToken` middleware.

To help ease concerns, I have added a test to validate that the `XSRF-TOKEN` cookie alone is not sufficient to bypass `TokenGuard`.

This also addresses the PR request at https://github.com/laravel/passport/issues/515#issuecomment-430984030

I welcome as much scrutiny as possible on this as security is obviously the top priority.

Thanks!