### PR TITLE
Initial support for multi-auth.

### DIFF
--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -16,6 +16,7 @@ class CreateOauthClientsTable extends Migration
         Schema::create('oauth_clients', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('user_id')->index()->nullable();
+            $table->string('provider')->nullable();
             $table->string('name');
             $table->string('secret', 100);
             $table->text('redirect');

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -267,11 +267,10 @@ class PassportServiceProvider extends ServiceProvider
         return new RequestGuard(function ($request) use ($config) {
             return (new TokenGuard(
                 $this->app->make(ResourceServer::class),
-                Auth::createUserProvider($config['provider']),
                 $this->app->make(TokenRepository::class),
                 $this->app->make(ClientRepository::class),
                 $this->app->make('encrypter')
-            ))->user($request);
+            ))->user($config['provider'], $request);
         }, $this->app['request']);
     }
 


### PR DESCRIPTION
This PR is to setup multi-auth support. To achieve this, the oauth_client has a new column called `provider` which is nullable. The `TokenGuard` now checks to see if a provider is defined for a client, if one is it will validate it against the requested provider, if those match it will continue through as normal. If not, it will return early as the request is invalid.

https://github.com/laravel/passport/issues/982