### PR TITLE
Refactor Token to use Token Contract

### DIFF
--- a/src/Contracts/Token.php
+++ b/src/Contracts/Token.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Queue\QueueableEntity;
 
-interface TokenContract extends ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
+interface Token extends ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     /**
      * Get the client that the token belongs to.

--- a/src/Contracts/TokenContract.php
+++ b/src/Contracts/TokenContract.php
@@ -3,10 +3,10 @@
 namespace Laravel\Passport\Contracts;
 
 use ArrayAccess;
-use Illuminate\Contracts\Queue\QueueableEntity;
-use Illuminate\Contracts\Routing\UrlRoutable;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Contracts\Queue\QueueableEntity;
 use JsonSerializable;
 
 interface TokenContract extends ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable

--- a/src/Contracts/TokenContract.php
+++ b/src/Contracts/TokenContract.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Laravel\Passport\Contracts;
+
+use ArrayAccess;
+use Illuminate\Contracts\Queue\QueueableEntity;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JsonSerializable;
+
+interface TokenContract extends ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
+{
+    /**
+     * Get the client that the token belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function client();
+
+    /**
+     * Get the user that the token belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user();
+
+    /**
+     * Determine if the token has a given scope.
+     *
+     * @param string $scope
+     * @return bool
+     */
+    public function can($scope);
+
+    /**
+     * Determine if the token is missing a given scope.
+     *
+     * @param string $scope
+     * @return bool
+     */
+    public function cant($scope);
+
+    /**
+     * Revoke the token instance.
+     *
+     * @return bool
+     */
+    public function revoke();
+
+    /**
+     * Determine if the token is a transient JWT token.
+     *
+     * @return bool
+     */
+    public function transient();
+
+    /**
+     * Save the token to the database.
+     *
+     * @param  array  $options
+     * @return bool
+     */
+    public function save(array $options = []);
+}

--- a/src/Contracts/TokenContract.php
+++ b/src/Contracts/TokenContract.php
@@ -3,11 +3,11 @@
 namespace Laravel\Passport\Contracts;
 
 use ArrayAccess;
+use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Queue\QueueableEntity;
-use JsonSerializable;
 
 interface TokenContract extends ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {

--- a/src/Token.php
+++ b/src/Token.php
@@ -3,7 +3,7 @@
 namespace Laravel\Passport;
 
 use Illuminate\Database\Eloquent\Model;
-use Laravel\Passport\Contracts\TokenContract;
+use Laravel\Passport\Contracts\Token as TokenContract;
 
 class Token extends Model implements TokenContract
 {

--- a/src/Token.php
+++ b/src/Token.php
@@ -3,8 +3,9 @@
 namespace Laravel\Passport;
 
 use Illuminate\Database\Eloquent\Model;
+use Laravel\Passport\Contracts\TokenContract;
 
-class Token extends Model
+class Token extends Model implements TokenContract
 {
     /**
      * The database table used by the model.

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -3,7 +3,7 @@
 namespace Laravel\Passport;
 
 use Carbon\Carbon;
-use Laravel\Passport\Contracts\TokenContract;
+use Laravel\Passport\Contracts\Token;
 
 class TokenRepository
 {
@@ -71,10 +71,10 @@ class TokenRepository
     /**
      * Store the given token instance.
      *
-     * @param  \Laravel\Passport\Contracts\TokenContract  $token
+     * @param  \Laravel\Passport\Contracts\Token $token
      * @return void
      */
-    public function save(TokenContract $token)
+    public function save(Token $token)
     {
         $token->save();
     }

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport;
 
 use Carbon\Carbon;
+use Laravel\Passport\Contracts\TokenContract;
 
 class TokenRepository
 {
@@ -70,10 +71,10 @@ class TokenRepository
     /**
      * Store the given token instance.
      *
-     * @param  \Laravel\Passport\Token  $token
+     * @param  \Laravel\Passport\Contracts\TokenContract  $token
      * @return void
      */
-    public function save(Token $token)
+    public function save(TokenContract $token)
     {
         $token->save();
     }


### PR DESCRIPTION
By using a TokenContract as type hint inside the TokenRepository it allows custom Tokens to be used which is necessary when using a different database such as MongoDB as this requires the Token to extend a different base Model.

For #968