### PR TITLE
Allow Token model to update timestamp

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -47,13 +47,6 @@ class Token extends Model
     ];
 
     /**
-     * Indicates if the model should be timestamped.
-     *
-     * @var bool
-     */
-    public $timestamps = false;
-
-    /**
      * Get the client that the token belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo


### PR DESCRIPTION
The current model property does not set to update timestamp in the column `oauth_access_tokens`.`updated_at` on token revoke action.
