### PR TITLE
added $keyType = 'string' to Token model

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -14,6 +14,13 @@ class Token extends Model
     protected $table = 'oauth_access_tokens';
 
     /**
+     * The "type" of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * Indicates if the IDs are auto-incrementing.
      *
      * @var bool


### PR DESCRIPTION
This was made to fix usage of Token model in relations after upgrade to laravel 6.0.
Made this according to https://laravel.com/docs/6.0/upgrade#eloquent-primary-key-type 