### PR TITLE
[7.x] 'actingAsClient' method for tests

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -7,6 +7,7 @@ use DateInterval;
 use Carbon\Carbon;
 use DateTimeInterface;
 use Illuminate\Support\Facades\Route;
+use League\OAuth2\Server\ResourceServer;
 
 class Passport
 {
@@ -403,6 +404,29 @@ class Passport
         app('auth')->shouldUse($guard);
 
         return $user;
+    }
+
+    /**
+     * Set the current client for the application with the given scopes.
+     *
+     * @param  \Laravel\Passport\Client  $client
+     * @param  array  $scopes
+     * @return \Laravel\Passport\Client
+     */
+    public static function actingAsClient($client, $scopes = [])
+    {
+        $mock = Mockery::mock(ResourceServer::class);
+
+        $mock->shouldReceive('validateAuthenticatedRequest')
+            ->andReturnUsing(function ($request) use ($client, $scopes) {
+                return $request
+                    ->withAttribute('oauth_client_id', $client->id)
+                    ->withAttribute('oauth_scopes', $scopes);
+            });
+
+        app()->instance(ResourceServer::class, $mock);
+
+        return $client;
     }
 
     /**


### PR DESCRIPTION
Laravel Passport already provides an `actingAs` method that mocks the user authentication. This pull request adds the method `actingAsClient` to mock the client authentication (optionally using certain scopes).

```php
Passport::actingAsClient($client);
Passport::actingAsClient($client, ['check-status', 'place-orders']);
```

## Why ?

If you currently want to test an API route that uses client authentication, you have to make an actual request to the `/oauth/token` route to get a client access token. Then you have to add that token to the `Authorization` header of the next request that tests the API route.

_Fixes issues [#514](https://github.com/laravel/passport/issues/514) and [#680](https://github.com/laravel/passport/issues/680)._

## How?

This method was already proposed in an older pull request ([#847](https://github.com/laravel/passport/pull/847)), but that implementation mocked the middleware.

My implementation mocks the `ResourceServer` class. This class is used by both the `CheckClientCredentials` and `CheckClientCredentialsForAnyScope` middleware classes.
The `ResourceServer` class parses the request `Authorization` header and sets certain attributes on the request. (in the `BearerTokenValidator`)

```php
return $request
    ->withAttribute('oauth_access_token_id', $token->getClaim('jti'))
    ->withAttribute('oauth_client_id', $token->getClaim('aud'))
    ->withAttribute('oauth_user_id', $token->getClaim('sub'))
    ->withAttribute('oauth_scopes', $token->getClaim('scopes'));
```

Those attributes are later used in the middleware classes to validate the scopes.
By just mocking the `ResourceServer` class, we don't need to mock the entire middleware classes or the scopes logic.


_If the pull request is approved, I will make a pull request to update the documentation_
