### PR TITLE
Use config for session name

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -80,7 +80,7 @@ class Passport
      *
      * @var string
      */
-    public static $cookie = 'laravel_token';
+    public static $cookie = config('session.cookie') . '_token';
 
     /**
      * Indicates if Passport should ignore incoming CSRF tokens.

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -80,7 +80,7 @@ class Passport
      *
      * @var string
      */
-    public static $cookie = config('session.cookie') . '_token';
+    public static $cookie = config('session.cookie').'_token';
 
     /**
      * Indicates if Passport should ignore incoming CSRF tokens.


### PR DESCRIPTION
Uses config for the session name not exposing the `laravel` tags by default instead of using `Passport::cookie('custom_token')`