### PR TITLE
[7.x] Cast returned client identifier value to string

### DIFF
--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -10,6 +10,8 @@ class Client implements ClientEntityInterface
     use ClientTrait;
 
     /**
+     * The client identifier.
+     * 
      * @var string
      */
     protected $identifier;
@@ -31,6 +33,8 @@ class Client implements ClientEntityInterface
     }
 
     /**
+     * Get the client's identifier.
+     *
      * @return string
      */
     public function getIdentifier()
@@ -39,7 +43,9 @@ class Client implements ClientEntityInterface
     }
 
     /**
-     * @param string $identifier
+     * Set the client's identifier.
+     *
+     * @param  string  $identifier
      */
     public function setIdentifier($identifier)
     {

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -4,11 +4,15 @@ namespace Laravel\Passport\Bridge;
 
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\Traits\ClientTrait;
-use League\OAuth2\Server\Entities\Traits\EntityTrait;
 
 class Client implements ClientEntityInterface
 {
-    use ClientTrait, EntityTrait;
+    use ClientTrait;
+
+   /**
+     * @var string
+     */
+    protected $identifier;
 
     /**
      * Create a new client instance.
@@ -24,5 +28,21 @@ class Client implements ClientEntityInterface
 
         $this->name = $name;
         $this->redirectUri = explode(',', $redirectUri);
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return (string) $this->identifier;
+    }
+
+    /**
+     * @param string $identifier
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
     }
 }

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -9,7 +9,7 @@ class Client implements ClientEntityInterface
 {
     use ClientTrait;
 
-   /**
+    /**
      * @var string
      */
     protected $identifier;


### PR DESCRIPTION
Fixes https://github.com/laravel/passport/issues/1089.

Will benefit anyone who wishes to switch to native prepared statements for performance or other reasons.

Since it should be 100% backwards compatible, please let me know what kinds of tests would one need for such cases.