### PR TITLE
[9.x] Generate default cookie name from app name

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport;
 use Carbon\Carbon;
 use DateInterval;
 use DateTimeInterface;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use League\OAuth2\Server\ResourceServer;
@@ -365,7 +366,7 @@ class Passport
     {
         if (is_null($cookie)) {
             if (is_null(static::$cookie)) {
-                static::$cookie = Str::slug(env('APP_NAME', 'laravel'), '_').'_token';
+                static::$cookie = Str::slug(Config::get('app.name', 'laravel'), '_').'_token';
             }
 
             return static::$cookie;

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use DateInterval;
 use DateTimeInterface;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
 use League\OAuth2\Server\ResourceServer;
 use Mockery;
 
@@ -81,7 +82,7 @@ class Passport
      *
      * @var string
      */
-    public static $cookie = 'laravel_token';
+    public static $cookie;
 
     /**
      * Indicates if Passport should ignore incoming CSRF tokens.
@@ -363,6 +364,10 @@ class Passport
     public static function cookie($cookie = null)
     {
         if (is_null($cookie)) {
+            if (is_null(static::$cookie)) {
+                static::$cookie = Str::slug(env('APP_NAME', 'laravel'), '_').'_token';
+            }
+
             return static::$cookie;
         }
 

--- a/tests/ApiTokenCookieFactoryTest.php
+++ b/tests/ApiTokenCookieFactoryTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Passport\Tests;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Support\Facades\Config;
 use Laravel\Passport\ApiTokenCookieFactory;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +19,7 @@ class ApiTokenCookieFactoryTest extends TestCase
 
     public function test_cookie_can_be_successfully_created()
     {
+        Config::shouldReceive('get')->withSomeOfArgs('app.name')->andReturn('laravel');
         $config = m::mock(Repository::class);
         $config->shouldReceive('get')->with('session')->andReturn([
             'lifetime' => 120,

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Guards\TokenGuard;
 use Laravel\Passport\HasApiTokens;
@@ -104,6 +105,7 @@ class TokenGuardTest extends TestCase
 
     public function test_users_may_be_retrieved_from_cookies_with_csrf_token_header()
     {
+        Config::shouldReceive('get')->withSomeOfArgs('app.name')->andReturn('laravel');
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(UserProvider::class);
         $tokens = m::mock(TokenRepository::class);
@@ -132,6 +134,7 @@ class TokenGuardTest extends TestCase
 
     public function test_users_may_be_retrieved_from_cookies_with_xsrf_token_header()
     {
+        Config::shouldReceive('get')->withSomeOfArgs('app.name')->andReturn('laravel');
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(UserProvider::class);
         $tokens = m::mock(TokenRepository::class);
@@ -160,6 +163,7 @@ class TokenGuardTest extends TestCase
 
     public function test_cookie_xsrf_is_verified_against_csrf_token_header()
     {
+        Config::shouldReceive('get')->withSomeOfArgs('app.name')->andReturn('laravel');
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(UserProvider::class);
         $tokens = m::mock(TokenRepository::class);
@@ -186,6 +190,7 @@ class TokenGuardTest extends TestCase
 
     public function test_cookie_xsrf_is_verified_against_xsrf_token_header()
     {
+        Config::shouldReceive('get')->withSomeOfArgs('app.name')->andReturn('laravel');
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(UserProvider::class);
         $tokens = m::mock(TokenRepository::class);
@@ -212,6 +217,7 @@ class TokenGuardTest extends TestCase
 
     public function test_xsrf_token_cookie_without_a_token_header_is_not_accepted()
     {
+        Config::shouldReceive('get')->withSomeOfArgs('app.name')->andReturn('laravel');
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(UserProvider::class);
         $tokens = m::mock(TokenRepository::class);
@@ -238,6 +244,7 @@ class TokenGuardTest extends TestCase
 
     public function test_expired_cookies_may_not_be_used()
     {
+        Config::shouldReceive('get')->withSomeOfArgs('app.name')->andReturn('laravel');
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(UserProvider::class);
         $tokens = m::mock(TokenRepository::class);
@@ -264,6 +271,7 @@ class TokenGuardTest extends TestCase
 
     public function test_csrf_check_can_be_disabled()
     {
+        Config::shouldReceive('get')->withSomeOfArgs('app.name')->andReturn('laravel');
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(UserProvider::class);
         $tokens = m::mock(TokenRepository::class);
@@ -362,6 +370,7 @@ class TokenGuardTest extends TestCase
 
     public function test_clients_may_be_retrieved_from_cookies()
     {
+        Config::shouldReceive('get')->withSomeOfArgs('app.name')->andReturn('laravel');
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(UserProvider::class);
         $tokens = m::mock(TokenRepository::class);


### PR DESCRIPTION
This implements the proposal in #981 to set the default cookie name using the app name.

I'm not sure if this should target current major version as it is a potentially breaking change.
