### PR TITLE
[9.x] Use psr request attributes in 'check client credentials' middleware

### DIFF
--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -4,8 +4,8 @@ namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
 use Illuminate\Auth\AuthenticationException;
-use Laravel\Passport\Exceptions\MissingScopeException;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Exceptions\MissingScopeException;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;

--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -5,7 +5,7 @@ namespace Laravel\Passport\Http\Middleware;
 use Closure;
 use Illuminate\Auth\AuthenticationException;
 use Laravel\Passport\Exceptions\MissingScopeException;
-use Laravel\Passport\TokenRepository;
+use Laravel\Passport\ClientRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
@@ -24,9 +24,9 @@ class CheckClientCredentials
     protected $server;
 
     /**
-     * Token Repository.
+     * Client Repository.
      *
-     * @var \Laravel\Passport\TokenRepository
+     * @var \Laravel\Passport\ClientRepository
      */
     protected $repository;
 
@@ -34,10 +34,10 @@ class CheckClientCredentials
      * Create a new middleware instance.
      *
      * @param  \League\OAuth2\Server\ResourceServer  $server
-     * @param  \Laravel\Passport\TokenRepository  $repository
+     * @param  \Laravel\Passport\ClientRepository  $repository
      * @return void
      */
-    public function __construct(ResourceServer $server, TokenRepository $repository)
+    public function __construct(ResourceServer $server, ClientRepository $repository)
     {
         $this->server = $server;
         $this->repository = $repository;
@@ -82,18 +82,18 @@ class CheckClientCredentials
      */
     protected function validate($psr, $scopes)
     {
-        $token = $this->repository->find($psr->getAttribute('oauth_access_token_id'));
+        $client = $this->repository->find($psr->getAttribute('oauth_client_id'));
 
-        if (! $token || $token->client->firstParty()) {
+        if (! $client || $client->firstParty()) {
             throw new AuthenticationException;
         }
 
-        if (in_array('*', $token->scopes)) {
+        if (in_array('*', $tokenScopes = $psr->getAttribute('oauth_scopes'))) {
             return;
         }
 
         foreach ($scopes as $scope) {
-            if ($token->cant($scope)) {
+            if (! in_array($scope, $tokenScopes)) {
                 throw new MissingScopeException($scope);
             }
         }

--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -5,7 +5,7 @@ namespace Laravel\Passport\Http\Middleware;
 use Closure;
 use Illuminate\Auth\AuthenticationException;
 use Laravel\Passport\Exceptions\MissingScopeException;
-use Laravel\Passport\TokenRepository;
+use Laravel\Passport\ClientRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
@@ -24,9 +24,9 @@ class CheckClientCredentialsForAnyScope
     protected $server;
 
     /**
-     * Token Repository.
+     * Client Repository.
      *
-     * @var \Laravel\Passport\TokenRepository
+     * @var \Laravel\Passport\ClientRepository
      */
     protected $repository;
 
@@ -34,10 +34,10 @@ class CheckClientCredentialsForAnyScope
      * Create a new middleware instance.
      *
      * @param  \League\OAuth2\Server\ResourceServer  $server
-     * @param  \Laravel\Passport\TokenRepository  $repository
+     * @param  \Laravel\Passport\ClientRepository  $repository
      * @return void
      */
-    public function __construct(ResourceServer $server, TokenRepository $repository)
+    public function __construct(ResourceServer $server, ClientRepository $repository)
     {
         $this->server = $server;
         $this->repository = $repository;
@@ -84,18 +84,18 @@ class CheckClientCredentialsForAnyScope
      */
     protected function validate($psr, $scopes)
     {
-        $token = $this->repository->find($psr->getAttribute('oauth_access_token_id'));
+        $client = $this->repository->find($psr->getAttribute('oauth_client_id'));
 
-        if (! $token || $token->client->firstParty()) {
+        if (! $client || $client->firstParty()) {
             throw new AuthenticationException;
         }
 
-        if (in_array('*', $token->scopes)) {
+        if (in_array('*', $tokenScopes = $psr->getAttribute('oauth_scopes'))) {
             return true;
         }
 
         foreach ($scopes as $scope) {
-            if ($token->can($scope)) {
+            if (in_array($scope, $tokenScopes)) {
                 return true;
             }
         }

--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -4,8 +4,8 @@ namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
 use Illuminate\Auth\AuthenticationException;
-use Laravel\Passport\Exceptions\MissingScopeException;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Exceptions\MissingScopeException;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;

--- a/tests/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/CheckClientCredentialsForAnyScopeTest.php
@@ -4,8 +4,8 @@ namespace Laravel\Passport\Tests;
 
 use Illuminate\Http\Request;
 use Laravel\Passport\Client;
-use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Mockery as m;

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -4,10 +4,8 @@ namespace Laravel\Passport\Tests;
 
 use Illuminate\Http\Request;
 use Laravel\Passport\Client;
-use Laravel\Passport\Http\Middleware\CheckClientCredentials;
-use Laravel\Passport\Token;
-use Laravel\Passport\TokenRepository;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Http\Middleware\CheckClientCredentials;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Mockery as m;

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -7,6 +7,7 @@ use Laravel\Passport\Client;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
 use Laravel\Passport\Token;
 use Laravel\Passport\TokenRepository;
+use Laravel\Passport\ClientRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Mockery as m;
@@ -24,21 +25,17 @@ class CheckClientCredentialsTest extends TestCase
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
 
         $client = m::mock(Client::class);
         $client->shouldReceive('firstParty')->andReturnFalse();
 
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['*']);
+        $clientRepository = m::mock(ClientRepository::class);
+        $clientRepository->shouldReceive('find')->with(2)->andReturn($client);
 
-        $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
-
-        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentials($resourceServer, $clientRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -55,22 +52,17 @@ class CheckClientCredentialsTest extends TestCase
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['see-profile']);
 
         $client = m::mock(Client::class);
         $client->shouldReceive('firstParty')->andReturnFalse();
 
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['see-profile']);
-        $token->shouldReceive('cant')->with('see-profile')->andReturnFalse();
+        $clientRepository = m::mock(ClientRepository::class);
+        $clientRepository->shouldReceive('find')->with(2)->andReturn($client);
 
-        $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
-
-        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentials($resourceServer, $clientRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -87,13 +79,13 @@ class CheckClientCredentialsTest extends TestCase
      */
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
-        $tokenRepository = m::mock(TokenRepository::class);
+        $clientRepository = m::mock(ClientRepository::class);
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
             new OAuthServerException('message', 500, 'error type')
         );
 
-        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentials($resourceServer, $clientRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -111,23 +103,17 @@ class CheckClientCredentialsTest extends TestCase
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'notbar']);
 
         $client = m::mock(Client::class);
         $client->shouldReceive('firstParty')->andReturnFalse();
 
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['foo', 'notbar']);
-        $token->shouldReceive('cant')->with('foo')->andReturnFalse();
-        $token->shouldReceive('cant')->with('bar')->andReturnTrue();
+        $clientRepository = m::mock(ClientRepository::class);
+        $clientRepository->shouldReceive('find')->with(2)->andReturn($client);
 
-        $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
-
-        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentials($resourceServer, $clientRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -145,20 +131,17 @@ class CheckClientCredentialsTest extends TestCase
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
 
         $client = m::mock(Client::class);
         $client->shouldReceive('firstParty')->andReturnTrue();
 
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
+        $clientRepository = m::mock(ClientRepository::class);
+        $clientRepository->shouldReceive('find')->with(2)->andReturn($client);
 
-        $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
-
-        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentials($resourceServer, $clientRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');


### PR DESCRIPTION
The 'check client credentials' middleware currently fetches the client via the token. That means it first has to get the token and then load the client relation. The client id is already present in psr request via 'oauth_client_id' attribute. By using that attribute, the middleware has to make one less database query.
It also doesn't need to fetch the token in order to check the scopes. The psr request includes the scopes via 'oauth_scopes' attribute.

These psr attributes were used by the middleware in the previous version(s) of Passport.