### PR TITLE
Revert "[9.x] Use psr request attributes in 'check client credentials' middleware"

### DIFF
--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -4,8 +4,8 @@ namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
 use Illuminate\Auth\AuthenticationException;
-use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Exceptions\MissingScopeException;
+use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
@@ -24,9 +24,9 @@ class CheckClientCredentialsForAnyScope
     protected $server;
 
     /**
-     * Client Repository.
+     * Token Repository.
      *
-     * @var \Laravel\Passport\ClientRepository
+     * @var \Laravel\Passport\TokenRepository
      */
     protected $repository;
 
@@ -34,10 +34,10 @@ class CheckClientCredentialsForAnyScope
      * Create a new middleware instance.
      *
      * @param  \League\OAuth2\Server\ResourceServer  $server
-     * @param  \Laravel\Passport\ClientRepository  $repository
+     * @param  \Laravel\Passport\TokenRepository  $repository
      * @return void
      */
-    public function __construct(ResourceServer $server, ClientRepository $repository)
+    public function __construct(ResourceServer $server, TokenRepository $repository)
     {
         $this->server = $server;
         $this->repository = $repository;
@@ -84,18 +84,18 @@ class CheckClientCredentialsForAnyScope
      */
     protected function validate($psr, $scopes)
     {
-        $client = $this->repository->find($psr->getAttribute('oauth_client_id'));
+        $token = $this->repository->find($psr->getAttribute('oauth_access_token_id'));
 
-        if (! $client || $client->firstParty()) {
+        if (! $token || $token->client->firstParty()) {
             throw new AuthenticationException;
         }
 
-        if (in_array('*', $tokenScopes = $psr->getAttribute('oauth_scopes'))) {
+        if (in_array('*', $token->scopes)) {
             return true;
         }
 
         foreach ($scopes as $scope) {
-            if (in_array($scope, $tokenScopes)) {
+            if ($token->can($scope)) {
                 return true;
             }
         }

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -4,8 +4,9 @@ namespace Laravel\Passport\Tests;
 
 use Illuminate\Http\Request;
 use Laravel\Passport\Client;
-use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
+use Laravel\Passport\Token;
+use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Mockery as m;
@@ -23,17 +24,21 @@ class CheckClientCredentialsTest extends TestCase
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
 
         $client = m::mock(Client::class);
         $client->shouldReceive('firstParty')->andReturnFalse();
 
-        $clientRepository = m::mock(ClientRepository::class);
-        $clientRepository->shouldReceive('find')->with(2)->andReturn($client);
+        $token = m::mock(Token::class);
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
+        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['*']);
 
-        $middleware = new CheckClientCredentials($resourceServer, $clientRepository);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
+
+        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -50,17 +55,22 @@ class CheckClientCredentialsTest extends TestCase
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['see-profile']);
 
         $client = m::mock(Client::class);
         $client->shouldReceive('firstParty')->andReturnFalse();
 
-        $clientRepository = m::mock(ClientRepository::class);
-        $clientRepository->shouldReceive('find')->with(2)->andReturn($client);
+        $token = m::mock(Token::class);
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
+        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['see-profile']);
+        $token->shouldReceive('cant')->with('see-profile')->andReturnFalse();
 
-        $middleware = new CheckClientCredentials($resourceServer, $clientRepository);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
+
+        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -77,13 +87,13 @@ class CheckClientCredentialsTest extends TestCase
      */
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
-        $clientRepository = m::mock(ClientRepository::class);
+        $tokenRepository = m::mock(TokenRepository::class);
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
             new OAuthServerException('message', 500, 'error type')
         );
 
-        $middleware = new CheckClientCredentials($resourceServer, $clientRepository);
+        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -101,17 +111,23 @@ class CheckClientCredentialsTest extends TestCase
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'notbar']);
 
         $client = m::mock(Client::class);
         $client->shouldReceive('firstParty')->andReturnFalse();
 
-        $clientRepository = m::mock(ClientRepository::class);
-        $clientRepository->shouldReceive('find')->with(2)->andReturn($client);
+        $token = m::mock(Token::class);
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
+        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['foo', 'notbar']);
+        $token->shouldReceive('cant')->with('foo')->andReturnFalse();
+        $token->shouldReceive('cant')->with('bar')->andReturnTrue();
 
-        $middleware = new CheckClientCredentials($resourceServer, $clientRepository);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
+
+        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -129,17 +145,20 @@ class CheckClientCredentialsTest extends TestCase
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
 
         $client = m::mock(Client::class);
         $client->shouldReceive('firstParty')->andReturnTrue();
 
-        $clientRepository = m::mock(ClientRepository::class);
-        $clientRepository->shouldReceive('find')->with(2)->andReturn($client);
+        $token = m::mock(Token::class);
+        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
 
-        $middleware = new CheckClientCredentials($resourceServer, $clientRepository);
+        $tokenRepository = m::mock(TokenRepository::class);
+        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
+
+        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');


### PR DESCRIPTION
Reverting this for now since it is a slight change in behavior that I don't think is warranted.