### PR TITLE
[8.x] Fix 'actingAsClient' testing method

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Passport;
 
-use DateInterval;
 use Carbon\Carbon;
+use DateInterval;
 use DateTimeInterface;
 use Illuminate\Support\Facades\Route;
 use League\OAuth2\Server\ResourceServer;


### PR DESCRIPTION
The `Passport::actingAsClient()` is broken since version 8.0, because of the changes made by #1040. I updated the method to also mock the use of `TokenRepository` property.