### PR TITLE
[9.x] Client credentials middleware should allow any valid client (#1125)

### DIFF
--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -16,7 +16,7 @@ class CheckClientCredentials extends CheckCredentials
      */
     protected function validateCredentials($token)
     {
-        if (! $token || $token->client->firstParty()) {
+        if (! $token) {
             throw new AuthenticationException;
         }
     }

--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -16,7 +16,7 @@ class CheckClientCredentialsForAnyScope extends CheckCredentials
      */
     protected function validateCredentials($token)
     {
-        if (! $token || $token->client->firstParty()) {
+        if (! $token) {
             throw new AuthenticationException;
         }
     }

--- a/tests/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/CheckClientCredentialsForAnyScopeTest.php
@@ -137,35 +137,4 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
             return 'response';
         }, 'baz', 'notbar');
     }
-
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     */
-    public function test_exception_is_thrown_if_token_belongs_to_first_party_client()
-    {
-        $resourceServer = m::mock(ResourceServer::class);
-        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
-        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
-        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
-
-        $client = m::mock(Client::class);
-        $client->shouldReceive('firstParty')->andReturnTrue();
-
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-
-        $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
-
-        $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
-
-        $request = Request::create('/');
-        $request->headers->set('Authorization', 'Bearer token');
-
-        $response = $middleware->handle($request, function () {
-            return 'response';
-        });
-    }
 }

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -136,35 +136,4 @@ class CheckClientCredentialsTest extends TestCase
             return 'response';
         }, 'foo', 'bar');
     }
-
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     */
-    public function test_exception_is_thrown_if_token_belongs_to_first_party_client()
-    {
-        $resourceServer = m::mock(ResourceServer::class);
-        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
-        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
-        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
-
-        $client = m::mock(Client::class);
-        $client->shouldReceive('firstParty')->andReturnTrue();
-
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-
-        $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
-
-        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
-
-        $request = Request::create('/');
-        $request->headers->set('Authorization', 'Bearer token');
-
-        $response = $middleware->handle($request, function () {
-            return 'response';
-        });
-    }
 }


### PR DESCRIPTION
This commit "revert" Passport to its regular behavior where the client.credentials middleware only determines if the received access token is valid, which is only possible when the client credentials are correct, independently of the type of the client or even the type of the access token itself.

This was already discussed on this issue (#1125).
