### PR TITLE
[9.x] Switch from getKey() to getAuthIdentifier() to match Laravel core

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -107,7 +107,7 @@ class AuthorizationController
      */
     protected function approveRequest($authRequest, $user)
     {
-        $authRequest->setUser(new User($user->getKey()));
+        $authRequest->setUser(new User($user->getAuthIdentifier()));
 
         $authRequest->setAuthorizationApproved(true);
 

--- a/src/Http/Controllers/AuthorizedAccessTokenController.php
+++ b/src/Http/Controllers/AuthorizedAccessTokenController.php
@@ -34,7 +34,7 @@ class AuthorizedAccessTokenController
      */
     public function forUser(Request $request)
     {
-        $tokens = $this->tokenRepository->forUser($request->user()->getKey());
+        $tokens = $this->tokenRepository->forUser($request->user()->getAuthIdentifier());
 
         return $tokens->load('client')->filter(function ($token) {
             return ! $token->client->firstParty() && ! $token->revoked;
@@ -51,7 +51,7 @@ class AuthorizedAccessTokenController
     public function destroy(Request $request, $tokenId)
     {
         $token = $this->tokenRepository->findForUser(
-            $tokenId, $request->user()->getKey()
+            $tokenId, $request->user()->getAuthIdentifier()
         );
 
         if (is_null($token)) {

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -57,7 +57,7 @@ class ClientController
      */
     public function forUser(Request $request)
     {
-        $userId = $request->user()->getKey();
+        $userId = $request->user()->getAuthIdentifier();
 
         return $this->clients->activeForUser($userId)->makeVisible('secret');
     }
@@ -77,7 +77,7 @@ class ClientController
         ])->validate();
 
         return $this->clients->create(
-            $request->user()->getKey(), $request->name, $request->redirect,
+            $request->user()->getAuthIdentifier(), $request->name, $request->redirect,
             false, false, (bool) $request->input('confidential', true)
         )->makeVisible('secret');
     }
@@ -91,7 +91,7 @@ class ClientController
      */
     public function update(Request $request, $clientId)
     {
-        $client = $this->clients->findForUser($clientId, $request->user()->getKey());
+        $client = $this->clients->findForUser($clientId, $request->user()->getAuthIdentifier());
 
         if (! $client) {
             return new Response('', 404);
@@ -116,7 +116,7 @@ class ClientController
      */
     public function destroy(Request $request, $clientId)
     {
-        $client = $this->clients->findForUser($clientId, $request->user()->getKey());
+        $client = $this->clients->findForUser($clientId, $request->user()->getAuthIdentifier());
 
         if (! $client) {
             return new Response('', 404);

--- a/src/Http/Controllers/PersonalAccessTokenController.php
+++ b/src/Http/Controllers/PersonalAccessTokenController.php
@@ -45,7 +45,7 @@ class PersonalAccessTokenController
      */
     public function forUser(Request $request)
     {
-        $tokens = $this->tokenRepository->forUser($request->user()->getKey());
+        $tokens = $this->tokenRepository->forUser($request->user()->getAuthIdentifier());
 
         return $tokens->load('client')->filter(function ($token) {
             return $token->client->personal_access_client && ! $token->revoked;
@@ -80,7 +80,7 @@ class PersonalAccessTokenController
     public function destroy(Request $request, $tokenId)
     {
         $token = $this->tokenRepository->findForUser(
-            $tokenId, $request->user()->getKey()
+            $tokenId, $request->user()->getAuthIdentifier()
         );
 
         if (is_null($token)) {

--- a/src/Http/Controllers/RetrievesAuthRequestFromSession.php
+++ b/src/Http/Controllers/RetrievesAuthRequestFromSession.php
@@ -22,7 +22,7 @@ trait RetrievesAuthRequestFromSession
                 throw new Exception('Authorization request was not present in the session.');
             }
 
-            $authRequest->setUser(new User($request->user()->getKey()));
+            $authRequest->setUser(new User($request->user()->getAuthIdentifier()));
 
             $authRequest->setAuthorizationApproved(true);
         });

--- a/src/Http/Controllers/TransientTokenController.php
+++ b/src/Http/Controllers/TransientTokenController.php
@@ -35,7 +35,7 @@ class TransientTokenController
     public function refresh(Request $request)
     {
         return (new Response('Refreshed.'))->withCookie($this->cookieFactory->make(
-            $request->user()->getKey(), $request->session()->token()
+            $request->user()->getAuthIdentifier(), $request->session()->token()
         ));
     }
 }

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -51,7 +51,7 @@ class CreateFreshApiToken
 
         if ($this->shouldReceiveFreshToken($request, $response)) {
             $response->withCookie($this->cookieFactory->make(
-                $request->user($this->guard)->getKey(), $request->session()->token()
+                $request->user($this->guard)->getAuthIdentifier(), $request->session()->token()
             ));
         }
 

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -61,7 +61,7 @@ class TokenRepository
     public function getValidToken($user, $client)
     {
         return $client->tokens()
-                    ->whereUserId($user->getKey())
+                    ->whereUserId($user->getAuthIdentifier())
                     ->where('revoked', 0)
                     ->where('expires_at', '>', Carbon::now())
                     ->first();
@@ -115,7 +115,7 @@ class TokenRepository
     public function findValidToken($user, $client)
     {
         return $client->tokens()
-                      ->whereUserId($user->getKey())
+                      ->whereUserId($user->getAuthIdentifier())
                       ->where('revoked', 0)
                       ->where('expires_at', '>', Carbon::now())
                       ->latest('expires_at')

--- a/tests/ApproveAuthorizationControllerTest.php
+++ b/tests/ApproveAuthorizationControllerTest.php
@@ -51,7 +51,7 @@ class ApproveAuthorizationControllerFakeUser
 {
     public $id = 1;
 
-    public function getKey()
+    public function getAuthIdentifier()
     {
         return $this->id;
     }

--- a/tests/AuthorizationControllerTest.php
+++ b/tests/AuthorizationControllerTest.php
@@ -113,7 +113,7 @@ class AuthorizationControllerTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('user')->once()->andReturn($user = m::mock());
-        $user->shouldReceive('getKey')->andReturn(1);
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldNotReceive('session');
 
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
@@ -155,7 +155,7 @@ class AuthorizationControllerTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('user')->once()->andReturn($user = m::mock());
-        $user->shouldReceive('getKey')->andReturn(1);
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldNotReceive('session');
 
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);

--- a/tests/AuthorizedAccessTokenControllerTest.php
+++ b/tests/AuthorizedAccessTokenControllerTest.php
@@ -58,7 +58,7 @@ class AuthorizedAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () use ($token1, $token2) {
             $user = m::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -81,7 +81,7 @@ class AuthorizedAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = m::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -99,7 +99,7 @@ class AuthorizedAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = m::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });

--- a/tests/ClientControllerTest.php
+++ b/tests/ClientControllerTest.php
@@ -120,7 +120,7 @@ class ClientControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = m::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -157,7 +157,7 @@ class ClientControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = m::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -183,7 +183,7 @@ class ClientControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = m::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -212,7 +212,7 @@ class ClientControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = m::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -233,7 +233,7 @@ class ClientControllerFakeUser
 {
     public $id = 1;
 
-    public function getKey()
+    public function getAuthIdentifier()
     {
         return $this->id;
     }

--- a/tests/CreateFreshApiTokenTest.php
+++ b/tests/CreateFreshApiTokenTest.php
@@ -29,7 +29,7 @@ class CreateFreshApiTokenTest extends TestCase
 
         $guard = 'guard';
         $user = m::mock()
-            ->shouldReceive('getKey')
+            ->shouldReceive('getAuthIdentifier')
             ->andReturn($userKey = 1)
             ->getMock();
 
@@ -99,7 +99,7 @@ class CreateFreshApiTokenTest extends TestCase
 
         $request->setUserResolver(function () {
             return m::mock()
-                ->shouldReceive('getKey')
+                ->shouldReceive('getAuthIdentifier')
                 ->andReturn(1)
                 ->getMock();
         });

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -160,7 +160,7 @@ class DenyAuthorizationControllerFakeUser
 {
     public $id = 1;
 
-    public function getKey()
+    public function getAuthIdentifier()
     {
         return $this->id;
     }

--- a/tests/PersonalAccessTokenControllerTest.php
+++ b/tests/PersonalAccessTokenControllerTest.php
@@ -38,7 +38,7 @@ class PersonalAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () use ($token1, $token2) {
             $user = m::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -98,7 +98,7 @@ class PersonalAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = m::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });
@@ -120,7 +120,7 @@ class PersonalAccessTokenControllerTest extends TestCase
 
         $request->setUserResolver(function () {
             $user = m::mock();
-            $user->shouldReceive('getKey')->andReturn(1);
+            $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
             return $user;
         });

--- a/tests/TransientTokenControllerTest.php
+++ b/tests/TransientTokenControllerTest.php
@@ -23,7 +23,7 @@ class TransientTokenControllerTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('user')->andReturn($user = m::mock());
-        $user->shouldReceive('getKey')->andReturn(1);
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldReceive('session->token')->andReturn('token');
 
         $controller = new TransientTokenController($cookieFactory);


### PR DESCRIPTION
Switch from getKey to getAuthIdentifier to better match the core and work better with other 3rd party packages. This pull request closes #1006
