### PR TITLE
[8.x] Modify UserRepository to check for 'findAndValidateForPassport' method

### DIFF
--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -38,6 +38,16 @@ class UserRepository implements UserRepositoryInterface
             throw new RuntimeException('Unable to determine authentication model from configuration.');
         }
 
+        if (method_exists($model, 'findAndValidateForPassport')) {
+            $user = (new $model)->findAndValidateForPassport($username, $password);
+
+            if (! $user) {
+                return;
+            }
+
+            return new User($user->getAuthIdentifier());
+        }
+
         if (method_exists($model, 'findForPassport')) {
             $user = (new $model)->findForPassport($username);
         } else {


### PR DESCRIPTION
```php
/**
 * Find the user instance for the given username and validate its password.
 *
 * @param string $username
 * @param string $password
 *
 * @return null|\App\User
 */
public function findAndValidateForPassport($username, $password)
{
    $user = $this->where('username', $username)->first();

    if (! $user) {
        return;
    }

    return Hash::check($password, $user->password);
}
```

This PR updates the UserRepository to check if the `findAndValidateForPassport` method exists on the `User` model. It allows you to combine the existing `findForPassport` and `validateForPassportPasswordGrant` methods.

Why would you want to use this `findAndValidateForPassport` method on your `User` model?

Passport assumes the user with the username always already exists and always uses a traditional password to authenticate. That is not the case in certain applications. For example, if a user authenticates with his phone number and a verification code is received via SMS. You don't want to create that user unless he authenticates with his phone number and the correct verification code. By adding the `findAndValidateForPassport` method, you allow a lot more flexibility in the way you can customize Passport.

An example of how you could use this method:

```php
/**
 * Find the user instance for the given username and validate its password.
 *
 * @param string $username
 * @param string $password
 *
 * @return null|\App\User
 */
public function findAndValidateForPassport($username, $password)
{
    $verificationCode = VerificationCode::where('phone', $username)->first();

    if (! $verificationCode || ! Hash::check($password, $verificationCode->code)) {
        return;
    }

    return static::firstOrCreate(['phone' => $username]);
}
```

_If this PR gets accepted, I will create a PR to update the docs._