### PR TITLE
Allow client credentials secret to be hashed

### DIFF
--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -17,7 +17,7 @@ class CreateOauthClientsTable extends Migration
             $table->increments('id');
             $table->bigInteger('user_id')->index()->nullable();
             $table->string('name');
-            $table->string('secret')->nullable();
+            $table->string('secret', 100)->nullable();
             $table->text('redirect');
             $table->boolean('personal_access_client');
             $table->boolean('password_client');

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -17,7 +17,7 @@ class CreateOauthClientsTable extends Migration
             $table->increments('id');
             $table->bigInteger('user_id')->index()->nullable();
             $table->string('name');
-            $table->string('secret', 100)->nullable();
+            $table->string('secret')->nullable();
             $table->text('redirect');
             $table->boolean('personal_access_client');
             $table->boolean('password_client');

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
-use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Laravel\Passport\ClientRepository as ClientModelRepository;
 use Laravel\Passport\Passport;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
@@ -28,7 +28,7 @@ class ClientRepository implements ClientRepositoryInterface
      * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
      * @return void
      */
-    public function __construct(ClientModelRepository $clients, Hasher $hasher)
+    public function __construct(ClientModelRepository $clients, HasherContract $hasher)
     {
         $this->clients = $clients;
         $this->hasher = $hasher;

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -64,7 +64,7 @@ class ClientRepository implements ClientRepositoryInterface
             return false;
         }
 
-        return ! $record->confidential() || $this->verifySecret($record->secret, (string) $clientSecret);
+        return ! $record->confidential() || $this->verifySecret((string) $clientSecret, $record->secret);
     }
 
     /**
@@ -95,11 +95,11 @@ class ClientRepository implements ClientRepositoryInterface
     }
 
     /**
-     * @param  string  $storedHash
      * @param  string  $clientSecret
+     * @param  string  $storedHash
      * @return bool
      */
-    protected function verifySecret($storedHash, $clientSecret)
+    protected function verifySecret($clientSecret, $storedHash)
     {
         if (Passport::$useHashedClientSecrets) {
             return $this->hasher->check($clientSecret, $storedHash);

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Passport\Bridge;
 
-use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Laravel\Passport\ClientRepository as ClientModelRepository;
 use Laravel\Passport\Passport;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
@@ -17,21 +16,14 @@ class ClientRepository implements ClientRepositoryInterface
     protected $clients;
 
     /**
-     * @var \Illuminate\Contracts\Hashing\Hasher
-     */
-    protected $hasher;
-
-    /**
      * Create a new repository instance.
      *
      * @param  \Laravel\Passport\ClientRepository  $clients
-     * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
      * @return void
      */
-    public function __construct(ClientModelRepository $clients, HasherContract $hasher)
+    public function __construct(ClientModelRepository $clients)
     {
         $this->clients = $clients;
-        $this->hasher = $hasher;
     }
 
     /**
@@ -102,7 +94,7 @@ class ClientRepository implements ClientRepositoryInterface
     protected function verifySecret($clientSecret, $storedHash)
     {
         if (Passport::$useHashedClientSecrets) {
-            return $this->hasher->check($clientSecret, $storedHash);
+            return password_verify($clientSecret, $storedHash);
         }
 
         return hash_equals($storedHash, $clientSecret);

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -94,7 +94,7 @@ class ClientRepository implements ClientRepositoryInterface
     protected function verifySecret($clientSecret, $storedHash)
     {
         if (Passport::$useHashedClientSecrets) {
-            return password_verify($clientSecret, $storedHash);
+            $clientSecret = hash('sha256', $clientSecret);
         }
 
         return hash_equals($storedHash, $clientSecret);

--- a/src/Client.php
+++ b/src/Client.php
@@ -107,7 +107,7 @@ class Client extends Model
             return;
         }
 
-        $this->attributes['secret'] = password_hash($value, CRYPT_SHA256);
+        $this->attributes['secret'] = hash('sha256', $value);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Passport;
 
-use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Database\Eloquent\Model;
 
 class Client extends Model
@@ -108,7 +107,7 @@ class Client extends Model
             return;
         }
 
-        $this->attributes['secret'] = app(HasherContract::class)->make($value);
+        $this->attributes['secret'] = password_hash($value, CRYPT_SHA256);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -82,6 +82,20 @@ class Client extends Model
     }
 
     /**
+     * The temporary non-hashed client secret.
+     *
+     * If you're using hashed client secrets, this value will only be available
+     * once during the request the client was created. Afterwards, it cannot
+     * be retrieved or decrypted anymore.
+     *
+     * @return string|null
+     */
+    public function getPlainSecretAttribute()
+    {
+        return $this->plainSecret;
+    }
+
+    /**
      * @param string|null $value
      */
     public function setSecretAttribute($value)
@@ -95,20 +109,6 @@ class Client extends Model
         }
 
         $this->attributes['secret'] = app(HasherContract::class)->make($value);
-    }
-
-    /**
-     * The temporary non-hashed client secret.
-     *
-     * If you're using hashed client secrets, this value will only be available
-     * once during the request the client was created. Afterwards, it cannot
-     * be retrieved or decrypted anymore.
-     *
-     * @return string|null
-     */
-    public function plainSecret()
-    {
-        return $this->plainSecret;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport;
 
-use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Database\Eloquent\Model;
 
 class Client extends Model
@@ -94,7 +94,7 @@ class Client extends Model
             return;
         }
 
-        $this->attributes['secret'] = app(Hasher::class)->make($value);
+        $this->attributes['secret'] = app(HasherContract::class)->make($value);
     }
 
     /**

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -147,6 +147,13 @@ class Passport
     public static $unserializesCookies = false;
 
     /**
+     *
+     *
+     * @var bool
+     */
+    public static $useHashedClientSecrets = false;
+
+    /**
      * Indicates the scope should inherit its parent scope.
      *
      * @var bool
@@ -633,6 +640,18 @@ class Passport
     public static function ignoreMigrations()
     {
         static::$runsMigrations = false;
+
+        return new static;
+    }
+
+    /**
+     * Configure Passport to hash client credential secrets.
+     *
+     * @return static
+     */
+    public static function useHashedClientSecrets()
+    {
+        static::$useHashedClientSecrets = true;
 
         return new static;
     }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -147,8 +147,6 @@ class Passport
     public static $unserializesCookies = false;
 
     /**
-     *
-     *
      * @var bool
      */
     public static $useHashedClientSecrets = false;

--- a/tests/BridgeClientRepositoryHashedSecretsTest.php
+++ b/tests/BridgeClientRepositoryHashedSecretsTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Passport\Tests;
 
-use Illuminate\Contracts\Hashing\Hasher;
 use Laravel\Passport\Bridge\ClientRepository as BridgeClientRepository;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
@@ -14,49 +13,18 @@ class BridgeClientRepositoryHashedSecretsTest extends BridgeClientRepositoryTest
     {
         Passport::useHashedClientSecrets();
 
-        $hasher = m::mock(Hasher::class);
-
-        $hasher->shouldReceive('check')
-            ->with('secret', 'hashedsecret')
-            ->andReturnTrue();
-
-        $hasher->shouldReceive('check')
-            ->with('wrong-secret', 'hashedsecret')
-            ->andReturnFalse();
-
         $clientModelRepository = m::mock(ClientRepository::class);
         $clientModelRepository->shouldReceive('findActive')
             ->with(1)
             ->andReturn(new BridgeClientRepositoryHashedTestClientStub);
 
         $this->clientModelRepository = $clientModelRepository;
-        $this->hasher = $hasher;
+        $this->repository = new BridgeClientRepository($clientModelRepository);
 
-        $this->repository = new BridgeClientRepository($clientModelRepository, $hasher);
     }
 }
 
-class BridgeClientRepositoryHashedTestClientStub
+class BridgeClientRepositoryHashedTestClientStub extends BridgeClientRepositoryTestClientStub
 {
-    public $name = 'Client';
-
-    public $redirect = 'http://localhost';
-
-    public $secret = 'hashedsecret';
-
-    public $personal_access_client = false;
-
-    public $password_client = false;
-
-    public $grant_types;
-
-    public function firstParty()
-    {
-        return $this->personal_access_client || $this->password_client;
-    }
-
-    public function confidential()
-    {
-        return ! empty($this->secret);
-    }
+    public $secret = '$2y$10$ILY9x.zBwltszjoU21a21.naD6oeN5eMWd00l7P8OMrK5US3ZYeP2';
 }

--- a/tests/BridgeClientRepositoryHashedSecretsTest.php
+++ b/tests/BridgeClientRepositoryHashedSecretsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Passport\Tests;
+
+use Illuminate\Contracts\Hashing\Hasher;
+use Laravel\Passport\Bridge\Client;
+use Laravel\Passport\Bridge\ClientRepository as BridgeClientRepository;
+use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Passport;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class BridgeClientRepositoryHashedSecretsTest extends BridgeClientRepositoryTest
+{
+    protected function setUp(): void
+    {
+        Passport::useHashedClientSecrets();
+
+        $hasher = m::mock(Hasher::class);
+
+        $hasher->shouldReceive('check')
+            ->with('secret', 'hashedsecret')
+            ->andReturnTrue();
+
+        $hasher->shouldReceive('check')
+            ->with('wrong-secret', 'hashedsecret')
+            ->andReturnFalse();
+
+        $clientModelRepository = m::mock(ClientRepository::class);
+        $clientModelRepository->shouldReceive('findActive')
+            ->with(1)
+            ->andReturn(new BridgeClientRepositoryHashedTestClientStub);
+
+        $this->clientModelRepository = $clientModelRepository;
+        $this->repository = new BridgeClientRepository($clientModelRepository, $hasher);
+    }
+}
+
+class BridgeClientRepositoryHashedTestClientStub
+{
+    public $name = 'Client';
+
+    public $redirect = 'http://localhost';
+
+    public $secret = 'hashedsecret';
+
+    public $personal_access_client = false;
+
+    public $password_client = false;
+
+    public $grant_types;
+
+    public function firstParty()
+    {
+        return $this->personal_access_client || $this->password_client;
+    }
+
+    public function confidential()
+    {
+        return ! empty($this->secret);
+    }
+}

--- a/tests/BridgeClientRepositoryHashedSecretsTest.php
+++ b/tests/BridgeClientRepositoryHashedSecretsTest.php
@@ -20,7 +20,6 @@ class BridgeClientRepositoryHashedSecretsTest extends BridgeClientRepositoryTest
 
         $this->clientModelRepository = $clientModelRepository;
         $this->repository = new BridgeClientRepository($clientModelRepository);
-
     }
 }
 

--- a/tests/BridgeClientRepositoryHashedSecretsTest.php
+++ b/tests/BridgeClientRepositoryHashedSecretsTest.php
@@ -25,5 +25,5 @@ class BridgeClientRepositoryHashedSecretsTest extends BridgeClientRepositoryTest
 
 class BridgeClientRepositoryHashedTestClientStub extends BridgeClientRepositoryTestClientStub
 {
-    public $secret = '$2y$10$ILY9x.zBwltszjoU21a21.naD6oeN5eMWd00l7P8OMrK5US3ZYeP2';
+    public $secret = '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b';
 }

--- a/tests/BridgeClientRepositoryHashedSecretsTest.php
+++ b/tests/BridgeClientRepositoryHashedSecretsTest.php
@@ -3,12 +3,10 @@
 namespace Laravel\Passport\Tests;
 
 use Illuminate\Contracts\Hashing\Hasher;
-use Laravel\Passport\Bridge\Client;
 use Laravel\Passport\Bridge\ClientRepository as BridgeClientRepository;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
 
 class BridgeClientRepositoryHashedSecretsTest extends BridgeClientRepositoryTest
 {

--- a/tests/BridgeClientRepositoryHashedSecretsTest.php
+++ b/tests/BridgeClientRepositoryHashedSecretsTest.php
@@ -30,6 +30,8 @@ class BridgeClientRepositoryHashedSecretsTest extends BridgeClientRepositoryTest
             ->andReturn(new BridgeClientRepositoryHashedTestClientStub);
 
         $this->clientModelRepository = $clientModelRepository;
+        $this->hasher = $hasher;
+
         $this->repository = new BridgeClientRepository($clientModelRepository, $hasher);
     }
 }

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Tests;
 
+use Illuminate\Contracts\Hashing\Hasher;
 use Laravel\Passport\Bridge\Client;
 use Laravel\Passport\Bridge\ClientRepository as BridgeClientRepository;
 use Laravel\Passport\ClientRepository;
@@ -22,13 +23,15 @@ class BridgeClientRepositoryTest extends TestCase
 
     protected function setUp(): void
     {
+        $hasher = m::mock(Hasher::class);
+
         $clientModelRepository = m::mock(ClientRepository::class);
         $clientModelRepository->shouldReceive('findActive')
             ->with(1)
             ->andReturn(new BridgeClientRepositoryTestClientStub);
 
         $this->clientModelRepository = $clientModelRepository;
-        $this->repository = new BridgeClientRepository($clientModelRepository);
+        $this->repository = new BridgeClientRepository($clientModelRepository, $hasher);
     }
 
     protected function tearDown(): void

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Passport\Tests;
 
-use Illuminate\Contracts\Hashing\Hasher;
 use Laravel\Passport\Bridge\Client;
 use Laravel\Passport\Bridge\ClientRepository as BridgeClientRepository;
 use Laravel\Passport\ClientRepository;
@@ -31,16 +30,13 @@ class BridgeClientRepositoryTest extends TestCase
     {
         Passport::$useHashedClientSecrets = false;
 
-        $hasher = m::mock(Hasher::class);
-
         $clientModelRepository = m::mock(ClientRepository::class);
         $clientModelRepository->shouldReceive('findActive')
             ->with(1)
             ->andReturn(new BridgeClientRepositoryTestClientStub);
 
         $this->clientModelRepository = $clientModelRepository;
-        $this->hasher = $hasher;
-        $this->repository = new BridgeClientRepository($clientModelRepository, $hasher);
+        $this->repository = new BridgeClientRepository($clientModelRepository);
     }
 
     protected function tearDown(): void

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Hashing\Hasher;
 use Laravel\Passport\Bridge\Client;
 use Laravel\Passport\Bridge\ClientRepository as BridgeClientRepository;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Passport;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -17,12 +18,19 @@ class BridgeClientRepositoryTest extends TestCase
     protected $clientModelRepository;
 
     /**
+     * @var \Illuminate\Contracts\Hashing\Hasher
+     */
+    protected $hasher;
+
+    /**
      * @var \Laravel\Passport\Bridge\ClientRepository
      */
     protected $repository;
 
     protected function setUp(): void
     {
+        Passport::$useHashedClientSecrets = false;
+
         $hasher = m::mock(Hasher::class);
 
         $clientModelRepository = m::mock(ClientRepository::class);
@@ -31,6 +39,7 @@ class BridgeClientRepositoryTest extends TestCase
             ->andReturn(new BridgeClientRepositoryTestClientStub);
 
         $this->clientModelRepository = $clientModelRepository;
+        $this->hasher = $hasher;
         $this->repository = new BridgeClientRepository($clientModelRepository, $hasher);
     }
 

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -14,12 +14,12 @@ class BridgeClientRepositoryTest extends TestCase
     /**
      * @var \Laravel\Passport\ClientRepository
      */
-    private $clientModelRepository;
+    protected $clientModelRepository;
 
     /**
      * @var \Laravel\Passport\Bridge\ClientRepository
      */
-    private $repository;
+    protected $repository;
 
     protected function setUp(): void
     {

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -17,11 +17,6 @@ class BridgeClientRepositoryTest extends TestCase
     protected $clientModelRepository;
 
     /**
-     * @var \Illuminate\Contracts\Hashing\Hasher
-     */
-    protected $hasher;
-
-    /**
      * @var \Laravel\Passport\Bridge\ClientRepository
      */
     protected $repository;


### PR DESCRIPTION
A part of the discussion in #14 was about having client credentials secrets securely stored in the database. While encrypting this value when storing and decrypting when retrieving would be ok to do, it doesn't provide any real value as it can be easily decrypted if the attacker already has access to the application.

Another, more viable option was to treat the secret like a user password and hash it. It's not necessary to know the actual value when authenticating, so it doesn't need to be stored in plaintext or have the ability to be decrypted. This increases the security of the API by removing the ability for attackers, abusive users, or other parties to get a hold of those secrets (that sometimes give access to critical API endpoints).

This PR introduces a lightweight, optional way of enabling hashed client secrets for existing or future applications using Laravel Passport.

In the boot method of your service provider:

```php
Passport::useHashedClientSecrets();
```

### Showing the secret

The main downside of this feature is that, with it enabled, the developer will only have one chance to show the secret to the user (unless they manually keep track of it). During the HTTP request the OAuth client was created in, it will have the plaintext secret set on the client's `$client->plain_secret` field. When subsequently retrieving the client, it will be `null`.

Towards the user, it's more secure to not have API secrets viewable, just like you wouldn't have user passwords shown on their detail page or profile "just in case they forgot".

### Impact

By mainly changing the way the secret is verified in `\Laravel\Passport\Bridge\ClientRepository`, it enables hashed secrets throughout the entire flow. So besides the user-side and upgrade flow, there isn't really a big impact.

### Upgrading

For existing applications that want to make use of hashed secrets, enabling the option will break their authentication flow. Therefore they need to enable the flag, add a migration that removes the length limit on the `secret` field, and hash their secrets.

For the latter, I'd suggest a migration that both removes the length limit and converts the plaintext secrets to hashed secrets. Note that this would be a **one-time action** and could not be undone, as the secrets will the irreversibly hashed.

### Tests

I've opted to extend the existing test since the tests are identical, but the setup is different. This allows you to only maintain one test and have the other follow the lead of its parent. I didn't add tests for the client model, etc, as it seems some parts are not tested? I can add more tests if needed.

One remark here is that I do get a lot of PHPUnit 9.x deprecation warnings (I'm on PHP 7.4), but all tests pass.