### PR TITLE
Allow access to HTTP response status code on OAuthServerException.

### DIFF
--- a/src/Exceptions/OAuthServerException.php
+++ b/src/Exceptions/OAuthServerException.php
@@ -45,7 +45,7 @@ class OAuthServerException extends Exception
      *
      * @return int
      */
-    public function statusCode()
+    public function getStatusCode()
     {
         return $this->response->getStatusCode();
     }

--- a/src/Exceptions/OAuthServerException.php
+++ b/src/Exceptions/OAuthServerException.php
@@ -39,4 +39,14 @@ class OAuthServerException extends Exception
     {
         return $this->response;
     }
+
+    /**
+     * Get HTTP response status code.
+     *
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->response->getStatusCode();
+    }
 }

--- a/src/Exceptions/OAuthServerException.php
+++ b/src/Exceptions/OAuthServerException.php
@@ -41,11 +41,11 @@ class OAuthServerException extends Exception
     }
 
     /**
-     * Get HTTP response status code.
+     * Get the HTTP response status code.
      *
      * @return int
      */
-    public function getStatusCode()
+    public function statusCode()
     {
         return $this->response->getStatusCode();
     }

--- a/src/Exceptions/OAuthServerException.php
+++ b/src/Exceptions/OAuthServerException.php
@@ -45,7 +45,7 @@ class OAuthServerException extends Exception
      *
      * @return int
      */
-    public function getStatusCode()
+    public function statusCode()
     {
         return $this->response->getStatusCode();
     }


### PR DESCRIPTION
This would allow custom exception handler such as `dingo/api` to retrieved proper HTTP status code when rendering exception.

```php
use Laravel\Passport\Exceptions\OAuthServerException;

// ...

tap($this->app->make('api.exception'), static function ($handler) {
    $handler->register(static function (OAuthServerException $e) {
        return abort($e->getStatusCode(), $e->getMessage());
    });
});
```


Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
