### PR TITLE
Use avoid using deprecated PHPUnit annotation.

### DIFF
--- a/tests/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/CheckClientCredentialsForAnyScopeTest.php
@@ -83,11 +83,10 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
         $this->assertEquals('response', $response);
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     */
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
+        $this->expectException('Illuminate\Auth\AuthenticationException');
+
         $tokenRepository = m::mock(TokenRepository::class);
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
@@ -104,11 +103,10 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
         });
     }
 
-    /**
-     * @expectedException \Laravel\Passport\Exceptions\MissingScopeException
-     */
     public function test_exception_is_thrown_if_token_does_not_have_required_scope()
     {
+        $this->expectException('Laravel\Passport\Exceptions\MissingScopeException');
+
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
@@ -138,11 +136,10 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
         }, 'baz', 'notbar');
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     */
     public function test_exception_is_thrown_if_token_belongs_to_first_party_client()
     {
+        $this->expectException('Illuminate\Auth\AuthenticationException');
+
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);

--- a/tests/CheckClientCredentialsTest.php
+++ b/tests/CheckClientCredentialsTest.php
@@ -82,11 +82,10 @@ class CheckClientCredentialsTest extends TestCase
         $this->assertEquals('response', $response);
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     */
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
+        $this->expectException('Illuminate\Auth\AuthenticationException');
+
         $tokenRepository = m::mock(TokenRepository::class);
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
@@ -103,11 +102,10 @@ class CheckClientCredentialsTest extends TestCase
         });
     }
 
-    /**
-     * @expectedException \Laravel\Passport\Exceptions\MissingScopeException
-     */
     public function test_exception_is_thrown_if_token_does_not_have_required_scopes()
     {
+        $this->expectException('Laravel\Passport\Exceptions\MissingScopeException');
+
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
@@ -137,11 +135,10 @@ class CheckClientCredentialsTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     */
     public function test_exception_is_thrown_if_token_belongs_to_first_party_client()
     {
+        $this->expectException('Illuminate\Auth\AuthenticationException');
+
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);

--- a/tests/CheckForAnyScopeTest.php
+++ b/tests/CheckForAnyScopeTest.php
@@ -29,11 +29,10 @@ class CheckForAnyScopeTest extends TestCase
         $this->assertEquals('response', $response);
     }
 
-    /**
-     * @expectedException \Laravel\Passport\Exceptions\MissingScopeException
-     */
     public function test_exception_is_thrown_if_token_doesnt_have_scope()
     {
+        $this->expectException('Laravel\Passport\Exceptions\MissingScopeException');
+
         $middleware = new CheckScopes;
         $request = m::mock();
         $request->shouldReceive('user')->andReturn($user = m::mock());
@@ -46,11 +45,10 @@ class CheckForAnyScopeTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     */
     public function test_exception_is_thrown_if_no_authenticated_user()
     {
+        $this->expectException('Illuminate\Auth\AuthenticationException');
+
         $middleware = new CheckScopes;
         $request = m::mock();
         $request->shouldReceive('user')->once()->andReturn(null);
@@ -60,11 +58,10 @@ class CheckForAnyScopeTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     */
     public function test_exception_is_thrown_if_no_token()
     {
+        $this->expectException('Illuminate\Auth\AuthenticationException');
+
         $middleware = new CheckScopes;
         $request = m::mock();
         $request->shouldReceive('user')->andReturn($user = m::mock());

--- a/tests/CheckScopesTest.php
+++ b/tests/CheckScopesTest.php
@@ -29,11 +29,10 @@ class CheckScopesTest extends TestCase
         $this->assertEquals('response', $response);
     }
 
-    /**
-     * @expectedException \Laravel\Passport\Exceptions\MissingScopeException
-     */
     public function test_exception_is_thrown_if_token_doesnt_have_scope()
     {
+        $this->expectException('Laravel\Passport\Exceptions\MissingScopeException');
+
         $middleware = new CheckScopes;
         $request = m::mock();
         $request->shouldReceive('user')->andReturn($user = m::mock());
@@ -45,11 +44,10 @@ class CheckScopesTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     */
     public function test_exception_is_thrown_if_no_authenticated_user()
     {
+        $this->expectException('Illuminate\Auth\AuthenticationException');
+
         $middleware = new CheckScopes;
         $request = m::mock();
         $request->shouldReceive('user')->once()->andReturn(null);
@@ -59,11 +57,10 @@ class CheckScopesTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    /**
-     * @expectedException \Illuminate\Auth\AuthenticationException
-     */
     public function test_exception_is_thrown_if_no_token()
     {
+        $this->expectException('Illuminate\Auth\AuthenticationException');
+
         $middleware = new CheckScopes;
         $request = m::mock();
         $request->shouldReceive('user')->andReturn($user = m::mock());

--- a/tests/DenyAuthorizationControllerTest.php
+++ b/tests/DenyAuthorizationControllerTest.php
@@ -132,12 +132,11 @@ class DenyAuthorizationControllerTest extends TestCase
         $this->assertEquals('http://localhost?action=some_action&error=access_denied&state=state', $controller->deny($request));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Authorization request was not present in the session.
-     */
     public function test_auth_request_should_exist()
     {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('Authorization request was not present in the session.');
+
         $response = m::mock(ResponseFactory::class);
 
         $controller = new DenyAuthorizationController($response);

--- a/tests/PassportTest.php
+++ b/tests/PassportTest.php
@@ -48,11 +48,10 @@ class PassportTest extends TestCase
         $this->assertInstanceOf(Passport::personalAccessClientModel(), $client);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function test_missing_personal_access_client_is_reported()
     {
+        $this->expectException('RuntimeException');
+
         Passport::usePersonalAccessClientModel(PersonalAccessClientStub::class);
 
         $clientRepository = new ClientRepository;


### PR DESCRIPTION
> The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageRegExp() instead.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
