### PR TITLE
[9.x] Rename `validateForPassportPasswordGrant` to `validateForPassport`

### DIFF
--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -56,8 +56,8 @@ class UserRepository implements UserRepositoryInterface
 
         if (! $user) {
             return;
-        } elseif (method_exists($user, 'validateForPassportPasswordGrant')) {
-            if (! $user->validateForPassportPasswordGrant($password)) {
+        } elseif (method_exists($user, 'validateForPassport')) {
+            if (! $user->validateForPassport($password)) {
                 return;
             }
         } elseif (! $this->hasher->check($password, $user->getAuthPassword())) {


### PR DESCRIPTION
This PR renames the method `validateForPassportPasswordGrant` to `validateForPassport`.

I think it's a good idea to rename this method for a couple of reasons:

1. There is no real reason to specify 'PasswordGrant' in the method name. There are no other grant types that allow for similar customization.
2. It puts the method name in line with the 2 other Passport customization methods `findForPassport` and `findAndValidateForPassport`.
3. The name of the method is easier to remember.

I know it's a breaking change, but it's a very small one. It requires very little upgrade effort, while in the long run, it makes it clearer for people that want to use those methods.