### PR TITLE
[8.x] Update ClientCommand to support public clients

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -136,8 +136,7 @@ class ClientCommand extends Command
         );
 
         $client = $clients->create(
-			$userId, $name, $redirect, false, false,
-			!$this->option('public')
+            $userId, $name, $redirect, false, false, ! $this->option('public')
         );
 
         $this->info('New client created successfully.');

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -19,7 +19,8 @@ class ClientCommand extends Command
             {--client : Create a client credentials grant client}
             {--name= : The name of the client}
             {--redirect_uri= : The URI to redirect to after authorization }
-            {--user_id= : The user ID the client should be assigned to }';
+            {--user_id= : The user ID the client should be assigned to }
+            {--public : Set client type to public (Only for auth code grant type) }';
 
     /**
      * The console command description.
@@ -135,7 +136,8 @@ class ClientCommand extends Command
         );
 
         $client = $clients->create(
-            $userId, $name, $redirect
+			$userId, $name, $redirect, false, false,
+			!$this->option('public')
         );
 
         $this->info('New client created successfully.');

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -20,7 +20,7 @@ class ClientCommand extends Command
             {--name= : The name of the client}
             {--redirect_uri= : The URI to redirect to after authorization }
             {--user_id= : The user ID the client should be assigned to }
-            {--public : Set client type to public (Only for auth code grant type) }';
+            {--public : Create a public client (Auth code grant type only) }';
 
     /**
      * The console command description.


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Now you can create a public Auth Code Grant Type Client (for PKCE) with `php artisan passport:client --public`. Omitting `--public` will simply generate a confidential Client with a secret.