### PR TITLE
[8.x] Replace deprecated package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "league/oauth2-server": "^8.0",
         "phpseclib/phpseclib": "^2.0",
         "symfony/psr-http-message-bridge": "^1.0",
-        "zendframework/zend-diactoros": "^2.0"
+        "laminas/laminas-diactoros": "^2.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
The Zend package is deprecated. Replaced it with the new one. According to the docs, the package are the same except for the name.

- https://github.com/laminas/laminas-diactoros
- https://github.com/zendframework/zend-diactoros

