### PR TITLE
[8.x] Use Hasher interface instead of HashManager

### DIFF
--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
-use Illuminate\Hashing\HashManager;
+use Illuminate\Contracts\Hashing\Hasher;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use RuntimeException;
@@ -12,19 +12,19 @@ class UserRepository implements UserRepositoryInterface
     /**
      * The hasher implementation.
      *
-     * @var \Illuminate\Hashing\HashManager
+     * @var \Illuminate\Contracts\Hashing\Hasher
      */
     protected $hasher;
 
     /**
      * Create a new repository instance.
      *
-     * @param  \Illuminate\Hashing\HashManager  $hasher
+     * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
      * @return void
      */
-    public function __construct(HashManager $hasher)
+    public function __construct(Hasher $hasher)
     {
-        $this->hasher = $hasher->driver();
+        $this->hasher = $hasher;
     }
 
     /**


### PR DESCRIPTION
Currently there is no way to specify the hasher implementation because the hash manager would always return the default driver implementation. There is also no reason for the entire hash manager being there as we only need the hasher implementation and `$hasher->driver()` which was called in the constructor always returns the default one which is gonna be [injected by default anyway](https://github.com/laravel/framework/blob/v6.9.0/src/Illuminate/Hashing/HashServiceProvider.php#L22).

There are no breaking changes here as [the HashManager also implements the hasher interface](https://github.com/laravel/framework/blob/v6.9.0/src/Illuminate/Hashing/HashManager.php#L8).