### PR TITLE
[8.x] Add tests for Passport::actingAs and Passport::actingAsClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
+        "orchestra/testbench": "^4.4|^5.0",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Illuminate\Support\Facades\Route;
 use League\OAuth2\Server\ResourceServer;
 use Mockery;
+use Psr\Http\Message\ServerRequestInterface;
 
 class Passport
 {
@@ -429,7 +430,7 @@ class Passport
 
         $mock = Mockery::mock(ResourceServer::class);
         $mock->shouldReceive('validateAuthenticatedRequest')
-            ->andReturnUsing(function ($request) use ($token) {
+            ->andReturnUsing(function (ServerRequestInterface $request) use ($token) {
                 return $request->withAttribute('oauth_client_id', $token->client->id)
                     ->withAttribute('oauth_access_token_id', $token->id)
                     ->withAttribute('oauth_scopes', $token->scopes);

--- a/tests/Feature/ActingAsClientTest.php
+++ b/tests/Feature/ActingAsClientTest.php
@@ -1,10 +1,49 @@
 <?php
 
-
 namespace Laravel\Passport\Tests\Feature;
 
+use Illuminate\Contracts\Routing\Registrar;
+use Laravel\Passport\Client;
+use Laravel\Passport\Http\Middleware\CheckClientCredentials;
+use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
+use Laravel\Passport\Passport;
+use Orchestra\Testbench\TestCase;
 
-class ActingAsClientTest
+class ActingAsClientTest extends TestCase
 {
+    public function testActingAsClientWhenTheRouteIsProtectedByCheckClientCredentialsMiddleware()
+    {
+        $this->withoutExceptionHandling();
 
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('/foo', function () {
+            return 'bar';
+        })->middleware(CheckClientCredentials::class);
+
+        Passport::actingAsClient(new Client());
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
+
+    public function testActingAsClientWhenTheRouteIsProtectedByCheckClientCredentialsForAnyScope()
+    {
+        $this->withoutExceptionHandling();
+
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('/foo', function () {
+            return 'bar';
+        })->middleware(CheckClientCredentialsForAnyScope::class . ':testFoo');
+
+        Passport::actingAsClient(new Client(), ['testFoo']);
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
 }

--- a/tests/Feature/ActingAsClientTest.php
+++ b/tests/Feature/ActingAsClientTest.php
@@ -38,7 +38,7 @@ class ActingAsClientTest extends TestCase
 
         $router->get('/foo', function () {
             return 'bar';
-        })->middleware(CheckClientCredentialsForAnyScope::class . ':testFoo');
+        })->middleware(CheckClientCredentialsForAnyScope::class.':testFoo');
 
         Passport::actingAsClient(new Client(), ['testFoo']);
 

--- a/tests/Feature/ActingAsClientTest.php
+++ b/tests/Feature/ActingAsClientTest.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Laravel\Passport\Tests\Feature;
+
+
+class ActingAsClientTest
+{
+
+}

--- a/tests/Feature/ActingAsTest.php
+++ b/tests/Feature/ActingAsTest.php
@@ -38,7 +38,7 @@ class ActingAsTest extends PassportTestCase
 
         $router->get('/foo', function () {
             return 'bar';
-        })->middleware(CheckScopes::class . ':admin,footest');
+        })->middleware(CheckScopes::class.':admin,footest');
 
         Passport::actingAs(new PassportUser(), ['admin', 'footest']);
 
@@ -56,7 +56,7 @@ class ActingAsTest extends PassportTestCase
 
         $router->get('/foo', function () {
             return 'bar';
-        })->middleware(CheckForAnyScope::class . ':admin,footest');
+        })->middleware(CheckForAnyScope::class.':admin,footest');
 
         Passport::actingAs(new PassportUser(), ['footest']);
 

--- a/tests/Feature/ActingAsTest.php
+++ b/tests/Feature/ActingAsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature;
+
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Foundation\Auth\User;
+use Laravel\Passport\HasApiTokens;
+use Laravel\Passport\Http\Middleware\CheckForAnyScope;
+use Laravel\Passport\Http\Middleware\CheckScopes;
+use Laravel\Passport\Passport;
+
+class ActingAsTest extends PassportTestCase
+{
+    public function testActingAsWhenTheRouteIsProtectedByAuthMiddleware()
+    {
+        $this->withoutExceptionHandling();
+
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('/foo', function () {
+            return 'bar';
+        })->middleware('auth:api');
+
+        Passport::actingAs(new PassportUser());
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
+
+    public function testActingAsWhenTheRouteIsProtectedByCheckScopesMiddleware()
+    {
+        $this->withoutExceptionHandling();
+
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('/foo', function () {
+            return 'bar';
+        })->middleware(CheckScopes::class . ':admin,footest');
+
+        Passport::actingAs(new PassportUser(), ['admin', 'footest']);
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
+
+    public function testActingAsWhenTheRouteIsProtectedByCheckForAnyScopeMiddleware()
+    {
+        $this->withoutExceptionHandling();
+
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('/foo', function () {
+            return 'bar';
+        })->middleware(CheckForAnyScope::class . ':admin,footest');
+
+        Passport::actingAs(new PassportUser(), ['footest']);
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
+}
+
+class PassportUser extends User
+{
+    use HasApiTokens;
+
+    protected $table = 'users';
+}

--- a/tests/Feature/PassportTestCase.php
+++ b/tests/Feature/PassportTestCase.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature;
+
+use Illuminate\Contracts\Config\Repository;
+use Laravel\Passport\PassportServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+abstract class PassportTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('passport:keys');
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app->make(Repository::class)->set('auth.guards.api', ['driver' => 'passport', 'provider' => 'users']);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [PassportServiceProvider::class];
+    }
+}

--- a/tests/KeysCommandTest.php
+++ b/tests/KeysCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Tests;
 
+use Illuminate\Container\Container;
 use Laravel\Passport\Console\KeysCommand;
 use Laravel\Passport\Passport;
 use Mockery as m;
@@ -11,6 +12,11 @@ use PHPUnit\Framework\TestCase;
 function custom_path($file = null)
 {
     return __DIR__.DIRECTORY_SEPARATOR.'files'.DIRECTORY_SEPARATOR.$file;
+}
+
+function storage_path($file = null)
+{
+    return __DIR__.DIRECTORY_SEPARATOR.$file;
 }
 
 class KeysCommandTest extends TestCase
@@ -32,6 +38,8 @@ class KeysCommandTest extends TestCase
             ->shouldReceive('info')
             ->with('Encryption keys generated successfully.')
             ->getMock();
+
+        Container::getInstance()->instance('path.storage', storage_path());
 
         $rsa = new RSA();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,8 +1,3 @@
 <?php
 
 require __DIR__.'/../vendor/autoload.php';
-
-function storage_path($file = null)
-{
-    return __DIR__.DIRECTORY_SEPARATOR.$file;
-}


### PR DESCRIPTION
Currently Passport is being only unit tested which is great except that each method where Laravel global helpers are being used cannot be tested at all.

This is the case with the `Passport::actingAsClient` method which uses the `app` helper to resolve and bind stuff with the container. Because of that the method wasn't tested which resulted in it being broken from July (https://github.com/laravel/passport/pull/1040) till November (https://github.com/laravel/passport/pull/1119). The fix was made in November but as there are still no tests for it we won't know if it breaks again in the future.

This PR adds Orchestra Testbench so that we can write full functional tests with the whole framework and I've added tests for the `Passport::actingAs` and `Passport::actingAsClient` methods.

In doing so I had to fix the `storage_path` function conflict because now the foundation `storage_path` function exists.

I've also created an abstract `PassportTestCase` class, it does a few things so that we don't need to do them in almost every test (as they are gonna be needed):

1. It calls the `passport:keys` command which generates the oauth keys (if they don't exist already) - without the keys the `ResourceServer` class throws an exception on instantiation and the `ResourceServer` is probably gonna be instantiated at some point in 95% of the functional tests.
2. It sets the `passport` driver for the auth API guard.
3. It registers the `PassportServiceProvider` without which a bunch of bindings would be missing from the container.

This paves the way for further covering Passport functionality with feature/functional tests.