### PR TITLE
Feature: Purge Command for revoked and/or expired tokens and auth codes

### DIFF
--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Passport\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Laravel\Passport\AuthCode;
+use Laravel\Passport\RefreshToken;
+use Laravel\Passport\Token;
+
+class PurgeCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'passport:purge';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Purges revoked and expired tokens from oauth_access_tokens, oauth_auth_codes and oauth_refresh_tokens';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $now = Carbon::now();
+        Token::where('revoked', 1)->orWhereDate('expires_at', '<', $now)->delete();
+        AuthCode::where('revoked', 1)->orWhereDate('expires_at', '<', $now)->delete();
+        RefreshToken::where('revoked', 1)->orWhereDate('expires_at', '<', $now)->delete();
+    }
+}

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -35,16 +35,16 @@ class PurgeCommand extends Command
         $now = Carbon::now();
         if (
             ($options['revoked'] && $options['expired']) ||
-            (!$options['revoked'] && !$options['expired'])
+            (! $options['revoked'] && ! $options['expired'])
         ) {
             Token::where('revoked', 1)->orWhereDate('expires_at', '<', $now)->delete();
             AuthCode::where('revoked', 1)->orWhereDate('expires_at', '<', $now)->delete();
             RefreshToken::where('revoked', 1)->orWhereDate('expires_at', '<', $now)->delete();
-        } else if ($options['revoked']) {
+        } elseif ($options['revoked']) {
             Token::where('revoked', 1)->delete();
             AuthCode::where('revoked', 1)->delete();
             RefreshToken::where('revoked', 1)->delete();
-        } else if ($options['expired']) {
+        } elseif ($options['expired']) {
             Token::whereDate('expires_at', '<', $now)->delete();
             AuthCode::whereDate('expires_at', '<', $now)->delete();
             RefreshToken::whereDate('expires_at', '<', $now)->delete();

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -55,6 +55,7 @@ class PassportServiceProvider extends ServiceProvider
                 Console\InstallCommand::class,
                 Console\ClientCommand::class,
                 Console\KeysCommand::class,
+                Console\PurgeCommand::class,
             ]);
         }
     }


### PR DESCRIPTION
### What is this feature request for
This adds an artisan command, which allows for users to purge revoked and/or expired tokens and auth codes.

### Why is this feature request created?
With a single command to purge revoked and/or expired tokens, users can quickly schedule this to happen on a regular basis or easily purge them once in a while manually. 

### Usage:
One command is added with two options:

```
php artisan passport:purge` # This will purge both revoked and expired tokens and auth codes
php artisan passport:purge --revoked` # This will only purge revoked tokens and auth codes
php artisan passport:purge --expired` # This will only purge expired tokens and auth codes
php artisan passport:purge --revoked --expired` # This will purge both expired tokens and auth codes
```