### PR TITLE
Added support for API resources

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -17,4 +17,6 @@ return [
 
     'public_key' => env('PASSPORT_PUBLIC_KEY'),
 
+    'json_resource_wrapper' => null, // Set this to a string (usually 'data') to wrap the output
+
 ];

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Http\Resources\ClientResource;
 use Laravel\Passport\Http\Rules\RedirectRule;
 
 class ClientController
@@ -59,7 +60,7 @@ class ClientController
     {
         $userId = $request->user()->getKey();
 
-        return $this->clients->activeForUser($userId)->makeVisible('secret');
+        return ClientResource::collection($this->clients->activeForUser($userId)->makeVisible('secret'));
     }
 
     /**
@@ -76,10 +77,10 @@ class ClientController
             'confidential' => 'boolean',
         ])->validate();
 
-        return $this->clients->create(
+        return new ClientResource($this->clients->create(
             $request->user()->getKey(), $request->name, $request->redirect,
             false, false, (bool) $request->input('confidential', true)
-        )->makeVisible('secret');
+        )->makeVisible('secret'));
     }
 
     /**
@@ -102,9 +103,9 @@ class ClientController
             'redirect' => ['required', $this->redirectRule],
         ])->validate();
 
-        return $this->clients->update(
+        return new ClientResource($this->clients->update(
             $client, $request->name, $request->redirect
-        );
+        ));
     }
 
     /**

--- a/src/Http/Controllers/PersonalAccessTokenController.php
+++ b/src/Http/Controllers/PersonalAccessTokenController.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport\Http\Controllers;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Laravel\Passport\Http\Resources\PersonalAccessTokenResource;
 use Laravel\Passport\Passport;
 use Laravel\Passport\TokenRepository;
 
@@ -47,9 +48,9 @@ class PersonalAccessTokenController
     {
         $tokens = $this->tokenRepository->forUser($request->user()->getKey());
 
-        return $tokens->load('client')->filter(function ($token) {
+        return PersonalAccessTokenResource::collection($tokens->load('client')->filter(function ($token) {
             return $token->client->personal_access_client && ! $token->revoked;
-        })->values();
+        })->values());
     }
 
     /**
@@ -65,9 +66,9 @@ class PersonalAccessTokenController
             'scopes' => 'array|in:'.implode(',', Passport::scopeIds()),
         ])->validate();
 
-        return $request->user()->createToken(
+        return new PersonalAccessTokenResource($request->user()->createToken(
             $request->name, $request->scopes ?: []
-        );
+        ));
     }
 
     /**

--- a/src/Http/Resources/ClientResource.php
+++ b/src/Http/Resources/ClientResource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Passport\Http\Resources;
+
+class ClientResource extends Resource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->resource->toArray();
+    }
+}

--- a/src/Http/Resources/PersonalAccessTokenResource.php
+++ b/src/Http/Resources/PersonalAccessTokenResource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Passport\Http\Resources;
+
+class PersonalAccessTokenResource extends Resource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->resource->toArray();
+    }
+}

--- a/src/Http/Resources/Resource.php
+++ b/src/Http/Resources/Resource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Passport\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+abstract class Resource extends JsonResource
+{
+    /**
+     * Create a new resource instance.
+     *
+     * @param  mixed  $resource
+     * @return void
+     */
+    public function __construct($resource)
+    {
+        parent::__construct($resource);
+
+        self::$wrap = config('passport.json_resource_wrapper');
+    }
+}


### PR DESCRIPTION
I added this nice little addition that returns clients and personal access tokens as API resources. It's backwards compatible since the feature is turned off by default.