### PR TITLE
[8.x] Shouldn't the migrations use bigIncrements and indexes on relationships?

### DIFF
--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -15,8 +15,9 @@ class CreateOauthAuthCodesTable extends Migration
     {
         Schema::create('oauth_auth_codes', function (Blueprint $table) {
             $table->string('id', 100)->primary();
-            $table->bigInteger('user_id');
-            $table->unsignedInteger('client_id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('client_id')->unsigned();
+            $table->foreign('client_id')->references('id')->on('oauth_clients')->onDelete('cascade');
             $table->text('scopes')->nullable();
             $table->boolean('revoked');
             $table->dateTime('expires_at')->nullable();

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -15,8 +15,9 @@ class CreateOauthAccessTokensTable extends Migration
     {
         Schema::create('oauth_access_tokens', function (Blueprint $table) {
             $table->string('id', 100)->primary();
-            $table->bigInteger('user_id')->index()->nullable();
-            $table->unsignedInteger('client_id');
+            $table->bigInteger('user_id')->unsigned()->nullable()->index();
+            $table->bigInteger('client_id')->unsigned();
+            $table->foreign('client_id')->references('id')->on('oauth_clients')->onDelete('cascade');
             $table->string('name')->nullable();
             $table->text('scopes')->nullable();
             $table->boolean('revoked');

--- a/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
@@ -15,7 +15,8 @@ class CreateOauthRefreshTokensTable extends Migration
     {
         Schema::create('oauth_refresh_tokens', function (Blueprint $table) {
             $table->string('id', 100)->primary();
-            $table->string('access_token_id', 100)->index();
+            $table->string('access_token_id', 100);
+            $table->foreign('access_token_id')->references('id')->on('oauth_access_tokens')->onDelete('cascade');
             $table->boolean('revoked');
             $table->dateTime('expires_at')->nullable();
         });

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -14,10 +14,10 @@ class CreateOauthClientsTable extends Migration
     public function up()
     {
         Schema::create('oauth_clients', function (Blueprint $table) {
-            $table->increments('id');
-            $table->bigInteger('user_id')->index()->nullable();
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->nullable()->index();
             $table->string('name');
-            $table->string('secret', 100)->nullable();
+            $table->string('secret', 100);
             $table->text('redirect');
             $table->boolean('personal_access_client');
             $table->boolean('password_client');

--- a/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -14,8 +14,9 @@ class CreateOauthPersonalAccessClientsTable extends Migration
     public function up()
     {
         Schema::create('oauth_personal_access_clients', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('client_id')->index();
+            $table->bigIncrements('id');
+            $table->bigInteger('client_id')->unsigned();
+            $table->foreign('client_id')->references('id')->on('oauth_clients')->onDelete('cascade');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
I was looking through the migrations and saw that some of them seem pretty dated and don't use bigIncrements and indexes on certain possible relationships like the `user_id` field [here][1].

[1]: https://github.com/KieronWiltshire/passport/blob/8.x/database/migrations/2016_06_01_000004_create_oauth_clients_table.php#L18
