### PR TITLE
[8.x] Add a Passport Client factory to Passport publishing

### DIFF
--- a/database/factories/PassportClientFactory.php
+++ b/database/factories/PassportClientFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Faker\Generator as Faker;
+use Laravel\Passport\Client;
+
+$factory->define(Client::class, function (Faker $faker) {
+    return [
+        'user_id' => null,
+        'name' => $faker->company,
+        'secret' => Str::random(40),
+        'redirect' => $faker->url,
+        'personal_access_client' => 0,
+        'password_client' => 0,
+        'revoked' => 0,
+    ];
+});

--- a/database/factories/PassportClientFactory.php
+++ b/database/factories/PassportClientFactory.php
@@ -3,6 +3,7 @@
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use Faker\Generator as Faker;
+use Illuminate\Support\Str;
 use Laravel\Passport\Client;
 
 $factory->define(Client::class, function (Faker $faker) {

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -51,6 +51,10 @@ class PassportServiceProvider extends ServiceProvider
                 __DIR__.'/../resources/js/components' => base_path('resources/js/components/passport'),
             ], 'passport-components');
 
+            $this->publishes([
+                __DIR__.'/../database/factories' => database_path('factories'),
+            ], 'passport-factories');
+
             $this->commands([
                 Console\InstallCommand::class,
                 Console\ClientCommand::class,


### PR DESCRIPTION
In the help documentation for 6.x and up there is reference in the testing section to test Client access with the method `Passport::actingAsClient` and that it takes a Client model created by a factory to be passed in. https://laravel.com/docs/6.x/passport#testing

```php
use Laravel\Passport\Client;
use Laravel\Passport\Passport;

public function testGetOrders()
{
    Passport::actingAsClient(
        factory(Client::class)->create(),
        ['check-status']
    );

    $response = $this->get('/api/orders');

    $response->assertStatus(200);
}
```

Just trying that code out of the box fails since there is no published asset for a `Laravel\Passport\Client` factory. The user is left to make one on their own.
This will publish a Client factory that the user can use for this.

I don't believe it will break any existing features as it is just publishing a factory for the user. It could possibly overwrite one the user has already created if it was the same filename?
I think it will make testing this feature easier for Laravel users as they don't have to reference the `oauth_clients` table and create the factory themselves.

I don't have any tests included as I am not sure how to test the publish functionality and it seems the other publishes are not tested. If you would like me to write some tests please let me know. I could try harder to find a way to test that.

Thank you!