### PR TITLE
[8.x] Fix Foreign key oauth_clients in oauth_auth_codes and oauth_access_t…

### DIFF
--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -20,7 +20,6 @@ class CreateOauthAuthCodesTable extends Migration
             $table->text('scopes')->nullable();
             $table->boolean('revoked');
             $table->dateTime('expires_at')->nullable();
-
         });
     }
 

--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -21,7 +21,6 @@ class CreateOauthAuthCodesTable extends Migration
             $table->boolean('revoked');
             $table->dateTime('expires_at')->nullable();
 
-            $table->foreign('client_id')->references('id')->on('oauth_clients')->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -22,7 +22,6 @@ class CreateOauthAccessTokensTable extends Migration
             $table->boolean('revoked');
             $table->timestamps();
             $table->dateTime('expires_at')->nullable();
-
         });
     }
 

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -23,7 +23,6 @@ class CreateOauthAccessTokensTable extends Migration
             $table->timestamps();
             $table->dateTime('expires_at')->nullable();
 
-            $table->foreign('client_id')->references('id')->on('oauth_clients')->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2020_28_01_000006_add_foreign_key_oauth_clients_in_oauth_auth_codes_table.php
+++ b/database/migrations/2020_28_01_000006_add_foreign_key_oauth_clients_in_oauth_auth_codes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeyOauthClientsInOauthAuthCodesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oauth_auth_codes', function (Blueprint $table) {
+            $table->foreign('client_id')->references('id')->on('oauth_clients')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oauth_auth_codes', function (Blueprint $table) {
+            $table->dropForeign('oauth_auth_codes_client_id_foreign');
+        });
+    }
+}

--- a/database/migrations/2020_28_01_000007_add_foreign_key_oauth_clients_in_oauth_access_tokens_table.php
+++ b/database/migrations/2020_28_01_000007_add_foreign_key_oauth_clients_in_oauth_access_tokens_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeyOauthClientsInOauthAccessTokensTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oauth_access_tokens', function (Blueprint $table) {
+            $table->foreign('client_id')->references('id')->on('oauth_clients')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oauth_access_tokens', function (Blueprint $table) {
+            $table->dropForeign('oauth_access_tokens_client_id_foreign');
+        });
+    }
+}


### PR DESCRIPTION
There is a failure in migration
**2016_06_01_000001_create_oauth_auth_codes_table** and **2016_06_01_000002_create_oauth_access_tokens_table** where a foreign key was created before creating the oauth_clients table, remove it and create two additional migrations where add the foreign keys to their respective tables **oauth_auth_codes** and **oauth_access_tokens**