### PR TITLE
[8.x] Forget session keys on invalid match

### DIFF
--- a/src/Http/Controllers/RetrievesAuthRequestFromSession.php
+++ b/src/Http/Controllers/RetrievesAuthRequestFromSession.php
@@ -20,6 +20,8 @@ trait RetrievesAuthRequestFromSession
     protected function assertValidAuthToken(Request $request)
     {
         if ($request->has('auth_token') && $request->session()->get('authToken') !== $request->get('auth_token')) {
+            $request->session()->forget(['authToken', 'authRequest']);
+
             throw InvalidAuthTokenException::different();
         }
     }


### PR DESCRIPTION
When the auth token doesn't matches it's best to clear the session keys so they can't be tampered with any further.