### PR TITLE
[8.x] Fix resolveInheritedScopes.

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -116,10 +116,11 @@ class Token extends Model
     protected function resolveInheritedScopes($scope)
     {
         $parts = explode(':', $scope);
+        $partsCount = count($parts);
 
         $scopes = [];
 
-        for ($i = 0; $i <= count($parts); $i++) {
+        for ($i = 1; $i <= $partsCount; $i++) {
             $scopes[] = implode(':', array_slice($parts, 0, $i));
         }
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -116,6 +116,7 @@ class Token extends Model
     protected function resolveInheritedScopes($scope)
     {
         $parts = explode(':', $scope);
+
         $partsCount = count($parts);
 
         $scopes = [];

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport\Tests;
 use Laravel\Passport\Passport;
 use Laravel\Passport\Token;
 use PHPUnit\Framework\TestCase;
+use ReflectionObject;
 
 class TokenTest extends TestCase
 {
@@ -57,5 +58,21 @@ class TokenTest extends TestCase
         $this->assertTrue($token->can('user'));
         $this->assertTrue($token->can('something'));
         $this->assertTrue($token->can('admin:webhooks:write'));
+    }
+
+    public function test_token_resolves_inherited_scopes()
+    {
+        $token = new Token;
+
+        $reflector = new ReflectionObject($token);
+        $method = $reflector->getMethod('resolveInheritedScopes');
+        $method->setAccessible(true);
+        $inheritedScopes = $method->invoke($token, 'admin:webhooks:read');
+
+        $this->assertSame([
+            'admin',
+            'admin:webhooks',
+            'admin:webhooks:read',
+        ], $inheritedScopes);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Previously the first element returns by `resolveInheritedScopes` was an empty string.
This PR fixes this.
