### PR TITLE
[8.x] Allow custom routes options

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -177,7 +177,7 @@ class RouteRegistrar
     protected function ensureDefaultOptions(array $options = [])
     {
         $defaultOptions = [
-            'middleware' => ['web', 'auth']
+            'middleware' => ['web', 'auth'],
         ];
 
         return array_merge($defaultOptions, $options);


### PR DESCRIPTION
For now We couldn't provide route options to passport routes 

eg: If I enabled `MustVerifyEmail` in my app but I could not provide `verified` middleware to passport routes.

Now we can provide route options to auth passport routes like this
```
Passport::routes(function($router) {
   $router->all([
      'middleware' => ['web', 'auth', 'verified']
   ]);
});
```

Please verify the changes.