### PR TITLE
[9.x] Initial support for multiple providers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer require "illuminate/contracts=${{ matrix.laravel }}" --prefer-dist --no-interaction --no-suggest
+        run: composer require "illuminate/contracts=${{ matrix.laravel }}" --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -18,6 +18,7 @@ class CreateOauthClientsTable extends Migration
             $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->string('name');
             $table->string('secret', 100)->nullable();
+            $table->string('provider')->nullable();
             $table->text('redirect');
             $table->boolean('personal_access_client');
             $table->boolean('password_client');

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -16,16 +16,21 @@ class Client implements ClientEntityInterface
      */
     protected $identifier;
 
+    /**
+     * The client's provider.
+     *
+     * @var string
+     */
     public $provider;
 
     /**
      * Create a new client instance.
      *
-     * @param  string  $identifier
-     * @param  string  $name
-     * @param  string  $redirectUri
-     * @param  bool  $isConfidential
-     * @return void
+     * @param string $identifier
+     * @param string $name
+     * @param string $redirectUri
+     * @param bool $isConfidential
+     * @param string|null $provider
      */
     public function __construct($identifier, $name, $redirectUri, $isConfidential = false, $provider = null)
     {

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -16,6 +16,8 @@ class Client implements ClientEntityInterface
      */
     protected $identifier;
 
+    public $provider;
+
     /**
      * Create a new client instance.
      *
@@ -25,13 +27,14 @@ class Client implements ClientEntityInterface
      * @param  bool  $isConfidential
      * @return void
      */
-    public function __construct($identifier, $name, $redirectUri, $isConfidential = false)
+    public function __construct($identifier, $name, $redirectUri, $isConfidential = false, $provider = null)
     {
         $this->setIdentifier((string) $identifier);
 
         $this->name = $name;
         $this->isConfidential = $isConfidential;
         $this->redirectUri = explode(',', $redirectUri);
+        $this->provider = $provider;
     }
 
     /**

--- a/src/Bridge/Client.php
+++ b/src/Bridge/Client.php
@@ -26,11 +26,12 @@ class Client implements ClientEntityInterface
     /**
      * Create a new client instance.
      *
-     * @param string $identifier
-     * @param string $name
-     * @param string $redirectUri
-     * @param bool $isConfidential
-     * @param string|null $provider
+     * @param  string  $identifier
+     * @param  string  $name
+     * @param  string  $redirectUri
+     * @param  bool  $isConfidential
+     * @param  string|null  $provider
+     * @return void
      */
     public function __construct($identifier, $name, $redirectUri, $isConfidential = false, $provider = null)
     {

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -37,7 +37,7 @@ class ClientRepository implements ClientRepositoryInterface
         }
 
         return new Client(
-            $clientIdentifier, $record->name, $record->redirect, $record->confidential()
+            $clientIdentifier, $record->name, $record->redirect, $record->confidential(), $record->provider
         );
     }
 

--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -32,7 +32,7 @@ class UserRepository implements UserRepositoryInterface
      */
     public function getUserEntityByUserCredentials($username, $password, $grantType, ClientEntityInterface $clientEntity)
     {
-        $provider = config('auth.guards.api.provider');
+        $provider = $clientEntity->provider ?: config('auth.guards.api.provider');
 
         if (is_null($model = config('auth.providers.'.$provider.'.model'))) {
             throw new RuntimeException('Unable to determine authentication model from configuration.');

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,7 +3,6 @@
 namespace Laravel\Passport;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Auth;
 
 class Client extends Model
 {

--- a/src/Client.php
+++ b/src/Client.php
@@ -49,8 +49,10 @@ class Client extends Model
      */
     public function user()
     {
+        $provider = $this->provider ?: config('auth.guards.api.provider');
+
         return $this->belongsTo(
-            config('auth.providers.'.$this->provider ?: config('auth.guards.api.provider').'.model')
+            config("auth.providers.$provider.model")
         );
     }
 
@@ -107,7 +109,7 @@ class Client extends Model
     /**
      * Get the client's provider.
      *
-     * @return mixed
+     * @return \Illuminate\Contracts\Auth\UserProvider|null
      */
     public function getProvider()
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -51,7 +51,7 @@ class Client extends Model
         $provider = $this->provider ?: config('auth.guards.api.provider');
 
         return $this->belongsTo(
-            config("auth.providers.$provider.model")
+            config("auth.providers.{$provider}.model")
         );
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -105,14 +105,4 @@ class Client extends Model
     {
         return ! empty($this->secret);
     }
-
-    /**
-     * Get the client's provider.
-     *
-     * @return \Illuminate\Contracts\Auth\UserProvider|null
-     */
-    public function getProvider()
-    {
-        return $this->provider ? Auth::createUserProvider($this->provider) : null;
-    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 
 class Client extends Model
 {
@@ -49,7 +50,7 @@ class Client extends Model
     public function user()
     {
         return $this->belongsTo(
-            config('auth.providers.'.config('auth.guards.api.provider').'.model')
+            config('auth.providers.'.$this->provider ?: config('auth.guards.api.provider').'.model')
         );
     }
 
@@ -101,5 +102,15 @@ class Client extends Model
     public function confidential()
     {
         return ! empty($this->secret);
+    }
+
+    /**
+     * Get the client's provider.
+     *
+     * @return mixed
+     */
+    public function getProvider()
+    {
+        return $this->provider ? Auth::createUserProvider($this->provider) : null;
     }
 }

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -101,12 +101,13 @@ class ClientRepository
     /**
      * Store a new client.
      *
-     * @param  int  $userId
-     * @param  string  $name
-     * @param  string  $redirect
-     * @param  bool  $personalAccess
-     * @param  bool  $password
-     * @param  bool  $confidential
+     * @param int $userId
+     * @param string $name
+     * @param string $redirect
+     * @param string|null $provider
+     * @param bool $personalAccess
+     * @param bool $password
+     * @param bool $confidential
      * @return \Laravel\Passport\Client
      */
     public function create($userId, $name, $redirect, $provider = null, $personalAccess = false, $password = false, $confidential = true)
@@ -147,9 +148,10 @@ class ClientRepository
     /**
      * Store a new password grant client.
      *
-     * @param  int  $userId
-     * @param  string  $name
-     * @param  string  $redirect
+     * @param int $userId
+     * @param string $name
+     * @param string $redirect
+     * @param string|null $provider
      * @return \Laravel\Passport\Client
      */
     public function createPasswordGrantClient($userId, $name, $redirect, $provider = null)

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -109,13 +109,14 @@ class ClientRepository
      * @param  bool  $confidential
      * @return \Laravel\Passport\Client
      */
-    public function create($userId, $name, $redirect, $personalAccess = false, $password = false, $confidential = true)
+    public function create($userId, $name, $redirect, $provider = null, $personalAccess = false, $password = false, $confidential = true)
     {
         $client = Passport::client()->forceFill([
             'user_id' => $userId,
             'name' => $name,
             'secret' => ($confidential || $personalAccess) ? Str::random(40) : null,
             'redirect' => $redirect,
+            'provider' => $provider,
             'personal_access_client' => $personalAccess,
             'password_client' => $password,
             'revoked' => false,
@@ -136,7 +137,7 @@ class ClientRepository
      */
     public function createPersonalAccessClient($userId, $name, $redirect)
     {
-        return tap($this->create($userId, $name, $redirect, true), function ($client) {
+        return tap($this->create($userId, $name, $redirect, null, true), function ($client) {
             $accessClient = Passport::personalAccessClient();
             $accessClient->client_id = $client->id;
             $accessClient->save();
@@ -151,9 +152,9 @@ class ClientRepository
      * @param  string  $redirect
      * @return \Laravel\Passport\Client
      */
-    public function createPasswordGrantClient($userId, $name, $redirect)
+    public function createPasswordGrantClient($userId, $name, $redirect, $provider = null)
     {
-        return $this->create($userId, $name, $redirect, false, true);
+        return $this->create($userId, $name, $redirect, $provider, false, true);
     }
 
     /**

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -101,13 +101,13 @@ class ClientRepository
     /**
      * Store a new client.
      *
-     * @param int $userId
-     * @param string $name
-     * @param string $redirect
-     * @param string|null $provider
-     * @param bool $personalAccess
-     * @param bool $password
-     * @param bool $confidential
+     * @param  int  $userId
+     * @param  string  $name
+     * @param  string  $redirect
+     * @param  string|null  $provider
+     * @param  bool  $personalAccess
+     * @param  bool  $password
+     * @param  bool  $confidential
      * @return \Laravel\Passport\Client
      */
     public function create($userId, $name, $redirect, $provider = null, $personalAccess = false, $password = false, $confidential = true)
@@ -148,10 +148,10 @@ class ClientRepository
     /**
      * Store a new password grant client.
      *
-     * @param int $userId
-     * @param string $name
-     * @param string $redirect
-     * @param string|null $provider
+     * @param  int  $userId
+     * @param  string  $name
+     * @param  string  $redirect
+     * @param  string|null  $provider
      * @return \Laravel\Passport\Client
      */
     public function createPasswordGrantClient($userId, $name, $redirect, $provider = null)

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -18,6 +18,7 @@ class ClientCommand extends Command
             {--password : Create a password grant client}
             {--client : Create a client credentials grant client}
             {--name= : The name of the client}
+            {--provider= : The name of the provider}
             {--redirect_uri= : The URI to redirect to after authorization }
             {--user_id= : The user ID the client should be assigned to }
             {--public : Create a public client (Auth code grant type only) }';
@@ -83,8 +84,16 @@ class ClientCommand extends Command
             config('app.name').' Password Grant Client'
         );
 
+        $providers = array_keys(config('auth.providers'));
+
+        $provider = $this->option('provider') ?: $this->choice(
+            'What provider should be used?',
+            $providers,
+            $providers[0]
+        );
+
         $client = $clients->createPasswordGrantClient(
-            null, $name, 'http://localhost'
+            null, $name, 'http://localhost', $provider
         );
 
         $this->info('Password grant client created successfully.');
@@ -136,7 +145,7 @@ class ClientCommand extends Command
         );
 
         $client = $clients->create(
-            $userId, $name, $redirect, false, false, ! $this->option('public')
+            $userId, $name, $redirect, null, false, false, ! $this->option('public')
         );
 
         $this->info('New client created successfully.');

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -89,7 +89,7 @@ class ClientCommand extends Command
         $provider = $this->option('provider') ?: $this->choice(
             'What provider should be used?',
             $providers,
-            $providers[0]
+            in_array('users', $providers) ? 'users' : null
         );
 
         $client = $clients->createPasswordGrantClient(

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -30,6 +30,7 @@ class InstallCommand extends Command
     public function handle()
     {
         $provider = in_array('users', array_keys(config('auth.providers'))) ? 'users' : null;
+
         $this->call('passport:keys', ['--force' => $this->option('force'), '--length' => $this->option('length')]);
         $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client']);
         $this->call('passport:client', ['--password' => true, '--name' => config('app.name').' Password Grant Client', '--provider' => $provider]);

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -31,6 +31,6 @@ class InstallCommand extends Command
     {
         $this->call('passport:keys', ['--force' => $this->option('force'), '--length' => $this->option('length')]);
         $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client']);
-        $this->call('passport:client', ['--password' => true, '--name' => config('app.name').' Password Grant Client']);
+        $this->call('passport:client', ['--password' => true, '--name' => config('app.name').' Password Grant Client', '--provider' => array_keys(config('auth.providers'))[0]]);
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -29,8 +29,9 @@ class InstallCommand extends Command
      */
     public function handle()
     {
+        $provider = in_array('users', array_keys(config('auth.providers'))) ? 'users' : null;
         $this->call('passport:keys', ['--force' => $this->option('force'), '--length' => $this->option('length')]);
         $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client']);
-        $this->call('passport:client', ['--password' => true, '--name' => config('app.name').' Password Grant Client', '--provider' => array_keys(config('auth.providers'))[0]]);
+        $this->call('passport:client', ['--password' => true, '--name' => config('app.name').' Password Grant Client', '--provider' => $provider]);
     }
 }

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -98,7 +98,7 @@ class TokenGuard
         }
 
         // Determine if the client's provider and the request's provider have matching models.
-        return $client && $client->getProvider()->getModel() === $this->provider->getModel();
+        return $client->getProvider()->getModel() === $this->provider->getModel();
     }
 
     /**
@@ -150,13 +150,6 @@ class TokenGuard
         if (! $psr = $this->getPsrRequestViaBearerToken($request)) {
             return;
         }
-
-        $client = $this->client($request);
-
-        if ($client && $model = class_exists(config('auth.providers'.$this->client($request)->provider.'.model'))) {
-            $this->provider->setModel($model);
-        }
-
 
         // If the access token is valid we will retrieve the user according to the user ID
         // associated with the token. We will use the provider implementation which may

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -90,7 +90,14 @@ class TokenGuard
      */
     protected function validateProvider(Request $request)
     {
-        return $this->client($request) && $this->client($request)->getProvider() == $this->provider;
+        $client = $this->client($request);
+
+        // If not client provider is defined, fallback to old behavior.
+        if ($client && empty($client->getProvider())) {
+            return true;
+        }
+
+        return $client && $this->provider == $client->getProvider();
     }
 
     /**

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -98,7 +98,7 @@ class TokenGuard
         }
 
         // Determine if the client's provider and the request's provider have matching models.
-        return $client->getProvider()->getModel() === $this->provider->getModel();
+        return $client && $client->getProvider()->getModel() === $this->provider->getModel();
     }
 
     /**
@@ -109,6 +109,10 @@ class TokenGuard
      */
     public function user(Request $request)
     {
+        if (! $this->hasValidProvider($request)) {
+            return;
+        }
+
         if ($request->bearerToken()) {
             return $this->authenticateViaBearerToken($request);
         } elseif ($request->cookie(Passport::cookie())) {

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -97,7 +97,8 @@ class TokenGuard
             return true;
         }
 
-        return $client && $this->provider == $client->getProvider();
+        // Determine if the client's provider and the request's provider have matching models.
+        return $client && $client->getProvider()->getModel() === $this->provider->getModel();
     }
 
     /**
@@ -108,10 +109,6 @@ class TokenGuard
      */
     public function user(Request $request)
     {
-        if (! $this->hasValidProvider($request)) {
-            return;
-        }
-
         if ($request->bearerToken()) {
             return $this->authenticateViaBearerToken($request);
         } elseif ($request->cookie(Passport::cookie())) {
@@ -153,6 +150,13 @@ class TokenGuard
         if (! $psr = $this->getPsrRequestViaBearerToken($request)) {
             return;
         }
+
+        $client = $this->client($request);
+
+        if ($client && $model = class_exists(config('auth.providers'.$this->client($request)->provider.'.model'))) {
+            $this->provider->setModel($model);
+        }
+
 
         // If the access token is valid we will retrieve the user according to the user ID
         // associated with the token. We will use the provider implementation which may

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -83,6 +83,17 @@ class TokenGuard
     }
 
     /**
+     * Determine if the requested provider matches the client's provider.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function validateProvider(Request $request)
+    {
+        return $this->provider == $this->client($request)->getProvider();
+    }
+
+    /**
      * Get the user for the incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -90,6 +101,10 @@ class TokenGuard
      */
     public function user(Request $request)
     {
+        if (!$this->validateProvider($request)) {
+            return;
+        }
+
         if ($request->bearerToken()) {
             return $this->authenticateViaBearerToken($request);
         } elseif ($request->cookie(Passport::cookie())) {

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -94,7 +94,7 @@ class TokenGuard
         $client = $this->client($request);
 
         // If no client provider is defined, fallback to old behavior.
-        if ($client && ! is_null($client->provider)) {
+        if ($client && ! $client->provider) {
             return true;
         }
 

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -101,7 +101,7 @@ class TokenGuard
      */
     public function user(Request $request)
     {
-        if (!$this->validateProvider($request)) {
+        if (! $this->validateProvider($request)) {
             return;
         }
 

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -88,11 +88,11 @@ class TokenGuard
      * @param  \Illuminate\Http\Request  $request
      * @return bool
      */
-    protected function validateProvider(Request $request)
+    protected function hasValidProvider(Request $request)
     {
         $client = $this->client($request);
 
-        // If not client provider is defined, fallback to old behavior.
+        // If no client provider is defined, fallback to old behavior.
         if ($client && empty($client->getProvider())) {
             return true;
         }
@@ -108,7 +108,7 @@ class TokenGuard
      */
     public function user(Request $request)
     {
-        if (! $this->validateProvider($request)) {
+        if (! $this->hasValidProvider($request)) {
             return;
         }
 

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -90,7 +90,7 @@ class TokenGuard
      */
     protected function validateProvider(Request $request)
     {
-        return $this->provider == $this->client($request)->getProvider();
+        return $this->client($request) && $this->client($request)->getProvider() == $this->provider;
     }
 
     /**

--- a/src/Http/Middleware/CheckCredentials.php
+++ b/src/Http/Middleware/CheckCredentials.php
@@ -101,7 +101,7 @@ abstract class CheckCredentials
     abstract protected function validateCredentials($token);
 
     /**
-     * Validate token credentials.
+     * Validate token scopes.
      *
      * @param  \Laravel\Passport\Token  $token
      * @param  array  $scopes

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -276,7 +276,7 @@ class PassportServiceProvider extends ServiceProvider
         return new RequestGuard(function ($request) use ($config) {
             return (new TokenGuard(
                 $this->app->make(ResourceServer::class),
-                Auth::createUserProvider($config['provider']),
+                new PassportUserProvider(Auth::createUserProvider($config['provider']), $config['provider']),
                 $this->app->make(TokenRepository::class),
                 $this->app->make(ClientRepository::class),
                 $this->app->make('encrypter')

--- a/src/PassportUserProvider.php
+++ b/src/PassportUserProvider.php
@@ -45,7 +45,7 @@ class PassportUserProvider implements UserProvider
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function retrieveById($identifier)
     {
@@ -53,7 +53,7 @@ class PassportUserProvider implements UserProvider
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function retrieveByToken($identifier, $token)
     {
@@ -61,7 +61,7 @@ class PassportUserProvider implements UserProvider
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function updateRememberToken(Authenticatable $user, $token)
     {
@@ -69,7 +69,7 @@ class PassportUserProvider implements UserProvider
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function retrieveByCredentials(array $credentials)
     {
@@ -77,7 +77,7 @@ class PassportUserProvider implements UserProvider
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function validateCredentials(Authenticatable $user, array $credentials)
     {

--- a/src/PassportUserProvider.php
+++ b/src/PassportUserProvider.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Laravel\Passport;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\UserProvider;
+
+class PassportUserProvider implements UserProvider
+{
+    /**
+     * The Application UserProvider instance.
+     *
+     * @var \Illuminate\Contracts\Auth\UserProvider
+     */
+    protected $provider;
+
+    /**
+     * The Application UserProvider name.
+     *
+     * @var string
+     */
+    protected $providerName;
+
+    /**
+     * Create a new passport user provider.
+     *
+     * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
+     * @param  string  $providerName
+     * @return void
+     */
+    public function __construct(UserProvider $provider, $providerName)
+    {
+        $this->provider = $provider;
+        $this->providerName = $providerName;
+    }
+
+    /**
+     * Get the UserProvider name.
+     *
+     * @return string
+     */
+    public function getProviderName()
+    {
+        return $this->providerName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieveById($identifier)
+    {
+        return $this->provider->retrieveById($identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieveByToken($identifier, $token)
+    {
+        return $this->provider->retrieveByToken($identifier, $token);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function updateRememberToken(Authenticatable $user, $token)
+    {
+        $this->provider->updateRememberToken($user, $token);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieveByCredentials(array $credentials)
+    {
+        return $this->provider->retrieveByCredentials($credentials);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validateCredentials(Authenticatable $user, array $credentials)
+    {
+        return $this->provider->validateCredentials($user, $credentials);
+    }
+}

--- a/tests/BridgeClientRepositoryTest.php
+++ b/tests/BridgeClientRepositoryTest.php
@@ -191,6 +191,8 @@ class BridgeClientRepositoryTestClientStub
 
     public $password_client = false;
 
+    public $provider = null;
+
     public $grant_types;
 
     public function firstParty()

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -47,6 +47,7 @@ class TokenGuardTest extends TestCase
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(new TokenGuardTestUser);
         $tokens->shouldReceive('find')->once()->with('token')->andReturn($token = m::mock());
         $clients->shouldReceive('revoked')->with(1)->andReturn(false);
+        $clients->shouldReceive('findActive')->with(1)->andReturn(new TokenGuardTestClient);
 
         $user = $guard->user($request);
 
@@ -90,6 +91,10 @@ class TokenGuardTest extends TestCase
         $clients = m::mock(ClientRepository::class);
         $encrypter = m::mock(Encrypter::class);
 
+        $clients->shouldReceive('findActive')
+            ->with(1)
+            ->andReturn(new TokenGuardTestClient);
+
         $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
         $request = Request::create('/');
@@ -97,6 +102,7 @@ class TokenGuardTest extends TestCase
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock());
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(null);
 
         $this->assertNull($guard->user($request));
@@ -109,6 +115,10 @@ class TokenGuardTest extends TestCase
         $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
+
+        $clients->shouldReceive('findActive')
+            ->with(1)
+            ->andReturn(new TokenGuardTestClient);
 
         $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
@@ -137,6 +147,10 @@ class TokenGuardTest extends TestCase
         $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
+
+        $clients->shouldReceive('findActive')
+            ->with(1)
+            ->andReturn(new TokenGuardTestClient);
 
         $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
@@ -270,6 +284,10 @@ class TokenGuardTest extends TestCase
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
+        $clients->shouldReceive('findActive')
+            ->with(1)
+            ->andReturn(new TokenGuardTestClient);
+
         $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter);
 
         Passport::ignoreCsrfToken();
@@ -396,4 +414,8 @@ class TokenGuardTestUser
 
 class TokenGuardTestClient
 {
+    public function getProvider()
+    {
+        return null;
+    }
 }

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -416,6 +416,5 @@ class TokenGuardTestClient
 {
     public function getProvider()
     {
-        return null;
     }
 }

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -414,7 +414,4 @@ class TokenGuardTestUser
 
 class TokenGuardTestClient
 {
-    public function getProvider()
-    {
-    }
 }


### PR DESCRIPTION
This PR adds support to allow passport to use and enforce multiple providers.

### The issue:
Currently, Passport only uses the `UserProvider` passed into it from the `RequestGuard`. This can be problematic if you have more than one provider (config/auth.php) that needs to be authenticated. Since Passport has no knowledge of other `UserProvider` you can end up in situations where the wrong user is authenticated and returned.

### The solution:
This PR adds support to optionally set the provider that should be used on the `Passport\Client`. If a provider is defined on the `Passport\Client`, it will compare it against the `UserProvider` coming in from the `RequestGuard` and return the user if they match. This ensures that the user being returned is coming from the right model. If there is a mismatch, no user is returned, thus leaving you with an unauthenticated request. If no provider is defined on the `Passport\Client` then everything works as it always has.

### Breaking changes:
The only big breaking change here is that this requires a schema change to the `oauth_clients` table to add the `provider` column.