### PR TITLE
Fix 500 Internal Server Error response on validating recently deleted client

### DIFF
--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -17,7 +17,7 @@ class CheckClientCredentials extends CheckCredentials
      */
     protected function validateCredentials($token)
     {
-        if (! $token || $token->client->firstParty()) {
+        if (! $token || ! $token->client || $token->client->firstParty()) {
             throw new AuthenticationException;
         }
     }

--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -17,7 +17,7 @@ class CheckClientCredentialsForAnyScope extends CheckCredentials
      */
     protected function validateCredentials($token)
     {
-        if (! $token || $token->client->firstParty()) {
+        if (! $token || ! $token->client || $token->client->firstParty()) {
             throw new AuthenticationException;
         }
     }


### PR DESCRIPTION
**Description:**
Passport returns _500 Internal Server Error_ response on validating recently deleted client.

**Steps To Reproduce:**
1. Issue client credentials grant token
2. Request a token using _oauth/token_ endpoint
3. Delete client from _oauth_clients_ table
4. Send request to any valid api endpoint using Bearer authorization and token from step 2
5. Passport returns _500 (Internal Server Error)_ response instead of _401 (Unauthorized)_ response