### PR TITLE
[8.x] Automatic configuration of client uuids

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -17,4 +17,17 @@ return [
 
     'public_key' => env('PASSPORT_PUBLIC_KEY'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Client UUIDs
+    |--------------------------------------------------------------------------
+    |
+    | By default, Passport uses auto-incrementing primary keys when assigning
+    | IDs to clients. However, if Passport is installed using the provided
+    | --uuids switch, this will be set to "true" and UUIDs will be used.
+    |
+    */
+
+    'client_uuids' => false,
+
 ];

--- a/src/Client.php
+++ b/src/Client.php
@@ -53,7 +53,7 @@ class Client extends Model
 
         static::creating(function ($model) {
             if (config('passport.client_uuids')) {
-                $model->{$model->getKeyName()} = $model->{$model->getKeyName()} ?: (string) Str::uuid();
+                $model->{$model->getKeyName()} = $model->{$model->getKeyName()} ?: (string) Str::orderedUuid();
             }
         });
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -127,7 +127,7 @@ class Client extends Model
      */
     public function getKeyType()
     {
-        return config('passport.client_uuids') ? 'string' : $this->keyType;
+        return Passport::clientUuids() ? 'string' : $this->keyType;
     }
 
     /**
@@ -137,6 +137,6 @@ class Client extends Model
      */
     public function getIncrementing()
     {
-        return config('passport.client_uuids') ? false : $this->incrementing;
+        return Passport::clientUuids() ? false : $this->incrementing;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class Client extends Model
 {
@@ -40,6 +41,22 @@ class Client extends Model
         'password_client' => 'bool',
         'revoked' => 'bool',
     ];
+
+    /**
+     * Bootstrap the model and its traits.
+     *
+     * @return void
+     */
+    public static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (config('passport.client_uuids')) {
+                $model->{$model->getKeyName()} = $model->{$model->getKeyName()} ?: (string) Str::uuid();
+            }
+        });
+    }
 
     /**
      * Get the user that the client belongs to.
@@ -101,5 +118,25 @@ class Client extends Model
     public function confidential()
     {
         return ! empty($this->secret);
+    }
+
+    /**
+     * Get the auto-incrementing key type.
+     *
+     * @return string
+     */
+    public function getKeyType()
+    {
+        return config('passport.client_uuids') ? 'string' : $this->keyType;
+    }
+
+    /**
+     * Get the value indicating whether the IDs are incrementing.
+     *
+     * @return bool
+     */
+    public function getIncrementing()
+    {
+        return config('passport.client_uuids') ? false : $this->incrementing;
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -76,7 +76,7 @@ class InstallCommand extends Command
     {
         file_put_contents(
             $path,
-            str_replace($search, $replace, file_get_contents($path)),
+            str_replace($search, $replace, file_get_contents($path))
         );
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
+use Laravel\Passport\Passport;
 
 class InstallCommand extends Command
 {
@@ -51,6 +52,7 @@ class InstallCommand extends Command
         $this->call('vendor:publish', ['--tag' => 'passport-migrations']);
 
         config(['passport.client_uuids' => true]);
+        Passport::setClientUuids(true);
 
         $this->replaceInFile(config_path('passport.php'), 'false', 'true');
         $this->replaceInFile(database_path('migrations/2016_06_01_000001_create_oauth_auth_codes_table.php'), '$table->unsignedBigInteger(\'client_id\');', '$table->uuid(\'client_id\');');
@@ -61,6 +63,7 @@ class InstallCommand extends Command
         if ($this->confirm('In order to finish configuring client UUIDs, we need to rebuild the Passport database tables. Would you like to rollback and re-run your last migration?')) {
             $this->call('migrate:rollback');
             $this->call('migrate');
+            $this->line('');
         }
     }
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -12,6 +12,7 @@ class InstallCommand extends Command
      * @var string
      */
     protected $signature = 'passport:install
+                            {--uuids : Use UUIDs for all client IDs}
                             {--force : Overwrite keys they already exist}
                             {--length=4096 : The length of the private key}';
 
@@ -30,7 +31,52 @@ class InstallCommand extends Command
     public function handle()
     {
         $this->call('passport:keys', ['--force' => $this->option('force'), '--length' => $this->option('length')]);
+
+        if ($this->option('uuids')) {
+            $this->configureUuids();
+        }
+
         $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client']);
         $this->call('passport:client', ['--password' => true, '--name' => config('app.name').' Password Grant Client']);
+    }
+
+    /**
+     * Configure Passport for client UUIDs.
+     *
+     * @return void
+     */
+    protected function configureUuids()
+    {
+        $this->call('vendor:publish', ['--tag' => 'passport-config']);
+        $this->call('vendor:publish', ['--tag' => 'passport-migrations']);
+
+        config(['passport.client_uuids' => true]);
+
+        $this->replaceInFile(config_path('passport.php'), 'false', 'true');
+        $this->replaceInFile(database_path('migrations/2016_06_01_000001_create_oauth_auth_codes_table.php'), '$table->unsignedBigInteger(\'client_id\');', '$table->uuid(\'client_id\');');
+        $this->replaceInFile(database_path('migrations/2016_06_01_000002_create_oauth_access_tokens_table.php'), '$table->unsignedBigInteger(\'client_id\');', '$table->uuid(\'client_id\');');
+        $this->replaceInFile(database_path('migrations/2016_06_01_000004_create_oauth_clients_table.php'), '$table->bigIncrements(\'id\');', '$table->uuid(\'id\')->primary();');
+        $this->replaceInFile(database_path('migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php'), '$table->unsignedBigInteger(\'client_id\');', '$table->uuid(\'client_id\');');
+
+        if ($this->confirm('In order to finish configuring client UUIDs, we need to rebuild the Passport database tables. Would you like to rollback and re-run your last migration?')) {
+            $this->call('migrate:rollback');
+            $this->call('migrate');
+        }
+    }
+
+    /**
+     * Replace a given string in a given file.
+     *
+     * @param  string  $path
+     * @param  string  $search
+     * @param  string  $replace
+     * @return void
+     */
+    protected function replaceInFile($path, $search, $replace)
+    {
+        file_put_contents(
+            $path,
+            str_replace($search, $replace, file_get_contents($path)),
+        );
     }
 }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -113,6 +113,13 @@ class Passport
     public static $clientModel = 'Laravel\Passport\Client';
 
     /**
+     * Indicates if client's are identified by UUIDs.
+     *
+     * @var bool
+     */
+    public static $clientUuids = false;
+
+    /**
      * The personal access client model class name.
      *
      * @var string
@@ -532,6 +539,27 @@ class Passport
     public static function client()
     {
         return new static::$clientModel;
+    }
+
+    /**
+     * Determine if clients are identified using UUIDs.
+     *
+     * @return bool
+     */
+    public static function clientUuids()
+    {
+        return static::$clientUuids;
+    }
+
+    /**
+     * Specify if clients are identified using UUIDs.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function setClientUuids($value)
+    {
+        static::$clientUuids = $value;
     }
 
     /**

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -75,7 +75,7 @@ class PassportServiceProvider extends ServiceProvider
      */
     protected function registerMigrations()
     {
-        if (Passport::$runsMigrations) {
+        if (Passport::$runsMigrations && ! config('passport.client_uuids')) {
             return $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         }
     }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -89,6 +89,8 @@ class PassportServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/passport.php', 'passport');
 
+        Passport::setClientUuids($this->app->make(Config::class)->get('passport.client_uuids'));
+
         $this->registerAuthorizationServer();
         $this->registerResourceServer();
         $this->registerGuard();

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -89,7 +89,7 @@ class PassportServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/passport.php', 'passport');
 
-        Passport::setClientUuids($this->app->make(Config::class)->get('passport.client_uuids'));
+        Passport::setClientUuids($this->app->make(Config::class)->get('passport.client_uuids', false));
 
         $this->registerAuthorizationServer();
         $this->registerResourceServer();


### PR DESCRIPTION
This PR adds a new `--uuids` flag that can be used when calling `passport:install`. This flag will automatically configure Passport for using UUIDs for client IDs instead of auto-incrementing IDs. This should not be a breaking change.