### PR TITLE
Patch 1

### DIFF
--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -17,7 +17,7 @@ class CheckClientCredentials extends CheckCredentials
      */
     protected function validateCredentials($token)
     {
-        if (! $token || ! $token->client || $token->client->firstParty()) {
+        if (! $token) {
             throw new AuthenticationException;
         }
     }

--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -17,7 +17,7 @@ class CheckClientCredentialsForAnyScope extends CheckCredentials
      */
     protected function validateCredentials($token)
     {
-        if (! $token || ! $token->client || $token->client->firstParty()) {
+        if (! $token) {
             throw new AuthenticationException;
         }
     }


### PR DESCRIPTION
Last december a change was made to allow any valid client :

Based on the theory and official standards of OAuth2: "The Client Credentials grant is used when applications request an access token to access their own resources, not on behalf of a user." (REF1, REF2).

Shouldn't this change be persistant ?

(taylorotwell merged commit on 5 Dec 2019)

Ref
https://github.com/laravel/passport/issues/1125
https://github.com/laravel/passport/pull/1132