### PR TITLE
[9.x] Drop support for old JWT versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "firebase/php-jwt": "^3.0|^4.0|^5.0",
+        "firebase/php-jwt": "^5.0",
         "guzzlehttp/guzzle": "^6.0",
         "illuminate/auth": "^6.0|^7.0",
         "illuminate/console": "^6.0|^7.0",


### PR DESCRIPTION
These old versions aren't needed anymore and the newer v5 has been around for 3 years already.