### PR TITLE
[9.x] Implement passport:hash command

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -162,6 +162,6 @@ class ClientCommand extends Command
     protected function outputClientDetails(Client $client)
     {
         $this->line('<comment>Client ID:</comment> '.$client->id);
-        $this->line('<comment>Client secret:</comment> '.$client->secret);
+        $this->line('<comment>Client secret:</comment> '.$client->plainSecret);
     }
 }

--- a/src/Console/HashCommand.php
+++ b/src/Console/HashCommand.php
@@ -3,7 +3,6 @@
 namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Str;
 use Laravel\Passport\Passport;
 
 class HashCommand extends Command
@@ -39,7 +38,7 @@ class HashCommand extends Command
             $model = Passport::clientModel();
 
             foreach ((new $model)->whereNotNull('secret')->cursor() as $client) {
-                if (Str::startsWith($client->secret, '$2y')) {
+                if (password_get_info($client->secret)['algo'] === PASSWORD_BCRYPT) {
                     continue;
                 }
 

--- a/src/Console/HashCommand.php
+++ b/src/Console/HashCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 use Laravel\Passport\Passport;
 
 class HashCommand extends Command
@@ -38,6 +39,10 @@ class HashCommand extends Command
             $model = Passport::clientModel();
 
             foreach ((new $model)->whereNotNull('secret')->cursor() as $client) {
+                if (Str::startsWith($client->secret, '$2y')) {
+                    continue;
+                }
+
                 $client->timestamps = false;
 
                 $client->forceFill([

--- a/src/Console/HashCommand.php
+++ b/src/Console/HashCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Laravel\Passport\Console;
+
+use Illuminate\Console\Command;
+use Laravel\Passport\Passport;
+
+class HashCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'passport:hash';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Hash all of the existing secrets in the clients table';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! Passport::$hashesClientSecrets) {
+            $this->warn("Warning! You haven't enabled client hashing yet in your AppServiceProvider.");
+
+            return;
+        }
+
+        if ($this->confirm('Are you sure you want to hash ALL client secrets? This cannot be undone.')) {
+            $model = Passport::clientModel();
+
+            foreach ((new $model)->whereNotNull('secret')->cursor() as $client) {
+                $client->timestamps = false;
+
+                $client->forceFill([
+                    'secret' => password_hash($client->secret, PASSWORD_BCRYPT),
+                ])->save();
+            }
+
+            $this->info('All OAuth client secrets were successfully hashed.');
+        }
+    }
+}

--- a/src/Console/HashCommand.php
+++ b/src/Console/HashCommand.php
@@ -29,12 +29,12 @@ class HashCommand extends Command
     public function handle()
     {
         if (! Passport::$hashesClientSecrets) {
-            $this->warn("Warning! You haven't enabled client hashing yet in your AppServiceProvider.");
+            $this->warn("Please enable client hashing yet in your AppServiceProvider before continuning.");
 
             return;
         }
 
-        if ($this->confirm('Are you sure you want to hash ALL client secrets? This cannot be undone.')) {
+        if ($this->confirm('Are you sure you want to hash all client secrets? This cannot be undone.')) {
             $model = Passport::clientModel();
 
             foreach ((new $model)->whereNotNull('secret')->cursor() as $client) {
@@ -49,7 +49,7 @@ class HashCommand extends Command
                 ])->save();
             }
 
-            $this->info('All OAuth client secrets were successfully hashed.');
+            $this->info('All client secrets were successfully hashed.');
         }
     }
 }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -62,6 +62,7 @@ class PassportServiceProvider extends ServiceProvider
             $this->commands([
                 Console\InstallCommand::class,
                 Console\ClientCommand::class,
+                Console\HashCommand::class,
                 Console\KeysCommand::class,
                 Console\PurgeCommand::class,
             ]);


### PR DESCRIPTION
This is a PoC for a `passport:hash` command to help ease the migration to hashed client secrets. Follow-up for https://github.com/laravel/passport/pull/1145

I've added a confirmation to the command to be safe. And I've added a check to validate if the password is already hashed.

This PR also fixes a small regression where the plainSecret wasn't shown after creating a client with the `passport:install` command.