### PR TITLE
[9.x] Add force option to hash command

### DIFF
--- a/src/Console/HashCommand.php
+++ b/src/Console/HashCommand.php
@@ -12,7 +12,7 @@ class HashCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'passport:hash';
+    protected $signature = 'passport:hash {--force : Force the operation to run without confirmation prompt}';
 
     /**
      * The console command description.
@@ -34,7 +34,7 @@ class HashCommand extends Command
             return;
         }
 
-        if ($this->confirm('Are you sure you want to hash all client secrets? This cannot be undone.')) {
+        if ($this->option('force') || $this->confirm('Are you sure you want to hash all client secrets? This cannot be undone.')) {
             $model = Passport::clientModel();
 
             foreach ((new $model)->whereNotNull('secret')->cursor() as $client) {


### PR DESCRIPTION
This adds the force option (--force) to the passport:hash command. In environments such as Vapor where users are unable to interact with the terminal, this gives the ability to override the verification prompt and force the command to run.

Closes #1250 