### PR TITLE
[9.x] Allow to change Models database connection

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -46,4 +46,21 @@ return [
         'secret' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Passport Storage Driver
+    |--------------------------------------------------------------------------
+    |
+    | This configuration options determines the storage driver that will
+    | be used to store Passport's data. In addition, you may set any
+    | custom options as needed by the particular driver you choose.
+    |
+    */
+
+    'storage' => [
+        'database' => [
+            'connection' => env('DB_CONNECTION', 'mysql'),
+        ],
+    ],
+
 ];

--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -7,13 +7,40 @@ use Illuminate\Support\Facades\Schema;
 class CreateOauthAuthCodesTable extends Migration
 {
     /**
+     * The database schema.
+     *
+     * @var \Illuminate\Database\Schema\Builder
+     */
+    protected $schema;
+
+    /**
+     * Create a new migration instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->schema = Schema::connection($this->getConnection());
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return config('passport.storage.database.connection');
+    }
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('oauth_auth_codes', function (Blueprint $table) {
+        $this->schema->create('oauth_auth_codes', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->unsignedBigInteger('user_id')->index();
             $table->unsignedBigInteger('client_id');
@@ -30,6 +57,6 @@ class CreateOauthAuthCodesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('oauth_auth_codes');
+        $this->schema->dropIfExists('oauth_auth_codes');
     }
 }

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -7,13 +7,40 @@ use Illuminate\Support\Facades\Schema;
 class CreateOauthAccessTokensTable extends Migration
 {
     /**
+     * The database schema.
+     *
+     * @var \Illuminate\Database\Schema\Builder
+     */
+    protected $schema;
+
+    /**
+     * Create a new migration instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->schema = Schema::connection($this->getConnection());
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return config('passport.storage.database.connection');
+    }
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('oauth_access_tokens', function (Blueprint $table) {
+        $this->schema->create('oauth_access_tokens', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->unsignedBigInteger('client_id');
@@ -32,6 +59,6 @@ class CreateOauthAccessTokensTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('oauth_access_tokens');
+        $this->schema->dropIfExists('oauth_access_tokens');
     }
 }

--- a/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
@@ -7,13 +7,40 @@ use Illuminate\Support\Facades\Schema;
 class CreateOauthRefreshTokensTable extends Migration
 {
     /**
+     * The database schema.
+     *
+     * @var \Illuminate\Database\Schema\Builder
+     */
+    protected $schema;
+
+    /**
+     * Create a new migration instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->schema = Schema::connection($this->getConnection());
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return config('passport.storage.database.connection');
+    }
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('oauth_refresh_tokens', function (Blueprint $table) {
+        $this->schema->create('oauth_refresh_tokens', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->string('access_token_id', 100);
             $table->boolean('revoked');
@@ -28,6 +55,6 @@ class CreateOauthRefreshTokensTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('oauth_refresh_tokens');
+        $this->schema->dropIfExists('oauth_refresh_tokens');
     }
 }

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -7,13 +7,40 @@ use Illuminate\Support\Facades\Schema;
 class CreateOauthClientsTable extends Migration
 {
     /**
+     * The database schema.
+     *
+     * @var \Illuminate\Database\Schema\Builder
+     */
+    protected $schema;
+
+    /**
+     * Create a new migration instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->schema = Schema::connection($this->getConnection());
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return config('passport.storage.database.connection');
+    }
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('oauth_clients', function (Blueprint $table) {
+        $this->schema->create('oauth_clients', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->string('name');
@@ -34,6 +61,6 @@ class CreateOauthClientsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('oauth_clients');
+        $this->schema->dropIfExists('oauth_clients');
     }
 }

--- a/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -7,13 +7,40 @@ use Illuminate\Support\Facades\Schema;
 class CreateOauthPersonalAccessClientsTable extends Migration
 {
     /**
+     * The database schema.
+     *
+     * @var \Illuminate\Database\Schema\Builder
+     */
+    protected $schema;
+
+    /**
+     * Create a new migration instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->schema = Schema::connection($this->getConnection());
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return config('passport.storage.database.connection');
+    }
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('oauth_personal_access_clients', function (Blueprint $table) {
+        $this->schema->create('oauth_personal_access_clients', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('client_id');
             $table->timestamps();
@@ -27,6 +54,6 @@ class CreateOauthPersonalAccessClientsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('oauth_personal_access_clients');
+        $this->schema->dropIfExists('oauth_personal_access_clients');
     }
 }

--- a/src/AuthCode.php
+++ b/src/AuthCode.php
@@ -60,6 +60,16 @@ class AuthCode extends Model
     protected $keyType = 'string';
 
     /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return config('passport.storage.database.connection') ?? $this->connection;
+    }
+
+    /**
      * Get the client that owns the authentication code.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/Client.php
+++ b/src/Client.php
@@ -66,6 +66,16 @@ class Client extends Model
     }
 
     /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return config('passport.storage.database.connection') ?? $this->connection;
+    }
+
+    /**
      * Get the user that the client belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/PersonalAccessClient.php
+++ b/src/PersonalAccessClient.php
@@ -21,6 +21,16 @@ class PersonalAccessClient extends Model
     protected $guarded = [];
 
     /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return config('passport.storage.database.connection') ?? $this->connection;
+    }
+
+    /**
      * Get all of the authentication codes for the client.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -60,6 +60,16 @@ class RefreshToken extends Model
     public $timestamps = false;
 
     /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return config('passport.storage.database.connection') ?? $this->connection;
+    }
+
+    /**
      * Get the access token that the refresh token belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/Token.php
+++ b/src/Token.php
@@ -61,6 +61,16 @@ class Token extends Model
     public $timestamps = false;
 
     /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return config('passport.storage.database.connection') ?? $this->connection;
+    }
+
+    /**
      * Get the client that the token belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/tests/Feature/PassportTestCase.php
+++ b/tests/Feature/PassportTestCase.php
@@ -39,6 +39,8 @@ abstract class PassportTestCase extends TestCase
 
         $app['config']->set('database.default', 'testbench');
 
+        $app['config']->set('passport.storage.database.connection', 'testbench');
+
         $app['config']->set('database.connections.testbench', [
             'driver'   => 'sqlite',
             'database' => ':memory:',


### PR DESCRIPTION
This PR introduces configuration for model connection. It is working the same way as [Laravel Telescope Connection Config](https://github.com/laravel/telescope/blob/3.x/config/telescope.php#L47-L52).

This required when your database with OAuth server is working not on default connection.

Not a breaking change because models use `$connection` property as a fallback value.