### PR TITLE
[9.x] Fix personal access token secrets

### DIFF
--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -60,7 +60,7 @@ class ClientRepository implements ClientRepositoryInterface
             return false;
         }
 
-        return ! $record->confidential() || $this->verifySecret((string) $clientSecret, $record->secret);
+        return ! $record->confidential() || $this->verifySecret((string) $clientSecret, $record->secret, $grantType);
     }
 
     /**
@@ -95,11 +95,12 @@ class ClientRepository implements ClientRepositoryInterface
      *
      * @param  string  $clientSecret
      * @param  string  $storedHash
+     * @param  string  $grantType
      * @return bool
      */
-    protected function verifySecret($clientSecret, $storedHash)
+    protected function verifySecret($clientSecret, $storedHash, $grantType)
     {
-        return Passport::$hashesClientSecrets
+        return Passport::$hashesClientSecrets && $grantType !== 'personal_access'
                     ? password_verify($clientSecret, $storedHash)
                     : hash_equals($storedHash, $clientSecret);
     }

--- a/tests/BridgeClientRepositoryHashedSecretsTest.php
+++ b/tests/BridgeClientRepositoryHashedSecretsTest.php
@@ -21,6 +21,14 @@ class BridgeClientRepositoryHashedSecretsTest extends BridgeClientRepositoryTest
         $this->clientModelRepository = $clientModelRepository;
         $this->repository = new BridgeClientRepository($clientModelRepository);
     }
+
+    public function test_personal_access_grant_is_permitted()
+    {
+        $client = $this->clientModelRepository->findActive(1);
+        $client->personal_access_client = true;
+
+        $this->assertTrue($this->repository->validateClient(1, $client->secret, 'personal_access'));
+    }
 }
 
 class BridgeClientRepositoryHashedTestClientStub extends BridgeClientRepositoryTestClientStub


### PR DESCRIPTION
**Update:** I've sent an alternative PR for this here: https://github.com/laravel/passport/pull/1260

---

This PR fixes issuing access tokens using personal access clients when secret hashing is enabled. Unfortunately this will undo the hashing behavior (but only for personal access clients) and simply compare secrets with each other like before. 

Fixes https://github.com/laravel/passport/issues/1252