### PR TITLE
[9.x] Implement secret modal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ## General Notes
 
-In general, every time you update Passport, it's best that you re-publish and re-compile the Vue assets if you're using them:
+After updating Passport, you should always re-publish and re-compile the Vue "quickstart" assets if you're using them:
 
     php artisan vendor:publish --tag=passport-views --force
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade Guide
 
+## General Notes
+
+In general, every time you update Passport, it's best that you re-publish and re-compile the Vue assets if you're using them:
+
+    php artisan vendor:publish --tag=passport-views --force
+
 ## Upgrading To 9.0 From 8.0
 
 ### Support For Multiple Guards

--- a/resources/js/components/Clients.vue
+++ b/resources/js/components/Clients.vue
@@ -224,6 +224,35 @@
                 </div>
             </div>
         </div>
+
+        <!-- Client Secret Modal -->
+        <div class="modal fade" id="modal-client-secret" tabindex="-1" role="dialog">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h4 class="modal-title">
+                            Client Secret
+                        </h4>
+
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    </div>
+
+                    <div class="modal-body">
+                        <p>
+                            Here is your new client secret. This is the only time it will be shown so don't lose it!
+                            You may now use this secret to make API requests.
+                        </p>
+
+                        <input type="text" class="form-control" v-model="clientSecret">
+                    </div>
+
+                    <!-- Modal Actions -->
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -235,6 +264,8 @@
         data() {
             return {
                 clients: [],
+
+                clientSecret: null,
 
                 createForm: {
                     errors: [],
@@ -341,17 +372,17 @@
 
                 axios[method](uri, form)
                     .then(response => {
-                        if (method === 'post') {
-                            this.clients.push(response.data);
-                        } else {
-                            this.getClients();
-                        }
+                        this.getClients();
 
                         form.name = '';
                         form.redirect = '';
                         form.errors = [];
 
                         $(modal).modal('hide');
+
+                        if (response.data.plainSecret) {
+                            this.showClientSecret(response.data.plainSecret);
+                        }
                     })
                     .catch(error => {
                         if (typeof error.response.data === 'object') {
@@ -360,6 +391,15 @@
                             form.errors = ['Something went wrong. Please try again.'];
                         }
                     });
+            },
+
+            /**
+             * Show the given client secret to the user.
+             */
+            showClientSecret(clientSecret) {
+                this.clientSecret = clientSecret;
+
+                $('#modal-client-secret').modal('show');
             },
 
             /**

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -89,7 +89,7 @@ class ClientController
         );
 
         if (Passport::$hashesClientSecrets) {
-            return ['secret' => $client->plainSecret] + $client->toArray();
+            return ['plainSecret' => $client->plainSecret] + $client->toArray();
         }
 
         return $client->makeVisible('secret');
@@ -115,9 +115,15 @@ class ClientController
             'redirect' => ['required', $this->redirectRule],
         ])->validate();
 
-        return $this->clients->update(
+        $client = $this->clients->update(
             $client, $request->name, $request->redirect
         );
+
+        if (Passport::$hashesClientSecrets) {
+            return $client;
+        }
+
+        return $client->makeVisible('secret');
     }
 
     /**

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -115,15 +115,9 @@ class ClientController
             'redirect' => ['required', $this->redirectRule],
         ])->validate();
 
-        $client = $this->clients->update(
+        return $this->clients->update(
             $client, $request->name, $request->redirect
         );
-
-        if (Passport::$hashesClientSecrets) {
-            return $client;
-        }
-
-        return $client->makeVisible('secret');
     }
 
     /**


### PR DESCRIPTION
This PR implements a new modal that explicitly shows the new client secret when hashing is enabled. This is done in the same fashion as the personal access token.

<img width="531" alt="Screenshot 2020-05-08 at 12 17 10" src="https://user-images.githubusercontent.com/594614/81396977-b8986000-9126-11ea-8342-08fa9a30154a.png">

I've also added a note to the upgrade guide that people should re-publish the Vue assets every time they upgrade.