### PR TITLE
[9.x] Warn about one-time-hashed-secret

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport\Console;
 use Illuminate\Console\Command;
 use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Passport;
 
 class ClientCommand extends Command
 {
@@ -161,6 +162,10 @@ class ClientCommand extends Command
      */
     protected function outputClientDetails(Client $client)
     {
+        if (Passport::$hashesClientSecrets) {
+            $this->line('<comment>Here is your new client secret. This is the only time it will be shown so don\'t lose it!</comment>');
+        }
+
         $this->line('<comment>Client ID:</comment> '.$client->id);
         $this->line('<comment>Client secret:</comment> '.$client->plainSecret);
     }

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -164,6 +164,7 @@ class ClientCommand extends Command
     {
         if (Passport::$hashesClientSecrets) {
             $this->line('<comment>Here is your new client secret. This is the only time it will be shown so don\'t lose it!</comment>');
+            $this->line('');
         }
 
         $this->line('<comment>Client ID:</comment> '.$client->id);


### PR DESCRIPTION
It seemed better to explicitly warn about the one-time-secret like in the modal pr I just sent in.

<img width="901" alt="Screenshot 2020-05-08 at 12 51 26" src="https://user-images.githubusercontent.com/594614/81399129-c18b3080-912a-11ea-9d94-845f0349dee6.png">
