### PR TITLE
[9.x] Implement personal access client config

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,22 @@ PR: https://github.com/laravel/passport/pull/1145
 
 Client secrets may now be stored using a Bcrypt hash. However, before enabling this functionality, please consider the following. First, there is no way to reverse the hashing process once you have migrated your existing tokens. Secondly, when hashing client secrets, you will only have one opportunity to display the plain-text value to the user before it is hashed and stored in the database.
 
+#### Personal Access Client
+
+Before you continue, there's a special case for personal access clients. You should set your personal access client ID and unhashed secret in your `.env` file:
+
+    PASSPORT_PERSONAL_ACCESS_CLIENT_ID=
+    PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET=
+
+After this, you should set register them with the `Passport` instance by playing the following calls within the `boot` method of your `AppServiceProvider`:
+
+    Passport::personalAccessClientId(config('passport.personal_access_token.id'));
+    Passport::personalAccessClientSecret(config('passport.personal_access_token.secret'));
+
+Make sure to do this before hashing your secrets using the step below, otherwise they'll be lost forever.
+
+#### Hashing Existing Secrets
+
 You may enable client secret hashing by calling the `Passport::hashClientSecrets()` method within the `boot` method of your `AppServiceProvider`. For convenience, we've included a new Artisan command which you can run to hash all existing client secrets:
 
     php artisan passport:hash

--- a/config/passport.php
+++ b/config/passport.php
@@ -30,4 +30,20 @@ return [
 
     'client_uuids' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Personal Access Client
+    |--------------------------------------------------------------------------
+    |
+    | If you enable client hashing, you should set the personal access
+    | client id and secret in your config file. This way they will be
+    | used when you issue access tokens to your users.
+    |
+    */
+
+    'personal_access_client' => [
+        'id' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_ID'),
+        'secret' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET'),
+    ],
+
 ];

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -22,9 +22,16 @@ class Passport
     /**
      * The personal access token client ID.
      *
-     * @var int
+     * @var int|string
      */
     public static $personalAccessClientId;
+
+    /**
+     * The personal access token client secret.
+     *
+     * @var string
+     */
+    public static $personalAccessClientSecret;
 
     /**
      * The default scope.
@@ -192,12 +199,25 @@ class Passport
     /**
      * Set the client ID that should be used to issue personal access tokens.
      *
-     * @param  int  $clientId
+     * @param  int|string  $clientId
      * @return static
      */
     public static function personalAccessClientId($clientId)
     {
         static::$personalAccessClientId = $clientId;
+
+        return new static;
+    }
+
+    /**
+     * Set the client secret that should be used to issue personal access tokens.
+     *
+     * @param  string  $clientSecret
+     * @return static
+     */
+    public static function personalAccessClientSecret($clientSecret)
+    {
+        static::$personalAccessClientSecret = $clientSecret;
 
         return new static;
     }

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -93,10 +93,12 @@ class PersonalAccessTokenFactory
      */
     protected function createRequest($client, $userId, array $scopes)
     {
+        $secret = Passport::$hashesClientSecrets ? Passport::$personalAccessClientSecret : $client->secret;
+
         return (new ServerRequest)->withParsedBody([
             'grant_type' => 'personal_access',
             'client_id' => $client->id,
-            'client_secret' => $client->secret,
+            'client_secret' => $secret,
             'user_id' => $userId,
             'scope' => implode(' ', $scopes),
         ]);


### PR DESCRIPTION
This is an alternative to https://github.com/laravel/passport/pull/1256 which implements secret hashing in a proper way for personal access clients. This will require some additional upgrade steps for the users unfortunately but at least this allows proper hashing for all client types. _People who have already hashed their personal access client secrets will need to create new personal access clients with new secrets._

Ideally in a follow-up pr for this, we'll get rid of the required `Passport::personalAccessClientId` and `Passport::personalAccessClientSecret` calls so the developer doesn't needs to implement these anymore. But that'll have to be for a next major version release.

Fixes #1252