### PR TITLE
Match name of personal access token methods to config

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -33,8 +33,8 @@ Before you continue, you should set your personal access client ID and unhashed 
 
 Next, you should register these values by placing the following calls within the `boot` method of your `AppServiceProvider`:
 
-    Passport::personalAccessClientId(config('passport.personal_access_token.id'));
-    Passport::personalAccessClientSecret(config('passport.personal_access_token.secret'));
+    Passport::personalAccessClientId(config('passport.personal_access_client.id'));
+    Passport::personalAccessClientSecret(config('passport.personal_access_client.secret'));
 
 > Make sure you follow the instructions above before hashing your secrets. Otherwise, irreversible data loss may occur.
 


### PR DESCRIPTION
The config values included in passport.php don't match those shown in the upgrade guide for personal access tokens in v9.1. This matches the values with those in the config file.