### PR TITLE
[10.x] Change to forceFill

### DIFF
--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -32,7 +32,7 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
             'expires_at' => $authCodeEntity->getExpiryDateTime(),
         ];
 
-        Passport::authCode()->setRawAttributes($attributes)->save();
+        Passport::authCode()->forceFill($attributes)->save();
     }
 
     /**


### PR DESCRIPTION
`Laravel\Passport\Bridge\AuthCodeRepository` currently uses the `setRawAttributes` method to populate a model when saving an auth code.

This PR replaces that with `forceFill`, to ensure that accessors & mutators are executed before saving.

I couldn't find any tests that test this particular bit of code. If I missed them, I'm happy to add tests for it.

 Fixes #908