### PR TITLE
Nonstandard ID in the token's relationship with the user

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -79,7 +79,9 @@ class Token extends Model
     {
         $provider = config('auth.guards.api.provider');
 
-        return $this->belongsTo(config('auth.providers.'.$provider.'.model'));
+        $model = config('auth.providers.'.$provider.'.model');
+
+        return $this->belongsTo($model, 'user_id', (new $model)->getKeyName());
     }
 
     /**


### PR DESCRIPTION
When the user model does not have the primary key as "id" the relationship does not work, I left it in a way where the primary key is dynamic.