### PR TITLE
Fix actingAsClient token relation

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -419,7 +419,8 @@ class Passport
     {
         $token = app(self::tokenModel());
 
-        $token->client = $client;
+        $token->client_id = $client->id;
+        $token->setRelation('client', $client);
         $token->scopes = $scopes;
 
         $mock = Mockery::mock(ResourceServer::class);


### PR DESCRIPTION
In the `Passport::actingAsClient()` method, sets the Token's `client_id` attribute and a proper `client` relationship instead of simply setting a `client` attribute. This mirrors the expected Eloquent behavior.