### PR TITLE
fix double hashing of secrets

### DIFF
--- a/src/Console/HashCommand.php
+++ b/src/Console/HashCommand.php
@@ -45,7 +45,7 @@ class HashCommand extends Command
                 $client->timestamps = false;
 
                 $client->forceFill([
-                    'secret' => password_hash($client->secret, PASSWORD_BCRYPT),
+                    'secret' => $client->secret,
                 ])->save();
             }
 


### PR DESCRIPTION
The artisan command passport:hash does not need to hash the secret before updating the model, as the Client model itself already hashes the secret through a setter, resulting in a double hash and possibly loss of all secrets. This patch removes the hashing from the command.  More info in issue https://github.com/laravel/passport/issues/1270
