### PR TITLE
Use PASSPORT_DB_CONNECTION as a default name for the passport's db connection

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -59,7 +59,7 @@ return [
 
     'storage' => [
         'database' => [
-            'connection' => env('DB_CONNECTION', 'mysql'),
+            'connection' => env('PASSPORT_DB_CONNECTION', env('DB_CONNECTION', 'mysql')),
         ],
     ],
 


### PR DESCRIPTION
Maybe it is not a good idea to use the `DB_CONNECTION` and `mysql` names for the passport db connection?

Maybe, it's better to use the `PASSPORT_` prefix to the passport's db connection, like any other variable in the `config/passport.php`?

For example, I don't have `DB_CONNECTION` env-variable, but have multiple databases and connections whose names are stored in the separated env-variables.
And the env-variable that is called `DB_CONNECTION` will tell nothing, this name is ambiguous, `PASSPORT_DB_CONNECTION` will be much better.

So, I suggest to use `PASSPORT_DB_CONNECTION` as a default name for passport db connection env-variable.
```php
    'storage' => [
        'database' => [
            'connection' => env('PASSPORT_DB_CONNECTION', env('DB_CONNECTION', 'mysql')),
        ],
    ],
```