### PR TITLE
[9.x] Added provider check to cookie authentication

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -225,6 +225,10 @@ class TokenGuard
             return;
         }
 
+        if (! $this->hasValidProvider($request)) {
+            return;
+        }
+
         // If this user exists, we will return this user and attach a "transient" token to
         // the user model. The transient token assumes it has all scopes since the user
         // is physically logged into the application via the application's interface.


### PR DESCRIPTION
This PR attempts to add provider validation for cookie-based authentication. This needs to be tested locally, as it may re-introduce #1243 