### PR TITLE
[9.x] Added Cookie Based Multi Auth

### DIFF
--- a/src/ApiTokenCookieFactory.php
+++ b/src/ApiTokenCookieFactory.php
@@ -50,7 +50,7 @@ class ApiTokenCookieFactory
 
         $expiration = Carbon::now()->addMinutes($config['lifetime']);
 
-        $provider = config("auth.guards.$guard.provider") ?: config("auth.guards.web.provider");
+        $provider = config("auth.guards.$guard.provider") ?: config('auth.guards.web.provider');
 
         return new Cookie(
             Passport::cookie(),

--- a/src/ApiTokenCookieFactory.php
+++ b/src/ApiTokenCookieFactory.php
@@ -44,11 +44,13 @@ class ApiTokenCookieFactory
      * @param  string  $csrfToken
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function make($userId, $csrfToken, $provider)
+    public function make($userId, $csrfToken, $guard = null)
     {
         $config = $this->config->get('session');
 
         $expiration = Carbon::now()->addMinutes($config['lifetime']);
+
+        $provider = config("auth.guards.$guard.provider") ?: config("auth.guards.web.provider");
 
         return new Cookie(
             Passport::cookie(),

--- a/src/ApiTokenCookieFactory.php
+++ b/src/ApiTokenCookieFactory.php
@@ -44,7 +44,7 @@ class ApiTokenCookieFactory
      * @param  string  $csrfToken
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function make($userId, $csrfToken)
+    public function make($userId, $csrfToken, $provider)
     {
         $config = $this->config->get('session');
 
@@ -52,7 +52,7 @@ class ApiTokenCookieFactory
 
         return new Cookie(
             Passport::cookie(),
-            $this->createToken($userId, $csrfToken, $expiration),
+            $this->createToken($userId, $csrfToken, $expiration, $provider),
             $expiration,
             $config['path'],
             $config['domain'],
@@ -71,10 +71,11 @@ class ApiTokenCookieFactory
      * @param  \Carbon\Carbon  $expiration
      * @return string
      */
-    protected function createToken($userId, $csrfToken, Carbon $expiration)
+    protected function createToken($userId, $csrfToken, Carbon $expiration, $provider)
     {
         return JWT::encode([
             'sub' => $userId,
+            'provider' => $provider,
             'csrf' => $csrfToken,
             'expiry' => $expiration->getTimestamp(),
         ], $this->encrypter->getKey());

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -101,6 +101,21 @@ class TokenGuard
     }
 
     /**
+     * Determine if the request has valid provider in Cookie.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function hasValidCookieProvider(Request $request)
+    {
+        if($token = $this->getTokenViaCookie($request)) {
+            return $token['provider'] === $this->provider->getProviderName();
+        }
+
+        return false;
+    }
+
+    /**
      * Get the user for the incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -222,6 +237,10 @@ class TokenGuard
     protected function authenticateViaCookie($request)
     {
         if (! $token = $this->getTokenViaCookie($request)) {
+            return;
+        }
+
+        if(! $this->hasValidCookieProvider($request)) {
             return;
         }
 

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -108,7 +108,7 @@ class TokenGuard
      */
     protected function hasValidCookieProvider(Request $request)
     {
-        if($token = $this->getTokenViaCookie($request)) {
+        if ($token = $this->getTokenViaCookie($request)) {
             return $token['provider'] === $this->provider->getProviderName();
         }
 
@@ -240,7 +240,7 @@ class TokenGuard
             return;
         }
 
-        if(! $this->hasValidCookieProvider($request)) {
+        if (! $this->hasValidCookieProvider($request)) {
             return;
         }
 

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -49,11 +49,9 @@ class CreateFreshApiToken
 
         $response = $next($request);
 
-        $provider = config("auth.guards.$guard.provider") ?: config("auth.guards.web.provider");
-
         if ($this->shouldReceiveFreshToken($request, $response)) {
             $response->withCookie($this->cookieFactory->make(
-                $request->user($this->guard)->getAuthIdentifier(), $request->session()->token(), $provider
+                $request->user($this->guard)->getAuthIdentifier(), $request->session()->token(), $guard
             ));
         }
 

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -49,9 +49,11 @@ class CreateFreshApiToken
 
         $response = $next($request);
 
+        $provider = config("auth.guards.$guard.provider") ?: config("auth.guards.web.provider");
+
         if ($this->shouldReceiveFreshToken($request, $response)) {
             $response->withCookie($this->cookieFactory->make(
-                $request->user($this->guard)->getAuthIdentifier(), $request->session()->token()
+                $request->user($this->guard)->getAuthIdentifier(), $request->session()->token(), $provider
             ));
         }
 

--- a/tests/ApiTokenCookieFactoryTest.php
+++ b/tests/ApiTokenCookieFactoryTest.php
@@ -29,7 +29,7 @@ class ApiTokenCookieFactoryTest extends TestCase
         $encrypter = new Encrypter(str_repeat('a', 16));
         $factory = new ApiTokenCookieFactory($config, $encrypter);
 
-        $cookie = $factory->make(1, 'token');
+        $cookie = $factory->make(1, 'token', 'web');
 
         $this->assertInstanceOf(Cookie::class, $cookie);
     }


### PR DESCRIPTION
Added the multi auth support in the `CreateFreshApiToken` middleware.

> Currently `createToken` is not saving any provider information. But I've added a `provider` key to JWT then it is verifying in the cookie provider on `hasValidCookieProvider` method 

Just you need to add the `CreateFreshApiToken` middleware to the `$routeMiddleware` Like this:
```
protected $routeMiddleware = [
        . . .
        'api_token' => \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
    ];
```

and add to the route middleware
```
Route::group(['middleware' => 'api_token:guard-name'], function() {
    // Your Routes Here
});
```

> It will also work with `web` middlewareGroups as well (This is gonna be web guard by default)
