### PR TITLE
[9.x] Use the Hash facade for hashing secrets to utilize main app's hashing…

### DIFF
--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Bridge;
 
+use Illuminate\Support\Facades\Hash;
 use Laravel\Passport\ClientRepository as ClientModelRepository;
 use Laravel\Passport\Passport;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
@@ -100,7 +101,7 @@ class ClientRepository implements ClientRepositoryInterface
     protected function verifySecret($clientSecret, $storedHash)
     {
         return Passport::$hashesClientSecrets
-                    ? password_verify($clientSecret, $storedHash)
+                    ? Hash::check($clientSecret, $storedHash)
                     : hash_equals($storedHash, $clientSecret);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 class Client extends Model
@@ -127,7 +128,7 @@ class Client extends Model
             return;
         }
 
-        $this->attributes['secret'] = password_hash($value, PASSWORD_BCRYPT);
+        $this->attributes['secret'] = Hash::make($value);
     }
 
     /**


### PR DESCRIPTION
The client secrets are currently being hashed using *bcrypt* via PHP's *password_hash()*  function. Since there's already a nice *Hash* facade built into laravel, this should be used for the following end user benefit. It addresses #1276 
- It will allow the users to configure their hashing algorithm for client secrets via their main app's config.