### PR TITLE
[9.x] Fix maxlength for token names

### DIFF
--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -78,7 +78,7 @@ class ClientController
     public function store(Request $request)
     {
         $this->validation->make($request->all(), [
-            'name' => 'required|max:255',
+            'name' => 'required|max:191',
             'redirect' => ['required', $this->redirectRule],
             'confidential' => 'boolean',
         ])->validate();
@@ -111,7 +111,7 @@ class ClientController
         }
 
         $this->validation->make($request->all(), [
-            'name' => 'required|max:255',
+            'name' => 'required|max:191',
             'redirect' => ['required', $this->redirectRule],
         ])->validate();
 

--- a/src/Http/Controllers/PersonalAccessTokenController.php
+++ b/src/Http/Controllers/PersonalAccessTokenController.php
@@ -61,7 +61,7 @@ class PersonalAccessTokenController
     public function store(Request $request)
     {
         $this->validation->make($request->all(), [
-            'name' => 'required|max:255',
+            'name' => 'required|max:191',
             'scopes' => 'array|in:'.implode(',', Passport::scopeIds()),
         ])->validate();
 

--- a/tests/Unit/ClientControllerTest.php
+++ b/tests/Unit/ClientControllerTest.php
@@ -58,7 +58,7 @@ class ClientControllerTest extends TestCase
             'name' => 'client name',
             'redirect' => 'http://localhost',
         ], [
-            'name' => 'required|max:255',
+            'name' => 'required|max:191',
             'redirect' => ['required', $redirectRule],
             'confidential' => 'boolean',
         ])->andReturn($validator);
@@ -97,7 +97,7 @@ class ClientControllerTest extends TestCase
             'redirect' => 'http://localhost',
             'confidential' => false,
         ], [
-            'name' => 'required|max:255',
+            'name' => 'required|max:191',
             'redirect' => ['required', $redirectRule],
             'confidential' => 'boolean',
         ])->andReturn($validator);
@@ -136,7 +136,7 @@ class ClientControllerTest extends TestCase
             'name' => 'client name',
             'redirect' => 'http://localhost',
         ], [
-            'name' => 'required|max:255',
+            'name' => 'required|max:191',
             'redirect' => ['required', $redirectRule],
         ])->andReturn($validator);
         $validator->shouldReceive('validate')->once();

--- a/tests/Unit/PersonalAccessTokenControllerTest.php
+++ b/tests/Unit/PersonalAccessTokenControllerTest.php
@@ -74,7 +74,7 @@ class PersonalAccessTokenControllerTest extends TestCase
             'name' => 'token name',
             'scopes' => ['user', 'user-admin'],
         ], [
-            'name' => 'required|max:255',
+            'name' => 'required|max:191',
             'scopes' => 'array|in:'.implode(',', Passport::scopeIds()),
         ])->andReturn($validator);
         $validator->shouldReceive('validate')->once();


### PR DESCRIPTION
Fixes https://github.com/laravel/passport/issues/1299