### PR TITLE
check if column is missing and add it. Fixes issue with legacy instal…

### DIFF
--- a/database/migrations/2020_06_25_000001_provider_column_when_table_exists.php
+++ b/database/migrations/2020_06_25_000001_provider_column_when_table_exists.php
@@ -46,7 +46,7 @@ class ProviderColumnWhenTableExists extends Migration
      */
     public function up()
     {
-        if (!Schema::hasColumn($this->table, $this->column)) {
+        if (! Schema::hasColumn($this->table, $this->column)) {
             $this->schema->table($this->table, function (Blueprint $table) {
                 $table->string($this->column)->after('secret')->nullable();
             });

--- a/database/migrations/2020_06_25_000001_provider_column_when_table_exists.php
+++ b/database/migrations/2020_06_25_000001_provider_column_when_table_exists.php
@@ -1,0 +1,79 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ProviderColumnWhenTableExists extends Migration
+{
+    /**
+     * The database schema.
+     *
+     * @var \Illuminate\Database\Schema\Builder
+     */
+    protected $schema;
+
+    /**
+     * The table.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * The column.
+     *
+     * @var string
+     */
+    protected $column;
+
+    /**
+     * Create a new migration instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->schema = Schema::connection($this->getConnection());
+        $this->table = 'oauth_clients';
+        $this->column = 'provider';
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::hasColumn($this->table, $this->column)) {
+            $this->schema->table($this->table, function (Blueprint $table) {
+                $table->string($this->column)->after('secret')->nullable();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::hasColumn($this->table, $this->column)) {
+            $this->schema->table($this->table, function (Blueprint $table) {
+                $table->dropColumn($this->column);
+            });
+        }
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return config('passport.storage.database.connection');
+    }
+}


### PR DESCRIPTION
A new column was added to an existing table by editing a migration file from 2016. This makes it impossible to run a migration after upgrading from an older version of Passport and receive the new column.

We've been using Passport since version 1. After upgrading 7.x to 9.x, I was no longer able to create passport clients via artisan because this column is missing from the table. Running `php artisan migrate` yielded nothing to migrate.