### PR TITLE
[9.x] Use custom models in purge command if set

### DIFF
--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -4,9 +4,7 @@ namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
-use Laravel\Passport\AuthCode;
-use Laravel\Passport\RefreshToken;
-use Laravel\Passport\Token;
+use Laravel\Passport\Passport;
 
 class PurgeCommand extends Command
 {
@@ -35,21 +33,21 @@ class PurgeCommand extends Command
 
         if (($this->option('revoked') && $this->option('expired')) ||
             (! $this->option('revoked') && ! $this->option('expired'))) {
-            Token::where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
-            AuthCode::where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
-            RefreshToken::where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
+            Passport::token()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
+            Passport::authCode()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
+            Passport::refreshToken()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
 
             $this->info('Purged revoked items and items expired for more than seven days.');
         } elseif ($this->option('revoked')) {
-            Token::where('revoked', 1)->delete();
-            AuthCode::where('revoked', 1)->delete();
-            RefreshToken::where('revoked', 1)->delete();
+            Passport::token()->where('revoked', 1)->delete();
+            Passport::authCode()->where('revoked', 1)->delete();
+            Passport::refreshToken()->where('revoked', 1)->delete();
 
             $this->info('Purged revoked items.');
         } elseif ($this->option('expired')) {
-            Token::whereDate('expires_at', '<', $expired)->delete();
-            AuthCode::whereDate('expires_at', '<', $expired)->delete();
-            RefreshToken::whereDate('expires_at', '<', $expired)->delete();
+            Passport::token()->whereDate('expires_at', '<', $expired)->delete();
+            Passport::authCode()->whereDate('expires_at', '<', $expired)->delete();
+            Passport::refreshToken()->whereDate('expires_at', '<', $expired)->delete();
 
             $this->info('Purged items expired for more than seven days.');
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Purge command is currently not using models set by:

- `\Laravel\Passport\Passport::useAuthCodeModel($authCodeModel)`
- `\Laravel\Passport\Passport::useTokenModel($tokenModel)`
- `\Laravel\Passport\Passport::useRefreshTokenModel($refreshTokenModel)`

This PR is making sure these are used as a user might expect.