### PR TITLE
[10.x] Remove old static personal client methods

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -8,6 +8,33 @@ use RuntimeException;
 class ClientRepository
 {
     /**
+     * The personal access client ID.
+     *
+     * @var int|string|null
+     */
+    protected $personalAccessClientId;
+
+    /**
+     * The personal access client secret.
+     *
+     * @var string|null
+     */
+    protected $personalAccessClientSecret;
+
+    /**
+     * Create a new client repository.
+     *
+     * @param  int|string|null  $personalAccessClientId
+     * @param  string|null  $personalAccessClientSecret
+     * @return void
+     */
+    public function __construct($personalAccessClientId = null, $personalAccessClientSecret = null)
+    {
+        $this->personalAccessClientId = $personalAccessClientId;
+        $this->personalAccessClientSecret = $personalAccessClientSecret;
+    }
+
+    /**
      * Get a client by the given ID.
      *
      * @param  int  $id
@@ -85,8 +112,8 @@ class ClientRepository
      */
     public function personalAccessClient()
     {
-        if (Passport::$personalAccessClientId) {
-            return $this->find(Passport::$personalAccessClientId);
+        if ($this->personalAccessClientId) {
+            return $this->find($this->personalAccessClientId);
         }
 
         $client = Passport::personalAccessClient();
@@ -215,5 +242,25 @@ class ClientRepository
         $client->tokens()->update(['revoked' => true]);
 
         $client->forceFill(['revoked' => true])->save();
+    }
+
+    /**
+     * Get the personal access client id.
+     *
+     * @return int|string|null
+     */
+    public function getPersonalAccessClientId()
+    {
+        return $this->personalAccessClientId;
+    }
+
+    /**
+     * Get the personal access client secret.
+     *
+     * @return string|null
+     */
+    public function getPersonalAccessClientSecret()
+    {
+        return $this->personalAccessClientSecret;
     }
 }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -20,20 +20,6 @@ class Passport
     public static $implicitGrantEnabled = false;
 
     /**
-     * The personal access token client ID.
-     *
-     * @var int|string
-     */
-    public static $personalAccessClientId;
-
-    /**
-     * The personal access token client secret.
-     *
-     * @var string
-     */
-    public static $personalAccessClientSecret;
-
-    /**
      * The default scope.
      *
      * @var string
@@ -194,32 +180,6 @@ class Passport
         Route::group($options, function ($router) use ($callback) {
             $callback(new RouteRegistrar($router));
         });
-    }
-
-    /**
-     * Set the client ID that should be used to issue personal access tokens.
-     *
-     * @param  int|string  $clientId
-     * @return static
-     */
-    public static function personalAccessClientId($clientId)
-    {
-        static::$personalAccessClientId = $clientId;
-
-        return new static;
-    }
-
-    /**
-     * Set the client secret that should be used to issue personal access tokens.
-     *
-     * @param  string  $clientSecret
-     * @return static
-     */
-    public static function personalAccessClientSecret($clientSecret)
-    {
-        static::$personalAccessClientSecret = $clientSecret;
-
-        return new static;
     }
 
     /**

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -93,6 +93,7 @@ class PassportServiceProvider extends ServiceProvider
         Passport::setClientUuids($this->app->make(Config::class)->get('passport.client_uuids', false));
 
         $this->registerAuthorizationServer();
+        $this->registerClientRepository();
         $this->registerResourceServer();
         $this->registerGuard();
     }
@@ -218,6 +219,20 @@ class PassportServiceProvider extends ServiceProvider
             $this->makeCryptKey('private'),
             app('encrypter')->getKey()
         );
+    }
+
+    /**
+     * Register the client repository.
+     *
+     * @return void
+     */
+    protected function registerClientRepository()
+    {
+        $this->app->singleton(ClientRepository::class, function ($container) {
+            $config = $container->make('config')->get('passport.personal_access_client');
+
+            return new ClientRepository($config['id'] ?? null, $config['secret'] ?? null);
+        });
     }
 
     /**

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -93,7 +93,7 @@ class PersonalAccessTokenFactory
      */
     protected function createRequest($client, $userId, array $scopes)
     {
-        $secret = Passport::$hashesClientSecrets ? Passport::$personalAccessClientSecret : $client->secret;
+        $secret = Passport::$hashesClientSecrets ? $this->clients->getPersonalAccessClientSecret() : $client->secret;
 
         return (new ServerRequest)->withParsedBody([
             'grant_type' => 'personal_access',


### PR DESCRIPTION
This PR removes the old and now redundant way to set the personal access client ID and secret. This will make the install step here a bit easier: https://laravel.com/docs/7.x/passport#creating-a-personal-access-client

The only breaking change and upgrade step is to remove these methods from the app's `AuthServiceProvider`.