### PR TITLE
[9.x] Remove Guzzle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "php": "^7.2",
         "ext-json": "*",
         "firebase/php-jwt": "^5.0",
-        "guzzlehttp/guzzle": "^6.0|^7.0",
         "illuminate/auth": "^6.18.31|^7.22.4",
         "illuminate/console": "^6.18.31|^7.22.4",
         "illuminate/container": "^6.18.31|^7.22.4",

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Passport\Tests\Unit;
 
-use GuzzleHttp\Psr7\Response;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Http\Request;
 use Laravel\Passport\Bridge\Scope;
@@ -17,6 +16,7 @@ use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException as LeagueException;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use Mockery as m;
+use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;


### PR DESCRIPTION
For some reason Passport required Guzzle as a dependency even though the only Guzzle namespace mention in the entire codebase was in just one test (the Guzzle PSR 7 response class). So I've changed that to use the Nyholm PSR 7 response which is also required by Passport (and recommended by Symfony PSR HTTP bridge) and in doing so I've removed the entire Guzzle dependency.