### PR TITLE
[9.x] Allow PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^4.4|^5.0",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.5|^9.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This will allow us to test Passport 9 with PHP 8 after the support for it lands in the framework repository.
