### PR TITLE
[10.x] Use only one PSR 7 implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,8 @@
         "illuminate/encryption": "^6.18.31|^7.22.4",
         "illuminate/http": "^6.18.31|^7.22.4",
         "illuminate/support": "^6.18.31|^7.22.4",
-        "laminas/laminas-diactoros": "^2.2",
         "league/oauth2-server": "^8.1",
-        "nyholm/psr7": "^1.0",
+        "nyholm/psr7": "^1.3",
         "phpseclib/phpseclib": "^2.0",
         "symfony/psr-http-message-bridge": "^2.0"
     },

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -10,10 +10,6 @@ use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Http\Request;
-use Laminas\Diactoros\ResponseFactory;
-use Laminas\Diactoros\ServerRequestFactory;
-use Laminas\Diactoros\StreamFactory;
-use Laminas\Diactoros\UploadedFileFactory;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Laravel\Passport\PassportUserProvider;
@@ -21,6 +17,7 @@ use Laravel\Passport\TokenRepository;
 use Laravel\Passport\TransientToken;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 
 class TokenGuard
@@ -195,12 +192,12 @@ class TokenGuard
     {
         // First, we will convert the Symfony request to a PSR-7 implementation which will
         // be compatible with the base OAuth2 library. The Symfony bridge can perform a
-        // conversion for us to a new Diactoros implementation of this PSR-7 request.
+        // conversion for us to a new Nyholm implementation of this PSR-7 request.
         $psr = (new PsrHttpFactory(
-            new ServerRequestFactory,
-            new StreamFactory,
-            new UploadedFileFactory,
-            new ResponseFactory
+            new Psr17Factory,
+            new Psr17Factory,
+            new Psr17Factory,
+            new Psr17Factory
         ))->createRequest($request);
 
         try {

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -2,10 +2,10 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
-use Laminas\Diactoros\Response as Psr7Response;
 use Laravel\Passport\TokenRepository;
 use Lcobucci\JWT\Parser as JwtParser;
 use League\OAuth2\Server\AuthorizationServer;
+use Nyholm\Psr7\Response as Psr7Response;
 use Psr\Http\Message\ServerRequestInterface;
 
 class AccessTokenController

--- a/src/Http/Controllers/ApproveAuthorizationController.php
+++ b/src/Http/Controllers/ApproveAuthorizationController.php
@@ -3,8 +3,8 @@
 namespace Laravel\Passport\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Laminas\Diactoros\Response as Psr7Response;
 use League\OAuth2\Server\AuthorizationServer;
+use Nyholm\Psr7\Response as Psr7Response;
 
 class ApproveAuthorizationController
 {

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -5,12 +5,12 @@ namespace Laravel\Passport\Http\Controllers;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
-use Laminas\Diactoros\Response as Psr7Response;
 use Laravel\Passport\Bridge\User;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\AuthorizationServer;
+use Nyholm\Psr7\Response as Psr7Response;
 use Psr\Http\Message\ServerRequestInterface;
 
 class AuthorizationController

--- a/src/Http/Controllers/HandlesOAuthErrors.php
+++ b/src/Http/Controllers/HandlesOAuthErrors.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
-use Laminas\Diactoros\Response as Psr7Response;
 use Laravel\Passport\Exceptions\OAuthServerException;
 use League\OAuth2\Server\Exception\OAuthServerException as LeagueException;
+use Nyholm\Psr7\Response as Psr7Response;
 
 trait HandlesOAuthErrors
 {

--- a/src/Http/Middleware/CheckCredentials.php
+++ b/src/Http/Middleware/CheckCredentials.php
@@ -4,13 +4,10 @@ namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
 use Illuminate\Auth\AuthenticationException;
-use Laminas\Diactoros\ResponseFactory;
-use Laminas\Diactoros\ServerRequestFactory;
-use Laminas\Diactoros\StreamFactory;
-use Laminas\Diactoros\UploadedFileFactory;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 
 abstract class CheckCredentials
@@ -55,10 +52,10 @@ abstract class CheckCredentials
     public function handle($request, Closure $next, ...$scopes)
     {
         $psr = (new PsrHttpFactory(
-            new ServerRequestFactory,
-            new StreamFactory,
-            new UploadedFileFactory,
-            new ResponseFactory
+            new Psr17Factory,
+            new Psr17Factory,
+            new Psr17Factory,
+            new Psr17Factory
         ))->createRequest($request);
 
         try {

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -2,10 +2,11 @@
 
 namespace Laravel\Passport;
 
-use Laminas\Diactoros\Response;
-use Laminas\Diactoros\ServerRequest;
 use Lcobucci\JWT\Parser as JwtParser;
 use League\OAuth2\Server\AuthorizationServer;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\ServerRequest;
+use Psr\Http\Message\ServerRequestInterface;
 
 class PersonalAccessTokenFactory
 {
@@ -89,13 +90,13 @@ class PersonalAccessTokenFactory
      * @param  \Laravel\Passport\Client  $client
      * @param  mixed  $userId
      * @param  array  $scopes
-     * @return \Laminas\Diactoros\ServerRequest
+     * @return \Psr\Http\Message\ServerRequestInterface
      */
     protected function createRequest($client, $userId, array $scopes)
     {
         $secret = Passport::$hashesClientSecrets ? $this->clients->getPersonalAccessClientSecret() : $client->secret;
 
-        return (new ServerRequest)->withParsedBody([
+        return (new ServerRequest('POST', 'not-important'))->withParsedBody([
             'grant_type' => 'personal_access',
             'client_id' => $client->id,
             'client_secret' => $secret,
@@ -107,10 +108,10 @@ class PersonalAccessTokenFactory
     /**
      * Dispatch the given request to the authorization server.
      *
-     * @param  \Laminas\Diactoros\ServerRequest  $request
+     * @param  \Psr\Http\Message\ServerRequestInterface  $request
      * @return array
      */
-    protected function dispatchRequestToAuthorizationServer(ServerRequest $request)
+    protected function dispatchRequestToAuthorizationServer(ServerRequestInterface $request)
     {
         return json_decode($this->server->respondToAccessTokenRequest(
             $request, new Response

--- a/tests/Unit/AccessTokenControllerTest.php
+++ b/tests/Unit/AccessTokenControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Passport\Tests\Unit;
 
-use Laminas\Diactoros\Response;
 use Laravel\Passport\Exceptions\OAuthServerException;
 use Laravel\Passport\Http\Controllers\AccessTokenController;
 use Laravel\Passport\TokenRepository;
@@ -10,6 +9,7 @@ use Lcobucci\JWT\Parser;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException as LeagueException;
 use Mockery as m;
+use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/tests/Unit/ApproveAuthorizationControllerTest.php
+++ b/tests/Unit/ApproveAuthorizationControllerTest.php
@@ -3,11 +3,11 @@
 namespace Laravel\Passport\Tests\Unit;
 
 use Illuminate\Http\Request;
-use Laminas\Diactoros\Response;
 use Laravel\Passport\Http\Controllers\ApproveAuthorizationController;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use Mockery as m;
+use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 


### PR DESCRIPTION
Passport currently requires two PSR 7 implementations which is weird. Laravel already started the migration to Nyholm PSR 7 (https://github.com/laravel/framework/pull/31028) so with this PR I'm dropping the dependency on the Laminas Diactoros PSR 7 implementation in favor of Nyholm PSR 7. The few docblocks that were explicitly stating that a Diactoros implementation would be returned have been changed to specify that a PSR 7 compliant equivalent is going to be returned which will allow us to change PSR 7 implementations if there's gonna be a need for it without causing breaking changes for the users of this library.