### PR TITLE
Use proper spaces for docblock - actingAsClient

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -409,11 +409,11 @@ class Passport
     }
 
     /**
-     * Set the current client for the application with the given scopes.
+     * Set the current client for the application with the given scopes.
      *
-     * @param  \Laravel\Passport\Client  $client
-     * @param  array  $scopes
-     * @return \Laravel\Passport\Client
+     * @param \Laravel\Passport\Client $client
+     * @param array $scopes
+     * @return \Laravel\Passport\Client
      */
     public static function actingAsClient($client, $scopes = [])
     {


### PR DESCRIPTION
![spacing](https://user-images.githubusercontent.com/611784/91976163-8d95d580-ecee-11ea-812c-f00824c57fc1.png)

My IDE for some reason for this function only reports some strange chars. Looks like it was the nbsp; space vs a literal one. Looks like thats just how it was when it was added.

Original add: https://github.com/laravel/passport/commit/66add573c238307392a7e481a9151ae210193476#diff-f21ed80d2b094fcf734f3ca855cffc0b