### PR TITLE
Using assertSame to make assertion equals strict

### DIFF
--- a/tests/Unit/AccessTokenControllerTest.php
+++ b/tests/Unit/AccessTokenControllerTest.php
@@ -38,7 +38,7 @@ class AccessTokenControllerTest extends TestCase
 
         $controller = new AccessTokenController($server, $tokens, $jwt);
 
-        $this->assertEquals('{"access_token":"access-token"}', $controller->issueToken($request)->getContent());
+        $this->assertSame('{"access_token":"access-token"}', $controller->issueToken($request)->getContent());
     }
 
     public function test_exceptions_are_handled()

--- a/tests/Unit/ApproveAuthorizationControllerTest.php
+++ b/tests/Unit/ApproveAuthorizationControllerTest.php
@@ -49,7 +49,7 @@ class ApproveAuthorizationControllerTest extends TestCase
             ->with($authRequest, m::type(ResponseInterface::class))
             ->andReturn($psrResponse);
 
-        $this->assertEquals('response', $controller->approve($request)->getContent());
+        $this->assertSame('response', $controller->approve($request)->getContent());
     }
 }
 

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -56,10 +56,10 @@ class AuthorizationControllerTest extends TestCase
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
 
         $response->shouldReceive('view')->once()->andReturnUsing(function ($view, $data) use ($client, $user) {
-            $this->assertEquals('passport::authorize', $view);
+            $this->assertSame('passport::authorize', $view);
             $this->assertEquals($client, $data['client']);
             $this->assertEquals($user, $data['user']);
-            $this->assertEquals('description', $data['scopes'][0]->description);
+            $this->assertSame('description', $data['scopes'][0]->description);
 
             return 'view';
         });
@@ -67,7 +67,7 @@ class AuthorizationControllerTest extends TestCase
         $tokens = m::mock(TokenRepository::class);
         $tokens->shouldReceive('findValidToken')->with($user, $client)->andReturnNull();
 
-        $this->assertEquals('view', $controller->authorize(
+        $this->assertSame('view', $controller->authorize(
             m::mock(ServerRequestInterface::class), $request, $clients, $tokens
         ));
     }
@@ -131,7 +131,7 @@ class AuthorizationControllerTest extends TestCase
             ->andReturn($token = m::mock(Token::class));
         $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['scope-1']);
 
-        $this->assertEquals('approved', $controller->authorize(
+        $this->assertSame('approved', $controller->authorize(
             m::mock(ServerRequestInterface::class), $request, $clients, $tokens
         )->getContent());
     }
@@ -174,7 +174,7 @@ class AuthorizationControllerTest extends TestCase
             ->with($user, $client)
             ->andReturnNull();
 
-        $this->assertEquals('approved', $controller->authorize(
+        $this->assertSame('approved', $controller->authorize(
             m::mock(ServerRequestInterface::class), $request, $clients, $tokens
         )->getContent());
     }

--- a/tests/Unit/AuthorizedAccessTokenControllerTest.php
+++ b/tests/Unit/AuthorizedAccessTokenControllerTest.php
@@ -96,7 +96,7 @@ class AuthorizedAccessTokenControllerTest extends TestCase
 
         $response = $this->controller->destroy($request, 1);
 
-        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->status());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->status());
     }
 
     public function test_not_found_response_is_returned_if_user_doesnt_have_token()
@@ -112,6 +112,6 @@ class AuthorizedAccessTokenControllerTest extends TestCase
             return $user;
         });
 
-        $this->assertEquals(404, $this->controller->destroy($request, 3)->status());
+        $this->assertSame(404, $this->controller->destroy($request, 3)->status());
     }
 }

--- a/tests/Unit/BridgeAccessTokenRepositoryTest.php
+++ b/tests/Unit/BridgeAccessTokenRepositoryTest.php
@@ -27,9 +27,9 @@ class BridgeAccessTokenRepositoryTest extends TestCase
         $events = m::mock(Dispatcher::class);
 
         $tokenRepository->shouldReceive('create')->once()->andReturnUsing(function ($array) use ($expiration) {
-            $this->assertEquals(1, $array['id']);
-            $this->assertEquals(2, $array['user_id']);
-            $this->assertEquals('client-id', $array['client_id']);
+            $this->assertSame(1, $array['id']);
+            $this->assertSame(2, $array['user_id']);
+            $this->assertSame('client-id', $array['client_id']);
             $this->assertEquals(['scopes'], $array['scopes']);
             $this->assertEquals(false, $array['revoked']);
             $this->assertInstanceOf('DateTime', $array['created_at']);
@@ -62,6 +62,6 @@ class BridgeAccessTokenRepositoryTest extends TestCase
         $this->assertInstanceOf(AccessToken::class, $token);
         $this->assertEquals($client, $token->getClient());
         $this->assertEquals($scopes, $token->getScopes());
-        $this->assertEquals($userIdentifier, $token->getUserIdentifier());
+        $this->assertSame($userIdentifier, $token->getUserIdentifier());
     }
 }

--- a/tests/Unit/BridgeClientRepositoryTest.php
+++ b/tests/Unit/BridgeClientRepositoryTest.php
@@ -46,8 +46,8 @@ class BridgeClientRepositoryTest extends TestCase
         $client = $this->repository->getClientEntity(1);
 
         $this->assertInstanceOf(Client::class, $client);
-        $this->assertEquals('1', $client->getIdentifier());
-        $this->assertEquals('Client', $client->getName());
+        $this->assertSame('1', $client->getIdentifier());
+        $this->assertSame('Client', $client->getName());
         $this->assertEquals(['http://localhost'], $client->getRedirectUri());
         $this->assertTrue($client->isConfidential());
     }

--- a/tests/Unit/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/Unit/CheckClientCredentialsForAnyScopeTest.php
@@ -47,7 +47,7 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
             return 'response';
         });
 
-        $this->assertEquals('response', $response);
+        $this->assertSame('response', $response);
     }
 
     public function test_request_is_passed_along_if_token_has_any_required_scope()
@@ -80,7 +80,7 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
             return 'response';
         }, 'notfoo', 'bar', 'notbaz');
 
-        $this->assertEquals('response', $response);
+        $this->assertSame('response', $response);
     }
 
     public function test_exception_is_thrown_when_oauth_throws_exception()

--- a/tests/Unit/CheckClientCredentialsTest.php
+++ b/tests/Unit/CheckClientCredentialsTest.php
@@ -47,7 +47,7 @@ class CheckClientCredentialsTest extends TestCase
             return 'response';
         });
 
-        $this->assertEquals('response', $response);
+        $this->assertSame('response', $response);
     }
 
     public function test_request_is_passed_along_if_token_and_scope_are_valid()
@@ -79,7 +79,7 @@ class CheckClientCredentialsTest extends TestCase
             return 'response';
         }, 'see-profile');
 
-        $this->assertEquals('response', $response);
+        $this->assertSame('response', $response);
     }
 
     public function test_exception_is_thrown_when_oauth_throws_exception()

--- a/tests/Unit/CheckForAnyScopeTest.php
+++ b/tests/Unit/CheckForAnyScopeTest.php
@@ -26,7 +26,7 @@ class CheckForAnyScopeTest extends TestCase
             return 'response';
         }, 'foo', 'bar');
 
-        $this->assertEquals('response', $response);
+        $this->assertSame('response', $response);
     }
 
     public function test_exception_is_thrown_if_token_doesnt_have_scope()

--- a/tests/Unit/CheckScopesTest.php
+++ b/tests/Unit/CheckScopesTest.php
@@ -26,7 +26,7 @@ class CheckScopesTest extends TestCase
             return 'response';
         }, 'foo', 'bar');
 
-        $this->assertEquals('response', $response);
+        $this->assertSame('response', $response);
     }
 
     public function test_exception_is_thrown_if_token_doesnt_have_scope()

--- a/tests/Unit/ClientControllerTest.php
+++ b/tests/Unit/ClientControllerTest.php
@@ -145,7 +145,7 @@ class ClientControllerTest extends TestCase
             $clients, $validator, $redirectRule
         );
 
-        $this->assertEquals('response', $controller->update($request, 1));
+        $this->assertSame('response', $controller->update($request, 1));
     }
 
     public function test_404_response_if_client_doesnt_belong_to_user()
@@ -170,7 +170,7 @@ class ClientControllerTest extends TestCase
             $clients, $validator, m::mock(RedirectRule::class)
         );
 
-        $this->assertEquals(404, $controller->update($request, 1)->status());
+        $this->assertSame(404, $controller->update($request, 1)->status());
     }
 
     public function test_clients_can_be_deleted()
@@ -200,7 +200,7 @@ class ClientControllerTest extends TestCase
 
         $response = $controller->destroy($request, 1);
 
-        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->status());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->status());
     }
 
     public function test_404_response_if_client_doesnt_belong_to_user_on_delete()
@@ -225,7 +225,7 @@ class ClientControllerTest extends TestCase
             $clients, $validator, m::mock(RedirectRule::class)
         );
 
-        $this->assertEquals(404, $controller->destroy($request, 1)->status());
+        $this->assertSame(404, $controller->destroy($request, 1)->status());
     }
 }
 

--- a/tests/Unit/DenyAuthorizationControllerTest.php
+++ b/tests/Unit/DenyAuthorizationControllerTest.php
@@ -45,7 +45,7 @@ class DenyAuthorizationControllerTest extends TestCase
             return $url;
         });
 
-        $this->assertEquals('http://localhost?error=access_denied&state=state', $controller->deny($request));
+        $this->assertSame('http://localhost?error=access_denied&state=state', $controller->deny($request));
     }
 
     public function test_authorization_can_be_denied_with_multiple_redirect_uris()
@@ -77,7 +77,7 @@ class DenyAuthorizationControllerTest extends TestCase
             return $url;
         });
 
-        $this->assertEquals('http://localhost?error=access_denied&state=state', $controller->deny($request));
+        $this->assertSame('http://localhost?error=access_denied&state=state', $controller->deny($request));
     }
 
     public function test_authorization_can_be_denied_implicit()
@@ -109,7 +109,7 @@ class DenyAuthorizationControllerTest extends TestCase
             return $url;
         });
 
-        $this->assertEquals('http://localhost#error=access_denied&state=state', $controller->deny($request));
+        $this->assertSame('http://localhost#error=access_denied&state=state', $controller->deny($request));
     }
 
     public function test_authorization_can_be_denied_with_existing_query_string()
@@ -141,7 +141,7 @@ class DenyAuthorizationControllerTest extends TestCase
             return $url;
         });
 
-        $this->assertEquals('http://localhost?action=some_action&error=access_denied&state=state', $controller->deny($request));
+        $this->assertSame('http://localhost?action=some_action&error=access_denied&state=state', $controller->deny($request));
     }
 
     public function test_auth_request_should_exist()

--- a/tests/Unit/HandlesOAuthErrorsTest.php
+++ b/tests/Unit/HandlesOAuthErrorsTest.php
@@ -47,7 +47,7 @@ class HandlesOAuthErrorsTest extends TestCase
         }
 
         $this->assertInstanceOf(OAuthServerException::class, $e);
-        $this->assertEquals('Error', $e->getMessage());
+        $this->assertSame('Error', $e->getMessage());
         $this->assertInstanceOf(LeagueException::class, $e->getPrevious());
 
         $response = $e->render(new Request);

--- a/tests/Unit/PassportTest.php
+++ b/tests/Unit/PassportTest.php
@@ -21,7 +21,7 @@ class PassportTest extends TestCase
 
         $this->assertTrue(Passport::hasScope('user'));
         $this->assertEquals(['user'], Passport::scopeIds());
-        $this->assertEquals('user', Passport::scopes()[0]->id);
+        $this->assertSame('user', Passport::scopes()[0]->id);
     }
 
     public function test_auth_code_instance_can_be_created()

--- a/tests/Unit/PersonalAccessTokenControllerTest.php
+++ b/tests/Unit/PersonalAccessTokenControllerTest.php
@@ -82,7 +82,7 @@ class PersonalAccessTokenControllerTest extends TestCase
         $tokenRepository = m::mock(TokenRepository::class);
         $controller = new PersonalAccessTokenController($tokenRepository, $validator);
 
-        $this->assertEquals('response', $controller->store($request));
+        $this->assertSame('response', $controller->store($request));
     }
 
     public function test_tokens_can_be_deleted()
@@ -108,7 +108,7 @@ class PersonalAccessTokenControllerTest extends TestCase
 
         $response = $controller->destroy($request, 1);
 
-        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->status());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->status());
     }
 
     public function test_not_found_response_is_returned_if_user_doesnt_have_token()
@@ -128,6 +128,6 @@ class PersonalAccessTokenControllerTest extends TestCase
         $validator = m::mock(Factory::class);
         $controller = new PersonalAccessTokenController($tokenRepository, $validator);
 
-        $this->assertEquals(404, $controller->destroy($request, 3)->status());
+        $this->assertSame(404, $controller->destroy($request, 3)->status());
     }
 }

--- a/tests/Unit/TransientTokenControllerTest.php
+++ b/tests/Unit/TransientTokenControllerTest.php
@@ -30,7 +30,7 @@ class TransientTokenControllerTest extends TestCase
 
         $response = $controller->refresh($request);
 
-        $this->assertEquals(200, $response->status());
-        $this->assertEquals('Refreshed.', $response->getOriginalContent());
+        $this->assertSame(200, $response->status());
+        $this->assertSame('Refreshed.', $response->getOriginalContent());
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion equals checking strict.