### PR TITLE
WIP: Multi-auth for Personal Access Tokens

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -163,9 +163,9 @@ class ClientRepository
      * @param  string  $redirect
      * @return \Laravel\Passport\Client
      */
-    public function createPersonalAccessClient($userId, $name, $redirect)
+    public function createPersonalAccessClient($userId, $name, $redirect, $provider)
     {
-        return tap($this->create($userId, $name, $redirect, null, true), function ($client) {
+        return tap($this->create($userId, $name, $redirect, $provider, true), function ($client) {
             $accessClient = Passport::personalAccessClient();
             $accessClient->client_id = $client->id;
             $accessClient->save();

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -123,11 +123,11 @@ class ClientRepository
         $personalAccessClient = $personalAccessClientModel
             ->join(
                 $clientModel->getTable(),
-                $personalAccessClientModel->getTable() . '.client_id',
+                $personalAccessClientModel->getTable().'.client_id',
                 '=',
-                $clientModel->getTable() . '.' . $clientModel->getKeyName()
+                $clientModel->getTable().'.'.$clientModel->getKeyName()
             )
-            ->where($clientModel->getTable() . '.provider', $provider)
+            ->where($clientModel->getTable().'.provider', $provider)
             ->first();
 
         if (is_null($personalAccessClient)) {

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -63,8 +63,16 @@ class ClientCommand extends Command
             config('app.name').' Personal Access Client'
         );
 
+        $providers = array_keys(config('auth.providers'));
+
+        $provider = $this->option('provider') ?: $this->choice(
+            'Which user provider should this client use to retrieve users?',
+            $providers,
+            in_array('users', $providers) ? 'users' : null
+        );
+
         $client = $clients->createPersonalAccessClient(
-            null, $name, 'http://localhost'
+            null, $name, 'http://localhost', $provider
         );
 
         $this->info('Personal access client created successfully.');

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -39,7 +39,7 @@ class InstallCommand extends Command
             $this->configureUuids();
         }
 
-        $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client']);
+        $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client', '--provider' => $provider]);
         $this->call('passport:client', ['--password' => true, '--name' => config('app.name').' Password Grant Client', '--provider' => $provider]);
     }
 

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -36,11 +36,11 @@ trait HasApiTokens
         return $this->hasMany(Passport::tokenModel(), 'user_id')
             ->join(
                 $clientModel->getTable(),
-                $tokenModel->getTable() . '.client_id',
+                $tokenModel->getTable().'.client_id',
                 '=',
-                $clientModel->getTable() . '.' . $clientModel->getKeyName()
+                $clientModel->getTable().'.'.$clientModel->getKeyName()
             )
-            ->where($clientModel->getTable() . '.provider', $this->getProvider())
+            ->where($clientModel->getTable().'.provider', $this->getProvider())
             ->orderBy('created_at', 'desc');
     }
 
@@ -94,15 +94,16 @@ trait HasApiTokens
         return $this;
     }
 
-    protected function getProvider() {
+    protected function getProvider()
+    {
         $providers = config('auth.providers');
 
         foreach ($providers as $name => $config) {
-            if($config['driver'] == 'eloquent' && is_a($this, $config['model'])) {
+            if ($config['driver'] == 'eloquent' && is_a($this, $config['model'])) {
                 return $name;
             }
 
-            if($config['driver'] == 'database' && $this->getTable() == $config['table']) {
+            if ($config['driver'] == 'database' && $this->getTable() == $config['table']) {
                 return $name;
             }
         }

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -61,15 +61,16 @@ class PersonalAccessTokenFactory
     /**
      * Create a new personal access token.
      *
-     * @param  mixed  $userId
-     * @param  string  $name
-     * @param  array  $scopes
+     * @param mixed $userId
+     * @param string $name
+     * @param array $scopes
+     * @param string|null $provider
      * @return \Laravel\Passport\PersonalAccessTokenResult
      */
-    public function make($userId, $name, array $scopes = [])
+    public function make($userId, $name, array $scopes = [], $provider = null)
     {
         $response = $this->dispatchRequestToAuthorizationServer(
-            $this->createRequest($this->clients->personalAccessClient(), $userId, $scopes)
+            $this->createRequest($this->clients->personalAccessClient($provider), $userId, $scopes)
         );
 
         $token = tap($this->findAccessToken($response), function ($token) use ($userId, $name) {

--- a/tests/Unit/PersonalAccessTokenFactoryTest.php
+++ b/tests/Unit/PersonalAccessTokenFactoryTest.php
@@ -53,7 +53,7 @@ class PersonalAccessTokenFactoryTest extends TestCase
         $tokens = m::mock(TokenRepository::class);
         $jwt = m::mock(Parser::class);
 
-        $provider = "some_provider";
+        $provider = 'some_provider';
 
         $factory = new PersonalAccessTokenFactory($server, $clients, $tokens, $jwt);
 


### PR DESCRIPTION
I should start out by saying that I'm a bit out of my depth here (mostly with how to test this well and with the oauth2 stuff), so this isn't a complete pull request yet. I'm opening this up now to see if I'm on the right track and get suggestions on how to handle some of the issues. I'm more than willing to do the work though. With that out of the way, let's get to the "what" and "why".

Previous attempts to support Multi-Auth in Passport focused on the password grant, but I have a use case where I have two independent models that both need their own sets of tokens (host and users in my case). I tried adding the "Has Api Tokens" to both of them, but quickly found that any shared ids would share tokens. I thought about working around this by making sure the IDs could never collide, but that felt like the wrong solution so here we are.

This enables the passport:client command to get a provider from the command line for the personal access token client (actually it forces you to pick one like the password grant). Things using the "HasApiTokens" trait will search the providers config for themselves and create a token for their specific client. When using the ->tokens call on that trait, it will be limited to the tokens related to your providers.

Here's some of the issues/known bugs that still need to be worked through:
- [ ] Testing. I added like... one test and I'm not even sure that's correct. I'm not used to testing where everything is mocked. (Tests are failing locally too, it's not just the CI in case you were going to go look into that)
- [ ] Current consumers are going to have a "null" in their provider and this code doesn't handle that at all.
- [ ] Pulling ->tokens on the HasApiTokens trait pulls the right tokens, but the user_id is always null. It looks correct in the database.
- [ ] In the Laravel\Passport\Token class, there's a ->user() method but it checks the api guard instead of the client's provider
- [ ] The PersonalAccessTokenController has a "forUser" method that looks up the token from the TokenRepository using just the user id. That obviously won't work with multi-auth but I'm not sure how to address it.

There's probably more than just that but those are the ones I know about right now. Am I going in the right direction to implement this feature?