### PR TITLE
[10.x] actingAs should as well cover request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes
 
-## [Unreleased](https://github.com/laravel/passport/compare/v8.4.4...8.x)
+## [Unreleased](https://github.com/laravel/passport/compare/v8.5.0...8.x)
+
+
+## [v8.5.0 (2020-05-05)](https://github.com/laravel/passport/compare/v8.4.4...v8.5.0)
+
+### Added
+- Automatic configuration of client UUIDs ([#1231](https://github.com/laravel/passport/pull/1231))
 
 
 ## [v8.4.4 (2020-04-21)](https://github.com/laravel/passport/compare/v8.4.3...v8.4.4)

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -417,7 +417,7 @@ class Passport
         app('auth')->guard($guard)->setUser($user);
 
         app('auth')->shouldUse($guard);
-        
+
         app('request')->setUserResolver(function () use ($user) {
             return $user;
         });


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When $request->user() is used in code and Passport::actingAs to mock currently logged in user. Tests fail, because $request->user() returns null, while Auth::user() returns user.