### PR TITLE
[10.x] Update the badges to use shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <p align="center">
 <a href="https://github.com/laravel/passport/actions"><img src="https://github.com/laravel/passport/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/passport"><img src="https://poser.pugx.org/laravel/passport/d/total.svg" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/passport"><img src="https://poser.pugx.org/laravel/passport/v/stable.svg" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/passport"><img src="https://poser.pugx.org/laravel/passport/license.svg" alt="License"></a>
+<a href="https://packagist.org/packages/laravel/passport"><img src="https://img.shields.io/packagist/dt/laravel/passport" alt="Total Downloads"></a>
+<a href="https://packagist.org/packages/laravel/passport"><img src="https://img.shields.io/packagist/v/laravel/passport" alt="Latest Stable Version"></a>
+<a href="https://packagist.org/packages/laravel/passport"><img src="https://img.shields.io/packagist/l/laravel/passport" alt="License"></a>
 </p>
 
 ## Introduction


### PR DESCRIPTION
Shields.io works a lot better than the old pugx.org.