### PR TITLE
cache-duplicate-queries

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -17,6 +17,20 @@ return [
 
     'public_key' => env('PASSPORT_PUBLIC_KEY'),
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Remove duplicate queries
+    |--------------------------------------------------------------------------
+    |
+    | By default, Passport doesn't cache queries .
+    | Change to true to increase performance
+    |
+    */
+
+
+    'use_cache' => env('PASSPORT_USE_CACHE', false),
+
     /*
     |--------------------------------------------------------------------------
     | Client UUIDs

--- a/src/CacheTokenRepository.php
+++ b/src/CacheTokenRepository.php
@@ -1,0 +1,60 @@
+<?php
+
+
+namespace Laravel\Passport;
+
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Cache;
+
+class CacheTokenRepository extends TokenRepository
+{
+
+    /**
+     * The key for caching queries.
+     *
+     * @var string
+     */
+    protected $cache_key = 'passport-token';
+
+    /**
+     * Get a token by the given ID.
+     *
+     * @param string $id
+     * @return Token
+     */
+    public function find($id)
+    {
+        return Cache::remember("$this->cache_key-id-$id", now()->addMinutes(30), function () use ($id) {
+            return parent::find($id);
+        });
+    }
+
+
+    /**
+     * Get a token by the given user ID and token ID.
+     *
+     * @param string $id
+     * @param int $userId
+     * @return Token|null
+     */
+    public function findForUser($id, $userId)
+    {
+        return Cache::remember("$this->cache_key-id-$id-user-$userId", now()->addMinutes(30), function () use ($id, $userId) {
+            return parent::findForUser($id, $userId);
+        });
+    }
+
+    /**
+     * Get the token instances for the given user ID.
+     *
+     * @param mixed $userId
+     * @return Collection
+     */
+    public function forUser($userId)
+    {
+        return Cache::remember("$this->cache_key-user-$userId", now()->addMinutes(30), function () use ($userId) {
+            return parent::forUser($userId);
+        });
+    }
+}


### PR DESCRIPTION
According to https://github.com/laravel/passport/issues/382 issue . 
This PR uses Cache facade to cache duplicated queries 

By changing the use_cache in the config/passport.php file into true 

```

    'use_cache' => env('PASSPORT_USE_CACHE', false),

```

