### PR TITLE
[10.x] Cache tokens to prevent unnecessary queries

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -172,13 +172,6 @@ class TokenGuard
 
         $clientId = $psr->getAttribute('oauth_client_id');
 
-        // Finally, we will verify if the client that issued this token is still valid and
-        // its tokens may still be used. If not, we will bail out since we don't want a
-        // user to be able to send access tokens for deleted or revoked applications.
-        if ($this->clients->revoked($clientId)) {
-            return;
-        }
-
         return $token ? $user->withAccessToken($token) : null;
     }
 

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -284,10 +284,15 @@ class PassportServiceProvider extends ServiceProvider
     protected function makeGuard(array $config)
     {
         return new RequestGuard(function ($request) use ($config) {
+            $tokenRepo = $this->app->make(TokenRepository::class);
+           
             return (new TokenGuard(
-                $this->app->make(ResourceServer::class),
+                new ResourceServer(
+                    new Bridge\AccessTokenRepository($tokenRepo, $this->app->make(\Illuminate\Contracts\Events\Dispatcher::class)),
+                    $this->makeCryptKey('public')
+                ),
                 new PassportUserProvider(Auth::createUserProvider($config['provider']), $config['provider']),
-                $this->app->make(TokenRepository::class),
+                $tokenRepo,
                 $this->app->make(ClientRepository::class),
                 $this->app->make('encrypter')
             ))->user($request);

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -7,6 +7,13 @@ use Carbon\Carbon;
 class TokenRepository
 {
     /**
+     * The tokens cached by the class
+     *
+     * @var array
+     */
+    protected $cachedTokens = [];
+
+    /**
      * Creates a new Access Token.
      *
      * @param  array  $attributes
@@ -25,7 +32,33 @@ class TokenRepository
      */
     public function find($id)
     {
-        return Passport::token()->where('id', $id)->first();
+        return $this->findByCache($id) ?? $this->addToCache(Passport::token()->where('id', $id)->first()); 
+    }
+
+    /**
+     * Add a token to the cache.
+     *
+     * @param  \Laravel\Passport\Token  $token
+     * @return \Laravel\Passport\Token
+     */
+    public function addToCache($token)
+    {
+        array_push($this->cachedTokens, $token);
+        return $token;
+    }
+
+    /**
+     * Search the cache for a token with a given ID.
+     *
+     * @param  string  $id
+     * @return \Laravel\Passport\Token
+     */
+    public function findByCache($id)
+    {
+        foreach($this->cachedTokens as $token) {
+            if($token->id == $id)
+                return $token;
+        }
     }
 
     /**
@@ -97,7 +130,7 @@ class TokenRepository
      */
     public function isAccessTokenRevoked($id)
     {
-        if ($token = $this->find($id)) {
+        if($token = $this->find($id)) {
             return $token->revoked;
         }
 

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -130,7 +130,7 @@ class TokenRepository
      */
     public function isAccessTokenRevoked($id)
     {
-        if($token = $this->find($id)) {
+        if ($token = $this->find($id)) {
             return $token->revoked;
         }
 


### PR DESCRIPTION
Fixes #382 by storing the tokens in memory after first retrieval. This is the only direct passport fix as the other queries come from league/oauth2-server and can't be stopped without passing the tokens around like with this.
It also removes the check for revoked client since the server already checks for it.

- [ ] Improve the way the service provider serves the same TokenRepository
- [ ] Add cacheing to the rest of the functions in the TokenRepository