### PR TITLE
[10.x] Return 'auth.failed' message for bad password credentials

### DIFF
--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -2,12 +2,12 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
+use Laravel\Passport\Exceptions\OAuthServerException;
 use Laravel\Passport\TokenRepository;
 use Lcobucci\JWT\Parser as JwtParser;
 use League\OAuth2\Server\AuthorizationServer;
 use Nyholm\Psr7\Response as Psr7Response;
 use Psr\Http\Message\ServerRequestInterface;
-use Laravel\Passport\Exceptions\OAuthServerException;
 
 class AccessTokenController
 {
@@ -72,7 +72,7 @@ class AccessTokenController
                     'error'=>'invalid_grant',
                     'error_description'=>__('auth.failed'),
                     'hint'=>'',
-                    'message'=>__('auth.failed')
+                    'message'=>__('auth.failed'),
                 ], $e->statusCode());
             }
             throw $e;

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -44,7 +44,8 @@ class AccessTokenController
      */
     public function __construct(AuthorizationServer $server,
                                 TokenRepository $tokens,
-                                JwtParser $jwt) {
+                                JwtParser $jwt)
+    {
         $this->jwt = $jwt;
         $this->server = $server;
         $this->tokens = $tokens;

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -42,11 +42,9 @@ class AccessTokenController
      * @param  \Lcobucci\JWT\Parser  $jwt
      * @return void
      */
-    public function __construct(
-        AuthorizationServer $server,
-        TokenRepository $tokens,
-        JwtParser $jwt
-    ) {
+    public function __construct(AuthorizationServer $server,
+                                TokenRepository $tokens,
+                                JwtParser $jwt) {
         $this->jwt = $jwt;
         $this->server = $server;
         $this->tokens = $tokens;

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -220,8 +220,10 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertArrayHasKey('error', $decodedResponse);
         $this->assertSame('invalid_grant', $decodedResponse['error']);
         $this->assertArrayHasKey('error_description', $decodedResponse);
+        $this->assertEquals(__('auth.failed'), $decodedResponse['error_description']);
         $this->assertArrayHasKey('hint', $decodedResponse);
         $this->assertArrayHasKey('message', $decodedResponse);
+        $this->assertEquals(__('auth.failed'), $decodedResponse['message']);
 
         $this->assertSame(0, Token::count());
     }


### PR DESCRIPTION
Recently the oauth2-server package changed the failed credentials response to be a generic `invalid_grant` error to line up with OAuth2 spec.  However, the message sent by this package is intentionally cryptic.  Because Passport is simply passing this message back to the response, API clients no longer have a default message that makes sense to the end user.

This pull request catches this exception and returns the 'auth.failed' message in the `error_description` and `message` fields of the response.  It retains the `invalid_grant` and 400 status that is correct for the OAuth2 spec.

Resolves https://github.com/laravel/passport/issues/1376