### PR TITLE
[9.x] Support PHP 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   tests:
-
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
         "firebase/php-jwt": "^5.0",
         "illuminate/auth": "^6.18.31|^7.22.4",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
         "firebase/php-jwt": "^5.0",
         "illuminate/auth": "^6.18.31|^7.22.4",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/support": "^6.18.31|^7.22.4",
         "laminas/laminas-diactoros": "^2.2",
         "lcobucci/jwt": "^3.4|^4.0",
-        "league/oauth2-server": "^8.1",
+        "league/oauth2-server": "^8.2.3",
         "nyholm/psr7": "^1.0",
         "phpseclib/phpseclib": "^2.0",
         "symfony/psr-http-message-bridge": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
         "firebase/php-jwt": "^5.0",
         "illuminate/auth": "^6.18.31|^7.22.4",
@@ -27,6 +27,7 @@
         "illuminate/http": "^6.18.31|^7.22.4",
         "illuminate/support": "^6.18.31|^7.22.4",
         "laminas/laminas-diactoros": "^2.2",
+        "lcobucci/jwt": "^3.4|^4.0",
         "league/oauth2-server": "^8.1",
         "nyholm/psr7": "^1.0",
         "phpseclib/phpseclib": "^2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,11 +18,6 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
     <php>
         <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
     </php>

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -14,6 +14,8 @@ use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Bridge\PersonalAccessGrant;
 use Laravel\Passport\Bridge\RefreshTokenRepository;
 use Laravel\Passport\Guards\TokenGuard;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Parser;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
@@ -94,6 +96,7 @@ class PassportServiceProvider extends ServiceProvider
 
         $this->registerAuthorizationServer();
         $this->registerResourceServer();
+        $this->registerJWTParser();
         $this->registerGuard();
     }
 
@@ -250,6 +253,18 @@ class PassportServiceProvider extends ServiceProvider
         }
 
         return new CryptKey($key, null, false);
+    }
+
+    /**
+     * Register the JWT Parser.
+     *
+     * @return void
+     */
+    protected function registerJWTParser()
+    {
+        $this->app->singleton(Parser::class, function () {
+            return Configuration::forUnsecuredSigner()->parser();
+        });
     }
 
     /**

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -126,7 +126,7 @@ class PersonalAccessTokenFactory
     protected function findAccessToken(array $response)
     {
         return $this->tokens->find(
-            $this->jwt->parse($response['access_token'])->getClaim('jti')
+            $this->jwt->parse($response['access_token'])->claims()->get('jti')
         );
     }
 }

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -12,7 +12,7 @@ use Laravel\Passport\ClientRepository;
 use Laravel\Passport\HasApiTokens;
 use Laravel\Passport\Token;
 use Laravel\Passport\TokenRepository;
-use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Configuration;
 
 class AccessTokenControllerTest extends PassportTestCase
 {
@@ -81,11 +81,11 @@ class AccessTokenControllerTest extends PassportTestCase
         $expiresInSeconds = 31536000;
         $this->assertEqualsWithDelta($expiresInSeconds, $decodedResponse['expires_in'], 5);
 
-        $jwtAccessToken = (new Parser())->parse($decodedResponse['access_token']);
-        $this->assertTrue($this->app->make(ClientRepository::class)->findActive($jwtAccessToken->getClaim('aud'))->is($client));
-        $this->assertTrue($this->app->make('auth')->createUserProvider()->retrieveById($jwtAccessToken->getClaim('sub'))->is($user));
+        $jwtAccessToken = Configuration::forUnsecuredSigner()->parser()->parse($decodedResponse['access_token']);
+        $this->assertTrue($this->app->make(ClientRepository::class)->findActive($jwtAccessToken->claims()->get('aud'))->is($client));
+        $this->assertTrue($this->app->make('auth')->createUserProvider()->retrieveById($jwtAccessToken->claims()->get('sub'))->is($user));
 
-        $token = $this->app->make(TokenRepository::class)->find($jwtAccessToken->getClaim('jti'));
+        $token = $this->app->make(TokenRepository::class)->find($jwtAccessToken->claims()->get('jti'));
         $this->assertInstanceOf(Token::class, $token);
         $this->assertFalse($token->revoked);
         $this->assertTrue($token->user->is($user));

--- a/tests/Unit/PersonalAccessTokenFactoryTest.php
+++ b/tests/Unit/PersonalAccessTokenFactoryTest.php
@@ -8,6 +8,10 @@ use Laravel\Passport\PersonalAccessTokenResult;
 use Laravel\Passport\Token;
 use Laravel\Passport\TokenRepository;
 use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Token\DataSet;
+use Lcobucci\JWT\Token\Plain as PlainToken;
+use Lcobucci\JWT\Token\RegisteredClaims;
+use Lcobucci\JWT\Token\Signature;
 use League\OAuth2\Server\AuthorizationServer;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -34,8 +38,13 @@ class PersonalAccessTokenFactoryTest extends TestCase
             'access_token' => 'foo',
         ]));
 
-        $jwt->shouldReceive('parse')->with('foo')->andReturn($parsedToken = m::mock());
-        $parsedToken->shouldReceive('getClaim')->with('jti')->andReturn('token');
+        $parsedToken = new PlainToken(
+            new DataSet([], ''),
+            new DataSet([RegisteredClaims::ID => 'token'], ''),
+            Signature::fromEmptyData()
+        );
+
+        $jwt->shouldReceive('parse')->with('foo')->andReturn($parsedToken);
         $tokens->shouldReceive('find')
             ->with('token')
             ->andReturn($foundToken = new PersonalAccessTokenFactoryTestModelStub);


### PR DESCRIPTION
This provides support for PHP 8 so people on Laravel 6 LTS can still install Passport. ~Unfortunately this requires the dropping of PHP 7.2 support because OAuth2 Server v8.2 dropped it as well.~

~An alternative solution to the issues for people on Laravel 6 LTS and keep PHP 7.2 support is to constrain `lcobucci/jwt` to `<=3.3.` but that then we won't be able to offer PHP 8 support on Passport 9.~

~@taylorotwell I'll leave it up to you to decide on this.~

Thanks to @Sephster PHP 7.2 was re-added to OAuth2 Server 8 🎉 