### PR TITLE
[10.x] Return a value after revoke refresh token

### DIFF
--- a/src/RefreshTokenRepository.php
+++ b/src/RefreshTokenRepository.php
@@ -56,7 +56,7 @@ class RefreshTokenRepository
      */
     public function revokeRefreshTokensByAccessTokenId($tokenId)
     {
-        Passport::refreshToken()->where('access_token_id', $tokenId)->update(['revoked' => true]);
+        return Passport::refreshToken()->where('access_token_id', $tokenId)->update(['revoked' => true]);
     }
 
     /**


### PR DESCRIPTION
I was trying to implement a logout function on my system. When user request a logout all access token and refresh token will be revoked. Only one access token and one refresh token can be actived at one time.

To revoke the access token I use this as shown in Laravel docs which will return `1` or `0` either success or failed updating the data:

```
public function revokeAccessToken($tokenId)
{
     $tokenRepository = app('Laravel\Passport\TokenRepository');
     return $tokenRepository->revokeAccessToken($tokenId);
}
```

For revoking refresh token here is the code:

```
public function revokeRefreshToken($tokenId)
{
    $refreshTokenRepository = app('Laravel\Passport\RefreshTokenRepository');
    return $refreshTokenRepository->revokeRefreshTokensByAccessTokenId($tokenId);
}
```

The problem is `revokeRefreshTokensByAccessTokenId` always return a null value even the data was successfully updated. This leads a problem when using database transaction.

Here is my code for database transaction:

```
$tokenId = 'the token id';
$valid = true;
$result = DB::transaction(function () use ($valid, $tokenId) {
    //here the return value is 1
    $valid = $valid && (bool) $this->revokeAccessToken($tokenId);

    //here the return value is null
    $valid = $valid && (bool) $this->revokeRefreshToken($tokenId);

    if (!$valid) {
        throw new \Exception('error!');
    }
});
```
Since the return value from `revokeRefreshTokensByAccessTokenId` always null, the `$valid` will always false and result to exception been thrown. This will lead to the token will not be revoked.

The reason why i need to use transaction because I need to check and make sure the access and refresh token are revoke altogether.