### PR TITLE
The `aud` is array in lcobucci/jwt v4

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Laravel\Passport\PassportUserProvider;
@@ -131,7 +132,7 @@ class TokenGuard
             );
         } elseif ($request->cookie(Passport::cookie())) {
             if ($token = $this->getTokenViaCookie($request)) {
-                return $this->clients->findActive($token['aud']);
+                return $this->clients->findActive(is_array($token['aud']) ? Arr::first($token['aud']) : $token['aud']);
             }
         }
     }

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Tests\Feature;
 
+use Arr;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Database\Schema\Blueprint;
@@ -87,6 +88,7 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertNull($token->name);
         $this->assertNull($token->user_id);
         $this->assertLessThanOrEqual(5, CarbonImmutable::now()->addSeconds($expiresInSeconds)->diffInSeconds($token->expires_at));
+        $this->assertEquals($client->id, Arr::first($jwtAccessToken->claims()->get('aud')));
     }
 
     public function testGettingAccessTokenWithClientCredentialsGrantInvalidClientSecret()
@@ -181,6 +183,7 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertTrue($token->client->is($client));
         $this->assertNull($token->name);
         $this->assertLessThanOrEqual(5, CarbonImmutable::now()->addSeconds($expiresInSeconds)->diffInSeconds($token->expires_at));
+        $this->assertEquals($client->id, Arr::first($jwtAccessToken->claims()->get('aud')));
     }
 
     public function testGettingAccessTokenWithPasswordGrantWithInvalidPassword()


### PR DESCRIPTION
lcobucci/jwt: https://github.com/lcobucci/jwt/blob/9c64c1739d9b8ceb1b919fbae3368ab6afef1d39/src/Token/Parser.php#L100
```
        if (array_key_exists(RegisteredClaims::AUDIENCE, $claims)) {
            $claims[RegisteredClaims::AUDIENCE] = (array) $claims[RegisteredClaims::AUDIENCE];
        }
```

RFC: https://tools.ietf.org/html/rfc7519#section-4.1.3

