### PR TITLE
[10.x] Add purging of invalid refresh tokens to command

### DIFF
--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -22,7 +22,7 @@ class PurgeCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Purge revoked and / or expired tokens and authentication codes';
+    protected $description = 'Purge revoked and / or expired tokens and authentication codes, and invalid refresh tokens.';
 
     /**
      * Execute the console command.
@@ -38,21 +38,21 @@ class PurgeCommand extends Command
             Passport::refreshToken()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
             Passport::refreshToken()->whereDoesntHave('accessToken')->delete();
 
-            $this->info('Purged revoked items and items expired for more than seven days.');
+            $this->info('Purged invalid refresh tokens, revoked items and items expired for more than seven days.');
         } elseif ($this->option('revoked')) {
             Passport::token()->where('revoked', 1)->delete();
             Passport::authCode()->where('revoked', 1)->delete();
             Passport::refreshToken()->where('revoked', 1)->delete();
             Passport::refreshToken()->whereDoesntHave('accessToken')->delete();
 
-            $this->info('Purged revoked items.');
+            $this->info('Purged invalid refresh tokens and revoked items.');
         } elseif ($this->option('expired')) {
             Passport::token()->whereDate('expires_at', '<', $expired)->delete();
             Passport::authCode()->whereDate('expires_at', '<', $expired)->delete();
             Passport::refreshToken()->whereDate('expires_at', '<', $expired)->delete();
             Passport::refreshToken()->whereDoesntHave('accessToken')->delete();
 
-            $this->info('Purged items expired for more than seven days.');
+            $this->info('Purged invalid refresh tokens and items expired for more than seven days.');
         }
     }
 }

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -36,18 +36,27 @@ class PurgeCommand extends Command
             Passport::token()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
             Passport::authCode()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
             Passport::refreshToken()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
+            Passport::refreshToken()->whereNotIn('access_token_id', function($subQuery) {
+                $subQuery->select('id')->from(Passport::token()->getTable());
+            })->delete();
 
             $this->info('Purged revoked items and items expired for more than seven days.');
         } elseif ($this->option('revoked')) {
             Passport::token()->where('revoked', 1)->delete();
             Passport::authCode()->where('revoked', 1)->delete();
             Passport::refreshToken()->where('revoked', 1)->delete();
+            Passport::refreshToken()->whereNotIn('access_token_id', function($subQuery) {
+                $subQuery->select('id')->from(Passport::token()->getTable());
+            })->delete();
 
             $this->info('Purged revoked items.');
         } elseif ($this->option('expired')) {
             Passport::token()->whereDate('expires_at', '<', $expired)->delete();
             Passport::authCode()->whereDate('expires_at', '<', $expired)->delete();
             Passport::refreshToken()->whereDate('expires_at', '<', $expired)->delete();
+            Passport::refreshToken()->whereNotIn('access_token_id', function($subQuery) {
+                $subQuery->select('id')->from(Passport::token()->getTable());
+            })->delete();
 
             $this->info('Purged items expired for more than seven days.');
         }

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -22,7 +22,7 @@ class PurgeCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Purge revoked and / or expired tokens and authentication codes, and invalid refresh tokens.';
+    protected $description = 'Purge revoked and / or expired tokens, authentication codes, and refresh tokens.';
 
     /**
      * Execute the console command.
@@ -38,21 +38,21 @@ class PurgeCommand extends Command
             Passport::refreshToken()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
             Passport::refreshToken()->whereDoesntHave('accessToken')->delete();
 
-            $this->info('Purged invalid refresh tokens, revoked items and items expired for more than seven days.');
+            $this->info('Purged invalid refresh tokens, revoked tokens, and tokens expired for more than seven days.');
         } elseif ($this->option('revoked')) {
             Passport::token()->where('revoked', 1)->delete();
             Passport::authCode()->where('revoked', 1)->delete();
             Passport::refreshToken()->where('revoked', 1)->delete();
             Passport::refreshToken()->whereDoesntHave('accessToken')->delete();
 
-            $this->info('Purged invalid refresh tokens and revoked items.');
+            $this->info('Purged invalid refresh tokens and revoked tokens.');
         } elseif ($this->option('expired')) {
             Passport::token()->whereDate('expires_at', '<', $expired)->delete();
             Passport::authCode()->whereDate('expires_at', '<', $expired)->delete();
             Passport::refreshToken()->whereDate('expires_at', '<', $expired)->delete();
             Passport::refreshToken()->whereDoesntHave('accessToken')->delete();
 
-            $this->info('Purged invalid refresh tokens and items expired for more than seven days.');
+            $this->info('Purged invalid refresh tokens and tokens expired for more than seven days.');
         }
     }
 }

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -36,27 +36,21 @@ class PurgeCommand extends Command
             Passport::token()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
             Passport::authCode()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
             Passport::refreshToken()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
-            Passport::refreshToken()->whereNotIn('access_token_id', function($subQuery) {
-                $subQuery->select('id')->from(Passport::token()->getTable());
-            })->delete();
+            Passport::refreshToken()->whereDoesntHave('accessToken')->delete();
 
             $this->info('Purged revoked items and items expired for more than seven days.');
         } elseif ($this->option('revoked')) {
             Passport::token()->where('revoked', 1)->delete();
             Passport::authCode()->where('revoked', 1)->delete();
             Passport::refreshToken()->where('revoked', 1)->delete();
-            Passport::refreshToken()->whereNotIn('access_token_id', function($subQuery) {
-                $subQuery->select('id')->from(Passport::token()->getTable());
-            })->delete();
+            Passport::refreshToken()->whereDoesntHave('accessToken')->delete();
 
             $this->info('Purged revoked items.');
         } elseif ($this->option('expired')) {
             Passport::token()->whereDate('expires_at', '<', $expired)->delete();
             Passport::authCode()->whereDate('expires_at', '<', $expired)->delete();
             Passport::refreshToken()->whereDate('expires_at', '<', $expired)->delete();
-            Passport::refreshToken()->whereNotIn('access_token_id', function($subQuery) {
-                $subQuery->select('id')->from(Passport::token()->getTable());
-            })->delete();
+            Passport::refreshToken()->whereDoesntHave('accessToken')->delete();
 
             $this->info('Purged items expired for more than seven days.');
         }

--- a/tests/Feature/Console/PurgeCommand.php
+++ b/tests/Feature/Console/PurgeCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature\Console;
+
+use Laravel\Passport\AuthCode;
+use Laravel\Passport\RefreshToken;
+use Laravel\Passport\Tests\Feature\PassportTestCase;
+use Laravel\Passport\Token;
+
+class PurgeCommand extends PassportTestCase
+{
+    public function test_purge()
+    {
+        $expired = now()->subDays(8);
+        $notExpired = now();
+
+        $accessTokenExpired = Token::create(['id' => 'a', 'user_id' => 1, 'client_id' => 1, 'revoked' => 0, 'expires_at' => $expired]);
+        $accessTokenRevoked = Token::create(['id' => 'b', 'user_id' => 1, 'client_id' => 1, 'revoked' => 1, 'expires_at' => $notExpired]);
+        $accessTokenOk = Token::create(['id' => 'c', 'user_id' => 1, 'client_id' => 1, 'revoked' => 0, 'expires_at' => $notExpired]);
+
+        $authCodeExpired = AuthCode::create(['id' => 'a', 'user_id' => 1, 'client_id' => 1, 'revoked' => 0, 'expires_at' => $expired]);
+        $authCodeRevoked = AuthCode::create(['id' => 'b', 'user_id' => 1, 'client_id' => 1, 'revoked' => 1, 'expires_at' => $notExpired]);
+        $authCodeOk = AuthCode::create(['id' => 'c', 'user_id' => 1, 'client_id' => 1, 'revoked' => 0, 'expires_at' => $notExpired]);
+
+        $refreshTokenExpired = RefreshToken::create(['id' => 'a', 'access_token_id' => $accessTokenExpired->id, 'revoked' => 0, 'expires_at' => $expired]);
+        $refreshTokenRevoked = RefreshToken::create(['id' => 'b', 'access_token_id' => $accessTokenRevoked->id, 'revoked' => 1, 'expires_at' => $notExpired]);
+        $refreshTokenInvalidAccessToken = RefreshToken::create(['id' => 'c', 'access_token_id' => 'xyz', 'revoked' => 0, 'expires_at' => $notExpired]);
+        $refreshTokenOk = RefreshToken::create(['id' => 'd', 'access_token_id' => $accessTokenOk->id, 'revoked' => 0, 'expires_at' => $notExpired]);
+
+        $this->artisan('passport:purge');
+
+        $this->assertFalse(Token::whereKey($accessTokenExpired->id)->exists());
+        $this->assertFalse(Token::whereKey($accessTokenRevoked->id)->exists());
+        $this->assertTrue(Token::whereKey($accessTokenOk->id)->exists());
+
+        $this->assertFalse(AuthCode::whereKey($authCodeExpired->id)->exists());
+        $this->assertFalse(AuthCode::whereKey($authCodeRevoked->id)->exists());
+        $this->assertTrue(AuthCode::whereKey($authCodeOk->id)->exists());
+
+        $this->assertFalse(RefreshToken::whereKey($refreshTokenExpired->id)->exists());
+        $this->assertFalse(RefreshToken::whereKey($refreshTokenRevoked->id)->exists());
+        $this->assertFalse(RefreshToken::whereKey($refreshTokenInvalidAccessToken->id)->exists());
+        $this->assertTrue(RefreshToken::whereKey($refreshTokenOk->id)->exists());
+    }
+}


### PR DESCRIPTION
The `passport:purge` command does a good job of removing revoked and expired tokens in the different tables, but we end up with lots of invalid refresh tokens pointing to non-existing access tokens. This PR adds purging of invalid refresh tokens to the command as well. Also added a test class for this command.