### PR TITLE
[10.x] Update to phpseclib v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "league/oauth2-server": "^8.2",
         "lcobucci/jwt": "^3.4|^4.0",
         "nyholm/psr7": "^1.3",
-        "phpseclib/phpseclib": "^2.0",
+        "phpseclib/phpseclib": "^3.0",
         "symfony/psr-http-message-bridge": "^2.0"
     },
     "require-dev": {

--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -3,9 +3,8 @@
 namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Arr;
 use Laravel\Passport\Passport;
-use phpseclib\Crypt\RSA;
+use phpseclib3\Crypt\RSA;
 
 class KeysCommand extends Command
 {
@@ -28,10 +27,9 @@ class KeysCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \phpseclib\Crypt\RSA  $rsa
      * @return void
      */
-    public function handle(RSA $rsa)
+    public function handle()
     {
         [$publicKey, $privateKey] = [
             Passport::keyPath('oauth-public.key'),
@@ -41,10 +39,10 @@ class KeysCommand extends Command
         if ((file_exists($publicKey) || file_exists($privateKey)) && ! $this->option('force')) {
             $this->error('Encryption keys already exist. Use the --force option to overwrite them.');
         } else {
-            $keys = $rsa->createKey($this->input ? (int) $this->option('length') : 4096);
+            $key = RSA::createKey($this->input ? (int) $this->option('length') : 4096);
 
-            file_put_contents($publicKey, Arr::get($keys, 'publickey'));
-            file_put_contents($privateKey, Arr::get($keys, 'privatekey'));
+            file_put_contents($publicKey, (string) $key->getPublicKey());
+            file_put_contents($privateKey, (string) $key);
 
             $this->info('Encryption keys generated successfully.');
         }

--- a/tests/Unit/KeysCommandTest.php
+++ b/tests/Unit/KeysCommandTest.php
@@ -6,7 +6,6 @@ use Illuminate\Container\Container;
 use Laravel\Passport\Console\KeysCommand;
 use Laravel\Passport\Passport;
 use Mockery as m;
-use phpseclib\Crypt\RSA;
 use PHPUnit\Framework\TestCase;
 
 class KeysCommandTest extends TestCase
@@ -41,9 +40,7 @@ class KeysCommandTest extends TestCase
 
         Container::getInstance()->instance('path.storage', self::KEYS);
 
-        $rsa = new RSA();
-
-        $command->handle($rsa);
+        $command->handle();
 
         $this->assertFileExists(self::PUBLIC_KEY);
         $this->assertFileExists(self::PRIVATE_KEY);
@@ -59,7 +56,7 @@ class KeysCommandTest extends TestCase
             ->with('Encryption keys generated successfully.')
             ->getMock();
 
-        $command->handle(new RSA);
+        $command->handle();
 
         $this->assertFileExists(self::PUBLIC_KEY);
         $this->assertFileExists(self::PRIVATE_KEY);
@@ -79,6 +76,6 @@ class KeysCommandTest extends TestCase
         $command->shouldReceive('error')
             ->with('Encryption keys already exist. Use the --force option to overwrite them.');
 
-        $command->handle(new RSA);
+        $command->handle();
     }
 }


### PR DESCRIPTION
There is technically a breaking change here for people people overwriting the `handle` method of the `KeysCommand`. I had to remove it because `RSA` is an abstract class in v3. I believe in reality there aren't many people who would be overwriting this command. phpseclib was first introduced in https://github.com/laravel/passport/pull/72 which adds the `RSA` class to the handle method but it's unclear why that was done. I cannot imagine anyone would want to swap it out.

Closes https://github.com/laravel/passport/issues/1409