### PR TITLE
[10.x] Add created_at and updated_at to date-mutator

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -50,7 +50,7 @@ class Token extends Model
      * @var array
      */
     protected $dates = [
-        'expires_at',
+        'created_at', 'updated_at', 'expires_at',
     ];
 
     /**


### PR DESCRIPTION
Unfortunately, the two variables `created_at` and `updated_at` are not automatically mutated. I could address the `expires_at` variable normally with Carbon, the other two not, because they were only a string.