### PR TITLE
[11.x] Revert model DB connection customization

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -46,21 +46,4 @@ return [
         'secret' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET'),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Passport Storage Driver
-    |--------------------------------------------------------------------------
-    |
-    | This configuration value allows you to customize the storage options
-    | for Passport, such as the database connection that should be used
-    | by Passport's internal database models which store tokens, etc.
-    |
-    */
-
-    'storage' => [
-        'database' => [
-            'connection' => env('DB_CONNECTION', 'mysql'),
-        ],
-    ],
-
 ];

--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -7,30 +7,13 @@ use Illuminate\Support\Facades\Schema;
 class CreateOauthAuthCodesTable extends Migration
 {
     /**
-     * The database schema.
-     *
-     * @var \Illuminate\Database\Schema\Builder
-     */
-    protected $schema;
-
-    /**
-     * Create a new migration instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->schema = Schema::connection($this->getConnection());
-    }
-
-    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        $this->schema->create('oauth_auth_codes', function (Blueprint $table) {
+        Schema::create('oauth_auth_codes', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->unsignedBigInteger('user_id')->index();
             $table->unsignedBigInteger('client_id');
@@ -47,16 +30,6 @@ class CreateOauthAuthCodesTable extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('oauth_auth_codes');
-    }
-
-    /**
-     * Get the migration connection name.
-     *
-     * @return string|null
-     */
-    public function getConnection()
-    {
-        return config('passport.storage.database.connection');
+        Schema::dropIfExists('oauth_auth_codes');
     }
 }

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -7,30 +7,13 @@ use Illuminate\Support\Facades\Schema;
 class CreateOauthAccessTokensTable extends Migration
 {
     /**
-     * The database schema.
-     *
-     * @var \Illuminate\Database\Schema\Builder
-     */
-    protected $schema;
-
-    /**
-     * Create a new migration instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->schema = Schema::connection($this->getConnection());
-    }
-
-    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        $this->schema->create('oauth_access_tokens', function (Blueprint $table) {
+        Schema::create('oauth_access_tokens', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->unsignedBigInteger('client_id');
@@ -49,16 +32,6 @@ class CreateOauthAccessTokensTable extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('oauth_access_tokens');
-    }
-
-    /**
-     * Get the migration connection name.
-     *
-     * @return string|null
-     */
-    public function getConnection()
-    {
-        return config('passport.storage.database.connection');
+        Schema::dropIfExists('oauth_access_tokens');
     }
 }

--- a/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
@@ -7,30 +7,13 @@ use Illuminate\Support\Facades\Schema;
 class CreateOauthRefreshTokensTable extends Migration
 {
     /**
-     * The database schema.
-     *
-     * @var \Illuminate\Database\Schema\Builder
-     */
-    protected $schema;
-
-    /**
-     * Create a new migration instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->schema = Schema::connection($this->getConnection());
-    }
-
-    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        $this->schema->create('oauth_refresh_tokens', function (Blueprint $table) {
+        Schema::create('oauth_refresh_tokens', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->string('access_token_id', 100)->index();
             $table->boolean('revoked');
@@ -45,16 +28,6 @@ class CreateOauthRefreshTokensTable extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('oauth_refresh_tokens');
-    }
-
-    /**
-     * Get the migration connection name.
-     *
-     * @return string|null
-     */
-    public function getConnection()
-    {
-        return config('passport.storage.database.connection');
+        Schema::dropIfExists('oauth_refresh_tokens');
     }
 }

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -7,40 +7,13 @@ use Illuminate\Support\Facades\Schema;
 class CreateOauthClientsTable extends Migration
 {
     /**
-     * The database schema.
-     *
-     * @var \Illuminate\Database\Schema\Builder
-     */
-    protected $schema;
-
-    /**
-     * Create a new migration instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->schema = Schema::connection($this->getConnection());
-    }
-
-    /**
-     * Get the migration connection name.
-     *
-     * @return string|null
-     */
-    public function getConnection()
-    {
-        return config('passport.storage.database.connection');
-    }
-
-    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        $this->schema->create('oauth_clients', function (Blueprint $table) {
+        Schema::create('oauth_clients', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->string('name');
@@ -61,6 +34,6 @@ class CreateOauthClientsTable extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('oauth_clients');
+        Schema::dropIfExists('oauth_clients');
     }
 }

--- a/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -7,30 +7,13 @@ use Illuminate\Support\Facades\Schema;
 class CreateOauthPersonalAccessClientsTable extends Migration
 {
     /**
-     * The database schema.
-     *
-     * @var \Illuminate\Database\Schema\Builder
-     */
-    protected $schema;
-
-    /**
-     * Create a new migration instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->schema = Schema::connection($this->getConnection());
-    }
-
-    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        $this->schema->create('oauth_personal_access_clients', function (Blueprint $table) {
+        Schema::create('oauth_personal_access_clients', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('client_id');
             $table->timestamps();
@@ -44,16 +27,6 @@ class CreateOauthPersonalAccessClientsTable extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('oauth_personal_access_clients');
-    }
-
-    /**
-     * Get the migration connection name.
-     *
-     * @return string|null
-     */
-    public function getConnection()
-    {
-        return config('passport.storage.database.connection');
+        Schema::dropIfExists('oauth_personal_access_clients');
     }
 }

--- a/src/AuthCode.php
+++ b/src/AuthCode.php
@@ -68,14 +68,4 @@ class AuthCode extends Model
     {
         return $this->belongsTo(Passport::clientModel());
     }
-
-    /**
-     * Get the current connection name for the model.
-     *
-     * @return string|null
-     */
-    public function getConnectionName()
-    {
-        return config('passport.storage.database.connection') ?? $this->connection;
-    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -185,16 +185,6 @@ class Client extends Model
     }
 
     /**
-     * Get the current connection name for the model.
-     *
-     * @return string|null
-     */
-    public function getConnectionName()
-    {
-        return config('passport.storage.database.connection') ?? $this->connection;
-    }
-
-    /**
      * Create a new factory instance for the model.
      *
      * @return \Illuminate\Database\Eloquent\Factories\Factory

--- a/src/PersonalAccessClient.php
+++ b/src/PersonalAccessClient.php
@@ -29,14 +29,4 @@ class PersonalAccessClient extends Model
     {
         return $this->belongsTo(Passport::clientModel());
     }
-
-    /**
-     * Get the current connection name for the model.
-     *
-     * @return string|null
-     */
-    public function getConnectionName()
-    {
-        return config('passport.storage.database.connection') ?? $this->connection;
-    }
 }

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -88,14 +88,4 @@ class RefreshToken extends Model
     {
         return false;
     }
-
-    /**
-     * Get the current connection name for the model.
-     *
-     * @return string|null
-     */
-    public function getConnectionName()
-    {
-        return config('passport.storage.database.connection') ?? $this->connection;
-    }
 }

--- a/src/Token.php
+++ b/src/Token.php
@@ -160,14 +160,4 @@ class Token extends Model
     {
         return false;
     }
-
-    /**
-     * Get the current connection name for the model.
-     *
-     * @return string|null
-     */
-    public function getConnectionName()
-    {
-        return config('passport.storage.database.connection') ?? $this->connection;
-    }
 }

--- a/tests/Feature/PassportTestCase.php
+++ b/tests/Feature/PassportTestCase.php
@@ -44,8 +44,6 @@ abstract class PassportTestCase extends TestCase
 
         $app['config']->set('database.default', 'testbench');
 
-        $app['config']->set('passport.storage.database.connection', 'testbench');
-
         $app['config']->set('database.connections.testbench', [
             'driver'   => 'sqlite',
             'database' => ':memory:',


### PR DESCRIPTION
This PR reverts https://github.com/laravel/passport/pull/1255. In hindsight that probably wasn't the best choice as it's [breaking some default Laravel behavior like the `--database` flag on the migration command](https://github.com/laravel/passport/issues/1370). This also causes Passport to differ from any other Laravel first party package (except Telescope). 

The problem that the PR wanted to solve can better be solved imo by overwriting the default models as explained here: https://laravel.com/docs/8.x/passport#overriding-default-models. In combination with [customizing the migrations](https://laravel.com/docs/8.x/passport#migration-customization) this already allows people to do whatever they want. I believe this is a more sensible approach to also keep the package straightforward and the code clean. I believe that not much people actually need https://github.com/laravel/passport/pull/1255. https://github.com/laravel/passport/pull/1255 wasn't documented anyway atm.

Targeting the next major Passport release because of the breaking change.

Ping @antonkomarev 

Fixes https://github.com/laravel/passport/issues/1370