### PR TITLE
[10.x] Backport phpseclib v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
         "illuminate/encryption": "^8.2",
         "illuminate/http": "^8.2",
         "illuminate/support": "^8.2",
-        "league/oauth2-server": "^8.2",
         "lcobucci/jwt": "^3.4|^4.0",
+        "league/oauth2-server": "^8.2",
         "nyholm/psr7": "^1.3",
-        "phpseclib/phpseclib": "^3.0",
+        "phpseclib/phpseclib": "^2.0|^3.0",
         "symfony/psr-http-message-bridge": "^2.0"
     },
     "require-dev": {

--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -3,8 +3,10 @@
 namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
 use Laravel\Passport\Passport;
 use phpseclib3\Crypt\RSA;
+use phpseclib\Crypt\RSA as LegacyRSA;
 
 class KeysCommand extends Command
 {
@@ -39,10 +41,17 @@ class KeysCommand extends Command
         if ((file_exists($publicKey) || file_exists($privateKey)) && ! $this->option('force')) {
             $this->error('Encryption keys already exist. Use the --force option to overwrite them.');
         } else {
-            $key = RSA::createKey($this->input ? (int) $this->option('length') : 4096);
+            if (class_exists(LegacyRSA::class)) {
+                $keys = (new LegacyRSA)->createKey($this->input ? (int) $this->option('length') : 4096);
 
-            file_put_contents($publicKey, (string) $key->getPublicKey());
-            file_put_contents($privateKey, (string) $key);
+                file_put_contents($publicKey, Arr::get($keys, 'publickey'));
+                file_put_contents($privateKey, Arr::get($keys, 'privatekey'));
+            } else {
+                $key = RSA::createKey($this->input ? (int) $this->option('length') : 4096);
+
+                file_put_contents($publicKey, (string) $key->getPublicKey());
+                file_put_contents($privateKey, (string) $key);
+            }
 
             $this->info('Encryption keys generated successfully.');
         }

--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -5,8 +5,8 @@ namespace Laravel\Passport\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Laravel\Passport\Passport;
-use phpseclib3\Crypt\RSA;
 use phpseclib\Crypt\RSA as LegacyRSA;
+use phpseclib3\Crypt\RSA;
 
 class KeysCommand extends Command
 {


### PR DESCRIPTION
This PR backports support for phpseclib v2 who are stuck on it due to 3rd party dependencies (like Flysystem v1's SFTP adapter).

See https://github.com/laravel/passport/issues/1416