### PR TITLE
Fix `$userId` type

### DIFF
--- a/src/Events/AccessTokenCreated.php
+++ b/src/Events/AccessTokenCreated.php
@@ -29,7 +29,7 @@ class AccessTokenCreated
      * Create a new event instance.
      *
      * @param  string  $tokenId
-     * @param  string  $userId
+     * @param  string|int|null  $userId
      * @param  string  $clientId
      * @return void
      */


### PR DESCRIPTION
The `$user_id` may be `int` and `null`.  
for example:  
The `$user_id` may be an `int` when using password grant.
The `$user_id` is `null` when using client grant.