### PR TITLE
[11.x] Allow timestamps on Token model

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -54,13 +54,6 @@ class Token extends Model
     ];
 
     /**
-     * Indicates if the model should be timestamped.
-     *
-     * @var bool
-     */
-    public $timestamps = false;
-
-    /**
      * Get the client that the token belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/tests/Unit/BridgeAccessTokenRepositoryTest.php
+++ b/tests/Unit/BridgeAccessTokenRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Tests\Unit;
 
 use Carbon\CarbonImmutable;
+use DateTime;
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Passport\Bridge\AccessToken;
 use Laravel\Passport\Bridge\AccessTokenRepository;
@@ -32,8 +33,8 @@ class BridgeAccessTokenRepositoryTest extends TestCase
             $this->assertSame('client-id', $array['client_id']);
             $this->assertEquals(['scopes'], $array['scopes']);
             $this->assertEquals(false, $array['revoked']);
-            $this->assertInstanceOf('DateTime', $array['created_at']);
-            $this->assertInstanceOf('DateTime', $array['updated_at']);
+            $this->assertInstanceOf(DateTime::class, $array['created_at']);
+            $this->assertInstanceOf(DateTime::class, $array['updated_at']);
             $this->assertEquals($expiration, $array['expires_at']);
         });
 


### PR DESCRIPTION
This PR removes the timestamp override on the Token model. I couldn't see any implications on this or reasoning why it was disabled in the first place.

Related issues/PRs:

- https://github.com/laravel/passport/pull/1411
- https://github.com/laravel/passport/issues/786
- https://github.com/laravel/passport/pull/787
- https://github.com/laravel/passport/pull/1075