### PR TITLE
Auth Query optimization for api calls

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -224,10 +224,8 @@ class ClientRepository
      * @param  int  $id
      * @return bool
      */
-    public function revoked($id)
+    public function revoked($client)
     {
-        $client = $this->find($id);
-
         return is_null($client) || $client->revoked;
     }
 

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -92,7 +92,7 @@ class TokenGuard
         $client = $this->client($request, $psr);
 
         if ($client && ! $client->provider) {
-            return true;
+            return $client;
         }
 
         return $client && $client->provider === $this->provider->getProviderName() ? $client : null;

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -133,12 +133,17 @@ class TokenGuard
     }
 
     /**
-     * Group similar function calls into one in order to stop using 2 extra queries
+     * Authenticate the incoming request via the Bearer token.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return array
+     * @return mixed
      */
-    protected function validateProvider($request, $psr){
+    protected function authenticateViaBearerToken($request)
+    {
+        if (! $psr = $this->getPsrRequestViaBearerToken($request)) {
+            return;
+        }
+
         $client = $this->hasValidProvider($request, $psr);
        
         if (!$client) {
@@ -151,24 +156,6 @@ class TokenGuard
         $user = $this->provider->retrieveById(
             $psr->getAttribute('oauth_user_id') ?: null
         );
-       
-        return [$client, $user];
-    }
-
-    /**
-     * Authenticate the incoming request via the Bearer token.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return mixed
-     */
-    protected function authenticateViaBearerToken($request)
-    {
-        if (! $psr = $this->getPsrRequestViaBearerToken($request)) {
-            return;
-        }
-
-        //Get Client (oauthClients table), User (users table)
-        list($client, $user) = $this->validateProvider($request, $psr);
 
         if (!$user) {
             return;

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -146,7 +146,7 @@ class TokenGuard
 
         $client = $this->hasValidProvider($request, $psr);
        
-        if (!$client) {
+        if (! $client) {
             return;
         }
 
@@ -157,7 +157,7 @@ class TokenGuard
             $psr->getAttribute('oauth_user_id') ?: null
         );
 
-        if (!$user) {
+        if (! $user) {
             return;
         }
 


### PR DESCRIPTION
While logging database queries I saw that there were 5 queries such as:

- 2 queries to oauth_clients table
- 3 queries to oauth_access_tokens table (2 of which were made by league/oauth2-server package)

In order to reduce number of queries some changes in code where made:
- revoked function in ClientRepository now will accept client as parameter instead of ID (this removes 1 query to oauth_clients table). Client object that is passed to this function is returned from findActive function in ClientRepository.
-  getPsrRequestViaBearerToken function in TokenGuard that returns some result from league/oauth2-server now will be passed as parameter to hasValidProvider and from there to client function in TokenGuard (this process removes 1 query from 3 total queries made to oauth_access_tokens table)

Changes that were made in this pull request will remove 2 queries out of 5, bringing down number of total queries on each request from 5 to 3.

