### PR TITLE
[11.x] Auth Query optimization for api calls

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -221,13 +221,11 @@ class ClientRepository
     /**
      * Determine if the given client is revoked.
      *
-     * @param  int  $id
+     * @param mixed $client
      * @return bool
      */
-    public function revoked($id)
+    public function revoked($client)
     {
-        $client = $this->find($id);
-
         return is_null($client) || $client->revoked;
     }
 

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -154,7 +154,6 @@ class TokenGuard
 
         $client = $this->hasValidProvider($request, $psr);
 
-
         if (! $client) {
             return;
         }

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -124,8 +124,8 @@ class TokenGuard
     public function client(Request $request, $psr = null)
     {
         if ($request->bearerToken()) {
-            if(! $psr){
-                if(! $psr = $this->getPsrRequestViaBearerToken($request)){
+            if(! $psr) {
+                if(! $psr = $this->getPsrRequestViaBearerToken($request)) {
                     return;
                 }
             }
@@ -153,6 +153,7 @@ class TokenGuard
         }
 
         $client = $this->hasValidProvider($request, $psr);
+
         
         if (! $client) {
             return;

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -124,8 +124,8 @@ class TokenGuard
     public function client(Request $request, $psr = null)
     {
         if ($request->bearerToken()) {
-            if(! $psr) {
-                if(! $psr = $this->getPsrRequestViaBearerToken($request)) {
+            if (! $psr) {
+                if (! $psr = $this->getPsrRequestViaBearerToken($request)) {
                     return;
                 }
             }
@@ -154,7 +154,7 @@ class TokenGuard
 
         $client = $this->hasValidProvider($request, $psr);
 
-        
+
         if (! $client) {
             return;
         }

--- a/tests/Unit/TokenGuardTest.php
+++ b/tests/Unit/TokenGuardTest.php
@@ -48,7 +48,7 @@ class TokenGuardTest extends TestCase
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
         $tokens->shouldReceive('find')->once()->with('token')->andReturn($token = m::mock());
-        $clients->shouldReceive('revoked')->with(1)->andReturn(false);
+        $clients->shouldReceive('revoked')->andReturn(false);
         $clients->shouldReceive('findActive')->with(1)->andReturn(new TokenGuardTestClient);
 
         $user = $guard->user($request);


### PR DESCRIPTION
While logging database queries I saw that there were **5 queries** such as:

**2 queries** to `oauth_clients` table
**3 queries** to `oauth_access_tokens` table (**2** of which were made by `league/oauth2-server` package)
In order to reduce number of queries some changes in code where made:

`revoked` function in ClientRepository now will accept client as parameter instead of ID (this removes **1 query** to `oauth_clients` table). Client object that is passed to this function is returned from findActive function in ClientRepository. To fit those changes I have removed `->with(1)` from clients mock in TokenGuardTests ( `revoked` ).
`getPsrRequestViaBearerToken` function in TokenGuard that returns some result from `league/oauth2-server` now will be passed as parameter to `hasValidProvider` and from there to `client` function in TokenGuard (this process removes **1 query** from **3 total queries** made to `oauth_access_tokens` table)
Changes that were made in this pull request will remove **2 queries** out of **5**, bringing down number of total **queries** on each request from **5** to **3**.

