### PR TITLE
Add prompt=login parameter option

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -58,6 +58,10 @@ class AuthorizationController
                               ClientRepository $clients,
                               TokenRepository $tokens)
     {
+        if ($request->get('prompt') === 'login') {
+            $request->session()->flush();
+        }
+
         $authRequest = $this->withErrorHandling(function () use ($psrRequest) {
             return $this->server->validateAuthorizationRequest($psrRequest);
         });


### PR DESCRIPTION
Add possibility to work with the prompt=login parameter so the user has to login again based on the OpenID specs:

https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest