### PR TITLE
Update TokenRepository.php

### DIFF
--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -73,7 +73,7 @@ class TokenRepository
      * @param  \Laravel\Passport\Token  $token
      * @return void
      */
-    public function save(Token $token)
+    public function save($token)
     {
         $token->save();
     }


### PR DESCRIPTION
Removing the Type of the Parameter here will allow us to use custom Token model class from auth service provider. Currently, I am having this issue.

`TypeError: Laravel\Passport\TokenRepository::save(): Argument #1 ($token) must be of type Laravel\Passport\Token, App\Models\Passport\Token given, called in /var/www/vendor/laravel/passport/src/PersonalAccessTokenFactory.php on line 80`
