### PR TITLE
Fix oauth2-server package require client_id string type

### DIFF
--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -100,7 +100,7 @@ class PersonalAccessTokenFactory
 
         return (new ServerRequest('POST', 'not-important'))->withParsedBody([
             'grant_type' => 'personal_access',
-            'client_id' => $client->id,
+            'client_id' => (string)$client->id,
             'client_secret' => $secret,
             'user_id' => $userId,
             'scope' => implode(' ', $scopes),


### PR DESCRIPTION
Hi,

Package oauth2-server just added type validation for redirect uri, client ID, client secret, scopes, auth code, state, username, and password inputs on 8.3.0 version

src/Grant/AbstractGrant.php line 241
if (\is_string($clientId))

Laravel Passport uses integers for $clientId

Please consider..