### PR TITLE
[10.x] Use Real Keys in Tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/http": "^8.2",
         "illuminate/support": "^8.2",
         "lcobucci/jwt": "^3.4|^4.0",
-        "league/oauth2-server": "^8.2",
+        "league/oauth2-server": "^8.3",
         "nyholm/psr7": "^1.3",
         "phpseclib/phpseclib": "^2.0|^3.0",
         "symfony/psr-http-message-bridge": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/http": "^8.2",
         "illuminate/support": "^8.2",
         "lcobucci/jwt": "^3.4|^4.0",
-        "league/oauth2-server": "^8.3",
+        "league/oauth2-server": "^8.2",
         "nyholm/psr7": "^1.3",
         "phpseclib/phpseclib": "^2.0|^3.0",
         "symfony/psr-http-message-bridge": "^2.0"

--- a/tests/Unit/PassportServiceProviderTest.php
+++ b/tests/Unit/PassportServiceProviderTest.php
@@ -40,12 +40,12 @@ class PassportServiceProviderTest extends TestCase
 
     public function test_can_use_crypto_keys_from_local_disk()
     {
+        Passport::loadKeysFrom(__DIR__.'/../keys');
+
         $privateKey = openssl_pkey_new();
 
         openssl_pkey_export_to_file($privateKey, __DIR__.'/../keys/oauth-private.key');
         openssl_pkey_export($privateKey, $privateKeyString);
-
-        Passport::loadKeysFrom(__DIR__.'/../keys');
 
         $config = m::mock(Config::class, function ($config) {
             $config->shouldReceive('get')->with('passport.private_key')->andReturn(null);

--- a/tests/Unit/PassportServiceProviderTest.php
+++ b/tests/Unit/PassportServiceProviderTest.php
@@ -13,10 +13,14 @@ class PassportServiceProviderTest extends TestCase
 {
     public function test_can_use_crypto_keys_from_config()
     {
-        $config = m::mock(Config::class, function ($config) {
+        $privateKey = openssl_pkey_new();
+
+        openssl_pkey_export($privateKey, $privateKeyString);
+
+        $config = m::mock(Config::class, function ($config) use ($privateKeyString) {
             $config->shouldReceive('get')
                 ->with('passport.private_key')
-                ->andReturn('-----BEGIN RSA PRIVATE KEY-----\nconfig\n-----END RSA PRIVATE KEY-----');
+                ->andReturn($privateKeyString);
         });
 
         $provider = new PassportServiceProvider(
@@ -29,19 +33,19 @@ class PassportServiceProviderTest extends TestCase
         })->call($provider);
 
         $this->assertSame(
-            "-----BEGIN RSA PRIVATE KEY-----\nconfig\n-----END RSA PRIVATE KEY-----",
+            $privateKeyString,
             file_get_contents($cryptKey->getKeyPath())
         );
     }
 
     public function test_can_use_crypto_keys_from_local_disk()
     {
-        Passport::loadKeysFrom(__DIR__.'/../keys');
+        $privateKey = openssl_pkey_new();
 
-        file_put_contents(
-            __DIR__.'/../keys/oauth-private.key',
-            "-----BEGIN RSA PRIVATE KEY-----\ndisk\n-----END RSA PRIVATE KEY-----"
-        );
+        openssl_pkey_export_to_file($privateKey, __DIR__.'/../keys/oauth-private.key');
+        openssl_pkey_export($privateKey, $privateKeyString);
+
+        Passport::loadKeysFrom(__DIR__.'/../keys');
 
         $config = m::mock(Config::class, function ($config) {
             $config->shouldReceive('get')->with('passport.private_key')->andReturn(null);
@@ -57,7 +61,7 @@ class PassportServiceProviderTest extends TestCase
         })->call($provider);
 
         $this->assertSame(
-            "-----BEGIN RSA PRIVATE KEY-----\ndisk\n-----END RSA PRIVATE KEY-----",
+            $privateKeyString,
             file_get_contents($cryptKey->getKeyPath())
         );
 


### PR DESCRIPTION
This PR changes the fake keys in Passport's test suite to use valid openssl generated keys. This change is required because the League's OAuth 2 server now validates keys using the openssl lib.

Previously keys were validated using basic regex matching. Keys are generated on the fly in this PR. It has negligible effects on runtime of tests but if you'd prefer hardcoded keys let me know. Cheers.
