### PR TITLE
Implement new oauth2-server revoke refresh tokens config option.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/support": "^6.18.31|^7.22.4",
         "laminas/laminas-diactoros": "^2.2",
         "lcobucci/jwt": "^3.4|^4.0",
-        "league/oauth2-server": "^8.2.3",
+        "league/oauth2-server": "^8.3",
         "nyholm/psr7": "^1.0",
         "phpseclib/phpseclib": "^2.0",
         "symfony/psr-http-message-bridge": "^2.0"

--- a/config/passport.php
+++ b/config/passport.php
@@ -63,4 +63,16 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Refresh token revocation
+    |--------------------------------------------------------------------------
+    |
+    | This configuration value allows you to switch revocation of oauth refresh
+    | tokens on or off. By default refresh tokens will always be revoked when
+    | used.
+    |
+    */
+
+    'revoke_refresh_tokens' => env('PASSPORT_REVOKE_REFRESH_TOKENS', true),
 ];

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -160,6 +160,13 @@ class Passport
     public static $withInheritedScopes = false;
 
     /**
+     * Indicates if refresh tokens should be revoked.
+     *
+     * @var bool
+     */
+    public static $revokeRefreshTokens = true;
+
+    /**
      * Enable the implicit grant type.
      *
      * @return static
@@ -690,5 +697,26 @@ class Passport
         static::$unserializesCookies = false;
 
         return new static;
+    }
+
+    /**
+     * Determine if refresh tokens must be revoked.
+     *
+     * @return bool
+     */
+    public static function revokeRefreshTokens()
+    {
+        return static::$revokeRefreshTokens;
+    }
+
+    /**
+     * Specify if refresh tokens should be revoked.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function setRevokeRefreshTokens(bool $value)
+    {
+        static::$revokeRefreshTokens = $value;
     }
 }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -93,6 +93,7 @@ class PassportServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/passport.php', 'passport');
 
         Passport::setClientUuids($this->app->make(Config::class)->get('passport.client_uuids', false));
+        Passport::setRevokeRefreshTokens($this->app->make(Config::class)->get('passport.revoke_refresh_tokens'));
 
         $this->registerAuthorizationServer();
         $this->registerResourceServer();
@@ -136,6 +137,8 @@ class PassportServiceProvider extends ServiceProvider
                         $this->makeImplicitGrant(), Passport::tokensExpireIn()
                     );
                 }
+
+                $server->revokeRefreshTokens(Passport::revokeRefreshTokens());
             });
         });
     }


### PR DESCRIPTION
This pr implements a newly added config option for oauth2-server package. The config options adds the ability to prevent refresh tokens from being revoked.

Hope someone can take a look at this. 
