### PR TITLE
[10.x] Implement new OAuth2 Server revoke refresh tokens config option

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -63,4 +63,16 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Refresh token revocation
+    |--------------------------------------------------------------------------
+    |
+    | This configuration value allows you to switch revocation of oauth refresh
+    | tokens on or off. By default refresh tokens will always be revoked when
+    | used.
+    |
+    */
+
+    'revoke_refresh_tokens' => env('PASSPORT_REVOKE_REFRESH_TOKENS', true),
 ];

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -146,6 +146,13 @@ class Passport
     public static $withInheritedScopes = false;
 
     /**
+     * Indicates if refresh tokens should be revoked.
+     *
+     * @var bool
+     */
+    public static $revokeRefreshTokens = true;
+
+    /**
      * Enable the implicit grant type.
      *
      * @return static
@@ -650,5 +657,26 @@ class Passport
         static::$unserializesCookies = false;
 
         return new static;
+    }
+
+    /**
+     * Determine if refresh tokens must be revoked.
+     *
+     * @return bool
+     */
+    public static function revokeRefreshTokens()
+    {
+        return static::$revokeRefreshTokens;
+    }
+
+    /**
+     * Specify if refresh tokens should be revoked.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function setRevokeRefreshTokens(bool $value)
+    {
+        static::$revokeRefreshTokens = $value;
     }
 }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -85,6 +85,7 @@ class PassportServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/passport.php', 'passport');
 
         Passport::setClientUuids($this->app->make(Config::class)->get('passport.client_uuids', false));
+        Passport::setRevokeRefreshTokens($this->app->make(Config::class)->get('passport.revoke_refresh_tokens'));
 
         $this->registerAuthorizationServer();
         $this->registerClientRepository();
@@ -129,6 +130,8 @@ class PassportServiceProvider extends ServiceProvider
                         $this->makeImplicitGrant(), Passport::tokensExpireIn()
                     );
                 }
+
+                $server->revokeRefreshTokens(Passport::revokeRefreshTokens());
             });
         });
     }


### PR DESCRIPTION
This pr implements a newly added config option for oauth2-server package. The config options adds the ability to prevent refresh tokens from being revoked.

Hope someone can take a look at this.