### PR TITLE
Fix tests failing due to latest OAuth 2 server release

### DIFF
--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -216,11 +216,11 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertArrayNotHasKey('expires_in', $decodedResponse);
         $this->assertArrayNotHasKey('access_token', $decodedResponse);
         $this->assertArrayNotHasKey('refresh_token', $decodedResponse);
+        $this->assertArrayNotHasKey('hint', $decodedResponse);
 
         $this->assertArrayHasKey('error', $decodedResponse);
         $this->assertSame('invalid_grant', $decodedResponse['error']);
         $this->assertArrayHasKey('error_description', $decodedResponse);
-        $this->assertArrayHasKey('hint', $decodedResponse);
         $this->assertArrayHasKey('message', $decodedResponse);
 
         $this->assertSame(0, Token::count());

--- a/tests/Unit/PassportServiceProviderTest.php
+++ b/tests/Unit/PassportServiceProviderTest.php
@@ -34,7 +34,7 @@ class PassportServiceProviderTest extends TestCase
 
         $this->assertSame(
             $privateKeyString,
-            file_get_contents($cryptKey->getKeyPath())
+            $cryptKey->getKeyContents()
         );
     }
 


### PR DESCRIPTION
This PR fixes tests in Passport that are broken due to small changes in the latest OAuth 2 server release. Namely:

* The invalid password error message has been made clearer. Previously this function set a blank string hint but now the hint is not set at all as the message is clear enough. Fixed the test so that we don't check for the hint key in the returned array from the exception
* Keys are no longer saved as files in the OAuth 2 server. If you passed an key as an in-memory key previously, we would save this as a file in the /tmp dir. There isn't really a need to do this as an in memory key is fine. I've tweaked a broken test to take note of this change.
