### PR TITLE
Add missing types to three models

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -23,14 +23,14 @@ class Client extends Model
      *
      * @var array
      */
-    protected $guarded = [];
+    protected array $guarded = [];
 
     /**
      * The attributes excluded from the model's JSON form.
      *
      * @var array
      */
-    protected $hidden = [
+    protected array $hidden = [
         'secret',
     ];
 
@@ -39,7 +39,7 @@ class Client extends Model
      *
      * @var array
      */
-    protected $casts = [
+    protected array $casts = [
         'grant_types' => 'array',
         'personal_access_client' => 'bool',
         'password_client' => 'bool',

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -32,14 +32,14 @@ class RefreshToken extends Model
      *
      * @var array
      */
-    protected $guarded = [];
+    protected array $guarded = [];
 
     /**
      * The attributes that should be cast to native types.
      *
      * @var array
      */
-    protected $casts = [
+    protected array $casts = [
         'revoked' => 'bool',
     ];
 
@@ -48,7 +48,7 @@ class RefreshToken extends Model
      *
      * @var array
      */
-    protected $dates = [
+    protected array $dates = [
         'expires_at',
     ];
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -32,14 +32,14 @@ class Token extends Model
      *
      * @var array
      */
-    protected $guarded = [];
+    protected array $guarded = [];
 
     /**
      * The attributes that should be cast to native types.
      *
      * @var array
      */
-    protected $casts = [
+    protected array $casts = [
         'scopes' => 'array',
         'revoked' => 'bool',
     ];
@@ -49,7 +49,7 @@ class Token extends Model
      *
      * @var array
      */
-    protected $dates = [
+    protected array $dates = [
         'expires_at',
     ];
 


### PR DESCRIPTION
Hi. I've done this simple pull request to fix the bug of #1473 which is caused by `\Illuminate\Database\Eloquent\Concerns\GuardsAttributes` trait which has strict types in it but some types are missed in these files `Token.php, `Client.php` and `RefreshToken.php`.

## What I've changed
I simply wrote `array` where needed in `Token.php`, `Client.php`, `RefreshToken.php`

## Does this PR breaks any behaviour?
No it does not on PHP 8.0 I don't know if it's better to target this PR on a "PHP 8 only" branch or something

## Why is this PR useful?
Some developers are encountering this problem even on fresh installations. I think this is an easy and fast fix