### PR TITLE
[10.x] Ensure client model factory always creates models with a primary key, even when events are disabled

### DIFF
--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -44,6 +44,7 @@ class ClientFactory extends Factory
     {
         if (Passport::clientUuids()) {
             $keyName = (new $this->model)->getKeyName();
+
             $data[$keyName] = (string) Str::orderedUuid();
         }
 


### PR DESCRIPTION
Fixes #1491

In short: Fixes the `ClientFactory` when using the `--uuids` option in conjunction with `Event::fake()` or quiet model creation

A few notes:
- There are currently 0 tests for clients using the UUIDs option, I found no easy way to add any without messing with the package's migrations so I opted not to add any
- This change should not be breaking