### PR TITLE
[10.x] Add custom encryption key for JWT tokens

### DIFF
--- a/src/ApiTokenCookieFactory.php
+++ b/src/ApiTokenCookieFactory.php
@@ -77,6 +77,6 @@ class ApiTokenCookieFactory
             'sub' => $userId,
             'csrf' => $csrfToken,
             'expiry' => $expiration->getTimestamp(),
-        ], Passport::encryptionKey($this->encrypter));
+        ], Passport::tokenEncryptionKey($this->encrypter));
     }
 }

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -269,7 +269,7 @@ class TokenGuard
     {
         return (array) JWT::decode(
             CookieValuePrefix::remove($this->encrypter->decrypt($request->cookie(Passport::cookie()), Passport::$unserializesCookies)),
-            Passport::encryptionKey($this->encrypter),
+            Passport::tokenEncryptionKey($this->encrypter),
             ['HS256']
         );
     }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -135,14 +135,18 @@ class Passport
     public static $unserializesCookies = false;
 
     /**
+     * Indicates if client secrets will be hashed.
+     *
      * @var bool
      */
     public static $hashesClientSecrets = false;
 
     /**
+     * The callback that should be used to generate JWT encryption keys.
+     *
      * @var callable
      */
-    public static $encryptsKeys;
+    public static $tokenEncryptionKeyCallback;
 
     /**
      * Indicates the scope should inherit its parent scope.
@@ -623,28 +627,28 @@ class Passport
     }
 
     /**
-     * Make Passport use your own encryption key when encrypting tokens.
+     * Specify the callback that should be invoked to generate encryption keys for encrypting JWT tokens.
      *
      * @param  callable  $callback
      * @return static
      */
-    public static function encryptTokenUsing($callback)
+    public static function encryptTokensUsing($callback)
     {
-        static::$encryptsKeys = $callback;
+        static::$tokenEncryptionKeyCallback = $callback;
 
         return new static;
     }
 
     /**
-     * Generates a token encryption key.
+     * Generate an encryption key for encrypting JWT tokens.
      *
      * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
      * @return string
      */
-    public static function encryptionKey(Encrypter $encrypter)
+    public static function tokenEncryptionKey(Encrypter $encrypter)
     {
-        return is_callable(static::$encryptsKeys) ?
-            (static::$encryptsKeys)($encrypter) :
+        return is_callable(static::$tokenEncryptionKeyCallback) ?
+            (static::$tokenEncryptionKeyCallback)($encrypter) :
             $encrypter->getKey();
     }
 

--- a/tests/Unit/ApiTokenCookieFactoryTest.php
+++ b/tests/Unit/ApiTokenCookieFactoryTest.php
@@ -38,7 +38,7 @@ class ApiTokenCookieFactoryTest extends TestCase
 
     public function test_cookie_can_be_successfully_created_when_using_a_custom_encryption_key()
     {
-        Passport::encryptTokenUsing(function (EncrypterContract $encrypter) {
+        Passport::encryptTokensUsing(function (EncrypterContract $encrypter) {
             return $encrypter->getKey().'.mykey';
         });
 
@@ -58,6 +58,6 @@ class ApiTokenCookieFactoryTest extends TestCase
         $this->assertInstanceOf(Cookie::class, $cookie);
 
         // Revert to the default encryption method
-        Passport::encryptTokenUsing(null);
+        Passport::encryptTokensUsing(null);
     }
 }

--- a/tests/Unit/TokenGuardTest.php
+++ b/tests/Unit/TokenGuardTest.php
@@ -232,7 +232,7 @@ class TokenGuardTest extends TestCase
 
     public function test_users_may_be_retrieved_from_cookies_with_xsrf_token_header_when_using_a_custom_encryption_key()
     {
-        Passport::encryptTokenUsing(function (EncrypterContract $encrypter) {
+        Passport::encryptTokensUsing(function (EncrypterContract $encrypter) {
             return $encrypter->getKey().'.mykey';
         });
 
@@ -256,7 +256,7 @@ class TokenGuardTest extends TestCase
                 'aud' => 1,
                 'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], Passport::encryptionKey($encrypter)), false)
+            ], Passport::tokenEncryptionKey($encrypter)), false)
         );
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
@@ -267,7 +267,7 @@ class TokenGuardTest extends TestCase
         $this->assertEquals($expectedUser, $user);
 
         // Revert to the default encryption method
-        Passport::encryptTokenUsing(null);
+        Passport::encryptTokensUsing(null);
     }
 
     public function test_xsrf_token_cookie_without_a_token_header_is_not_accepted()


### PR DESCRIPTION
This PR adds the ability to use a custom encryption key for encrypting tokens.

## Background
Passport provides a convenient way for authenticating front-end calls to the backend using a **XSRF token**: 

- The token is generated using the Encrypter class with the APP_KEY as the encryption key. 
- Authentication is successful when the submitted token can be decrypted in the backend using the same APP_KEY. 

The user id is retrieved from the payload and you're good to go.

## Problem

In some cases, the ability to decrypt the token is insufficient proof for establishing the user's identity. This happens when multi-tenancy is used (or multiple instances of the same application) while sharing the same APP_KEY among the tenants. 

For example, when using Archtechx's [tenancy](https://github.com/archtechx/tenancy) or Spatie's [laravel-multitenancy](https://spatie.be/docs/laravel-multitenancy/) together with separate databases per tenant, tokens that are encrypted by the first tenant will decrypt without a hassle by a second tenant. This causes a nasty security breach.

## Solution

Our initial thought was to rotate APP_KEY's for each environment, but that's quite complicated as the Encrypter is instantiated in quite an early stage in the Laravel lifecycle - and many developers recommend against changing the APP_KEY along the way.

This solution adds a callback method that provides a way of changing the encryption key without compromising the existing implementation:

```php

// Example code fragment. Tenant is represented by $instance.

Passport::encryptTokenUsing(function(Encrypter $encrypter) { 
    return $encrypter->getKey() . $instance->getKey();
});

```

Default behaviour is to remain using the APP_KEY by calling the `$encrypter->getKey()` method, which avoids breaking any existing implementations.

## Alternatives

- Rotating APP_KEY's per tenant: is discouraged by many (but perhaps unjustly?).
- Override the Encrypter's behaviour using the IoT Container: doesn't seem to work, the Encrypter is instantiated in an early stage, causing different APP_KEY's to be used throughout the request lifecycle.
- Create your own PassportServiceProvider that extends the existing one and override the token behaviour, which requires quite a bit of rewriting. It's an alternative, but many with the same setup would benefit from a built-in solution, mitigating potential security issues.
