### PR TITLE
[11.x] Allow authenticated client to be retrieved from the guard

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Http\Request;
+use Illuminate\Support\Traits\Macroable;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Laravel\Passport\PassportUserProvider;
@@ -24,7 +25,7 @@ use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 
 class TokenGuard implements Guard
 {
-    use GuardHelpers;
+    use GuardHelpers, Macroable;
 
     /**
      * The resource server instance.

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -146,6 +146,10 @@ class TokenGuard implements Guard
      */
     public function client()
     {
+        if (! is_null($this->client)) {
+            return $this->client;
+        }
+
         if ($this->request->bearerToken()) {
             if (! $psr = $this->getPsrRequestViaBearerToken($this->request)) {
                 return;

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -4,7 +4,6 @@ namespace Laravel\Passport;
 
 use DateInterval;
 use Illuminate\Auth\Events\Logout;
-use Illuminate\Auth\RequestGuard;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cookie;
@@ -341,19 +340,18 @@ class PassportServiceProvider extends ServiceProvider
      * Make an instance of the token guard.
      *
      * @param  array  $config
-     * @return \Illuminate\Auth\RequestGuard
+     * @return \Laravel\Passport\Guards\TokenGuard
      */
     protected function makeGuard(array $config)
     {
-        return new RequestGuard(function ($request) use ($config) {
-            return (new TokenGuard(
-                $this->app->make(ResourceServer::class),
-                new PassportUserProvider(Auth::createUserProvider($config['provider']), $config['provider']),
-                $this->app->make(TokenRepository::class),
-                $this->app->make(ClientRepository::class),
-                $this->app->make('encrypter')
-            ))->user($request);
-        }, $this->app['request']);
+        return new TokenGuard(
+            $this->app->make(ResourceServer::class),
+            new PassportUserProvider(Auth::createUserProvider($config['provider']), $config['provider']),
+            $this->app->make(TokenRepository::class),
+            $this->app->make(ClientRepository::class),
+            $this->app->make('encrypter'),
+            $this->app->make('request')
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes #882 

This PR allows developers to retrieve the currently authenticated client from the guard, this functionality was already present but inaccessible due to the guard being wrapped in another guard.
Tests all still work (I had to move some stuff around because request is now getting passed through the constructor, but I didn't functionally change any tests).

What this PR changes:
- Turns `TokenGuard` into an actual guard, implementing the `Guard` interface
- Removes the wrapped `RequestGuard`, instead `TokenGuard` is now used as is

A lot of the non-public methods on `TokenGuard` still take `$request` as an argument, which could be removed in favor of `$this->request`. I opted not to do this to keep the PR as small as possible