### PR TITLE
Fix str_replace error when third parameter ($subject) is null

### DIFF
--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -265,7 +265,7 @@ class PassportServiceProvider extends ServiceProvider
      */
     protected function makeCryptKey($type)
     {
-        $key = str_replace('\\n', "\n", $this->app->make(Config::class)->get('passport.'.$type.'_key') ?? "");
+        $key = str_replace('\\n', "\n", $this->app->make(Config::class)->get('passport.'.$type.'_key') ?? '');
 
         if (! $key) {
             $key = 'file://'.Passport::keyPath('oauth-'.$type.'.key');

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -265,7 +265,7 @@ class PassportServiceProvider extends ServiceProvider
      */
     protected function makeCryptKey($type)
     {
-        $key = str_replace('\\n', "\n", $this->app->make(Config::class)->get('passport.'.$type.'_key'));
+        $key = str_replace('\\n', "\n", $this->app->make(Config::class)->get('passport.'.$type.'_key') ?? "");
 
         if (! $key) {
             $key = 'file://'.Passport::keyPath('oauth-'.$type.'.key');


### PR DESCRIPTION
Using `PHP 8.1.0`

```
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/html/vendor/laravel/passport/src/PassportServiceProvider.php line 268
```
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
