### PR TITLE
fix: Internal method return types, php 8.1 tests compatibility

### DIFF
--- a/src/Bridge/Scope.php
+++ b/src/Bridge/Scope.php
@@ -25,6 +25,7 @@ class Scope implements ScopeEntityInterface
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getIdentifier();


### PR DESCRIPTION
Using PHP 8.1.0, passport 10.2.1 and running behat tests: 

```
During inheritance of JsonSerializable: Uncaught Behat\Testwork\Call\Exception\CallErrorException: 8192: 
Return type of Laravel\Passport\Bridge\Scope::jsonSerialize() should either be compatible with 
JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be 
used to temporarily suppress the notice in /var/www/vendor/laravel/passport/src/Bridge/Scope.php
 line 28 in /var/www/vendor/behat/behat/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php:90
```
