### PR TITLE
add optional clientId param to createToken

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -106,7 +106,7 @@ class ClientRepository
     /**
      * Get the personal access token client for the application.
      *
-     * @param  int|null $clientId
+     * @param  int|null  $clientId
      * @return \Laravel\Passport\Client
      *
      * @throws \RuntimeException

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -107,7 +107,6 @@ class ClientRepository
      * Get the personal access token client for the application.
      *
      * @param  int|null $clientId
-     *
      * @return \Laravel\Passport\Client
      *
      * @throws \RuntimeException

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -106,12 +106,18 @@ class ClientRepository
     /**
      * Get the personal access token client for the application.
      *
+     * @param  int|null $clientId
+     *
      * @return \Laravel\Passport\Client
      *
      * @throws \RuntimeException
      */
-    public function personalAccessClient()
+    public function personalAccessClient($clientId = null)
     {
+        if ($clientId) {
+            $this->personalAccessClientId = $clientId;
+        }
+
         if ($this->personalAccessClientId) {
             return $this->find($this->personalAccessClientId);
         }

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -57,9 +57,9 @@ trait HasApiTokens
     /**
      * Create a new personal access token for the user.
      *
-     * @param  int|null $clientId
-     * @param  string   $name
-     * @param  array    $scopes
+     * @param  int|null  $clientId
+     * @param  string  $name
+     * @param  array  $scopes
      * @return \Laravel\Passport\PersonalAccessTokenResult
      */
     public function createToken($name, array $scopes = [], $clientId = null)

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -57,14 +57,15 @@ trait HasApiTokens
     /**
      * Create a new personal access token for the user.
      *
-     * @param  string  $name
-     * @param  array  $scopes
+     * @param  int|null $clientId
+     * @param  string   $name
+     * @param  array    $scopes
      * @return \Laravel\Passport\PersonalAccessTokenResult
      */
-    public function createToken($name, array $scopes = [])
+    public function createToken($name, array $scopes = [], $clientId = null)
     {
         return Container::getInstance()->make(PersonalAccessTokenFactory::class)->make(
-            $this->getKey(), $name, $scopes
+            $this->getKey(), $name, $scopes, $clientId
         );
     }
 

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -63,10 +63,10 @@ class PersonalAccessTokenFactory
     /**
      * Create a new personal access token.
      *
-     * @param  int|null $clientId
-     * @param  mixed    $userId
-     * @param  string   $name
-     * @param  array    $scopes
+     * @param  int|null  $clientId
+     * @param  mixed  $userId
+     * @param  string  $name
+     * @param  array  $scopes
      * @return \Laravel\Passport\PersonalAccessTokenResult
      */
     public function make($userId, $name, array $scopes = [], $clientId = null)

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -63,15 +63,16 @@ class PersonalAccessTokenFactory
     /**
      * Create a new personal access token.
      *
-     * @param  mixed  $userId
-     * @param  string  $name
-     * @param  array  $scopes
+     * @param  int|null $clientId
+     * @param  mixed    $userId
+     * @param  string   $name
+     * @param  array    $scopes
      * @return \Laravel\Passport\PersonalAccessTokenResult
      */
-    public function make($userId, $name, array $scopes = [])
+    public function make($userId, $name, array $scopes = [], $clientId = null)
     {
         $response = $this->dispatchRequestToAuthorizationServer(
-            $this->createRequest($this->clients->personalAccessClient(), $userId, $scopes)
+            $this->createRequest($this->clients->personalAccessClient($clientId), $userId, $scopes)
         );
 
         $token = tap($this->findAccessToken($response), function ($token) use ($userId, $name) {

--- a/tests/Unit/HasApiTokensTest.php
+++ b/tests/Unit/HasApiTokensTest.php
@@ -32,7 +32,7 @@ class HasApiTokensTest extends TestCase
         $container = new Container;
         Container::setInstance($container);
         $container->instance(PersonalAccessTokenFactory::class, $factory = m::mock());
-        $factory->shouldReceive('make')->once()->with(1, 'name', ['scopes']);
+        $factory->shouldReceive('make')->once()->with(1, 'name', ['scopes'], null);
         $user = new HasApiTokensTestStub;
 
         $user->createToken('name', ['scopes']);


### PR DESCRIPTION
Currently, The `createToken` method uses the first personal access client from the database if the`passport.personal_access_client` config wasn't set at all.
I added the `clientId` param to the `createToken` method so you can create tokens for any clients by their id.