### PR TITLE
[11.x] Stub client on guard when calling Passport::actingAsClient()

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -13,6 +13,7 @@ use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Http\Request;
 use Illuminate\Support\Traits\Macroable;
+use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Laravel\Passport\PassportUserProvider;
@@ -352,5 +353,18 @@ class TokenGuard implements Guard
     public static function serialized()
     {
         return EncryptCookies::serialized('XSRF-TOKEN');
+    }
+
+    /**
+     * Set the client for the current request.
+     *
+     * @param  \Laravel\Passport\Client  $client
+     * @return $this
+     */
+    public function setClient(Client $client)
+    {
+        $this->client = $client;
+
+        return $this;
     }
 }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -381,7 +381,7 @@ class Passport
      *
      * @param  \Laravel\Passport\Client  $client
      * @param  array  $scopes
-     * @param  string $guard
+     * @param  string  $guard
      * @return \Laravel\Passport\Client
      */
     public static function actingAsClient($client, $scopes = [], $guard = 'api')

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -381,9 +381,10 @@ class Passport
      *
      * @param  \Laravel\Passport\Client  $client
      * @param  array  $scopes
+     * @param  string $guard
      * @return \Laravel\Passport\Client
      */
-    public static function actingAsClient($client, $scopes = [])
+    public static function actingAsClient($client, $scopes = [], $guard = 'api')
     {
         $token = app(self::tokenModel());
 
@@ -406,6 +407,10 @@ class Passport
         $mock->shouldReceive('find')->andReturn($token);
 
         app()->instance(TokenRepository::class, $mock);
+
+        app('auth')->guard($guard)->setClient($client);
+
+        app('auth')->shouldUse($guard);
 
         return $client;
     }

--- a/tests/Feature/ActingAsClientTest.php
+++ b/tests/Feature/ActingAsClientTest.php
@@ -9,7 +9,7 @@ use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
 use Laravel\Passport\Passport;
 use Orchestra\Testbench\TestCase;
 
-class ActingAsClientTest extends TestCase
+class ActingAsClientTest extends PassportTestCase
 {
     public function testActingAsClientWhenTheRouteIsProtectedByCheckClientCredentialsMiddleware()
     {
@@ -45,5 +45,12 @@ class ActingAsClientTest extends TestCase
         $response = $this->get('/foo');
         $response->assertSuccessful();
         $response->assertSee('bar');
+    }
+
+    public function testActingAsClientSetsTheClientOnTheGuard()
+    {
+        Passport::actingAsClient($client = new Client());
+
+        $this->assertSame($client, app('auth')->client());
     }
 }

--- a/tests/Feature/ActingAsClientTest.php
+++ b/tests/Feature/ActingAsClientTest.php
@@ -7,7 +7,6 @@ use Laravel\Passport\Client;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
 use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
 use Laravel\Passport\Passport;
-use Orchestra\Testbench\TestCase;
 
 class ActingAsClientTest extends PassportTestCase
 {


### PR DESCRIPTION
This PR changes the `Passport::actingAsClient()` method. Currently when stubbing the client via Passport, the guard doesn't actually reflect the stub:

```php
>>> $client = Laravel\Passport\Database\Factories\ClientFactory::new()->createOne()
=> Laravel\Passport\Client {#4807}
>>> Laravel\Passport\Passport::actingAsClient($client)
=> Laravel\Passport\Client {#4807}
>>> auth()->guard('api')->client()
=> null
```

After this PR the following happens:

```php
>>> $client = Laravel\Passport\Database\Factories\ClientFactory::new()->createOne()
=> Laravel\Passport\Client {#4807}
>>> Laravel\Passport\Passport::actingAsClient($client)
=> Laravel\Passport\Client {#4807}
>>> auth()->guard('api')->client()
=> Laravel\Passport\Client {#4807}
```

This makes `Passport::actingAsClient()` behave similar to `Passport::actingAs()` which sets the user on the api guard.

Why is this necessary:
- Code that uses Passport's middleware and also uses the TokenGuard to retrieve the client (e.g. for tracking which client created a model) will be hard to test because `Passport::actingAsClient()` does trick the middleware but not the guard. Note that this isn't an issue in the current version of Passport because `TokenGuard::client()` isn't currently accessible as a way to resolve the client making a request.

Breaking changes:
- This PR makes `Passport::actingAsClient()` assume that a `setClient()` method exists on the guard. This should almost never be a problem because you're testing Passport-related code specifically. But a `instanceof` check may be necessary to make it fully backwards compatible

Are there alternative ways of fixing this:
- Yes, you could mock the request instance as well, and make sure all the things that the guard checks return correctly. Though this has impact on the application state as whole (after all a lot of things rely on the request instance) and probably would introduce a lot of issues into tests calling `Passport::actingAsClient()`