### PR TITLE
Allow to use custom authorization server response

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -7,6 +7,7 @@ use DateInterval;
 use DateTimeInterface;
 use Illuminate\Contracts\Encryption\Encrypter;
 use League\OAuth2\Server\ResourceServer;
+use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Mockery;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -34,6 +35,13 @@ class Passport
     public static $scopes = [
         //
     ];
+
+    /**
+     * The authorization server response formatter.
+     *
+     * @var \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface|null
+     */
+    public static $authorizationServerResponseType = null;
 
     /**
      * The date when access tokens expire.

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -7,7 +7,6 @@ use DateInterval;
 use DateTimeInterface;
 use Illuminate\Contracts\Encryption\Encrypter;
 use League\OAuth2\Server\ResourceServer;
-use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Mockery;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -258,7 +258,8 @@ class PassportServiceProvider extends ServiceProvider
             $this->app->make(Bridge\AccessTokenRepository::class),
             $this->app->make(Bridge\ScopeRepository::class),
             $this->makeCryptKey('private'),
-            app('encrypter')->getKey()
+            app('encrypter')->getKey(),
+            Passport::$authorizationServerResponseType
         );
     }
 

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -10,6 +10,7 @@ use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Database\Factories\ClientFactory;
 use Laravel\Passport\HasApiTokens;
+use Laravel\Passport\Passport;
 use Laravel\Passport\Token;
 use Laravel\Passport\TokenRepository;
 use Lcobucci\JWT\Configuration;
@@ -270,9 +271,65 @@ class AccessTokenControllerTest extends PassportTestCase
 
         $this->assertSame(0, Token::count());
     }
+
+    public function testGettingCustomResponseType()
+    {
+        $this->withoutExceptionHandling();
+        Passport::$authorizationServerResponseType = new IdTokenResponse('foo_bar_open_id_token');
+
+        $user = new User();
+        $user->email = 'foo@gmail.com';
+        $user->password = $this->app->make(Hasher::class)->make('foobar123');
+        $user->save();
+
+        /** @var Client $client */
+        $client = ClientFactory::new()->asClientCredentials()->create(['user_id' => $user->id]);
+
+        $response = $this->post(
+            '/oauth/token',
+            [
+                'grant_type' => 'client_credentials',
+                'client_id' => $client->id,
+                'client_secret' => $client->secret,
+            ]
+        );
+
+        $response->assertOk();
+
+        $decodedResponse = $response->decodeResponseJson()->json();
+
+        $this->assertArrayHasKey('id_token', $decodedResponse);
+        $this->assertSame('foo_bar_open_id_token', $decodedResponse['id_token']);
+    }
 }
 
 class User extends \Illuminate\Foundation\Auth\User
 {
     use HasApiTokens;
+}
+
+class IdTokenResponse extends \League\OAuth2\Server\ResponseTypes\BearerTokenResponse
+{
+    /**
+     * @var string Id token.
+     */
+    protected $idToken;
+
+    /**
+     * @param string $idToken
+     */
+    public function __construct($idToken)
+    {
+        $this->idToken = $idToken;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getExtraParams(\League\OAuth2\Server\Entities\AccessTokenEntityInterface $accessToken)
+    {
+        return [
+            'id_token' => $this->idToken
+        ];
+    }
 }

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -316,7 +316,7 @@ class IdTokenResponse extends \League\OAuth2\Server\ResponseTypes\BearerTokenRes
     protected $idToken;
 
     /**
-     * @param string $idToken
+     * @param  string  $idToken
      */
     public function __construct($idToken)
     {
@@ -329,7 +329,7 @@ class IdTokenResponse extends \League\OAuth2\Server\ResponseTypes\BearerTokenRes
     protected function getExtraParams(\League\OAuth2\Server\Entities\AccessTokenEntityInterface $accessToken)
     {
         return [
-            'id_token' => $this->idToken
+            'id_token' => $this->idToken,
         ];
     }
 }


### PR DESCRIPTION
*league/oauth2-server* supports custom response type [https://github.com/thephpleague/oauth2-server/blob/master/src/AuthorizationServer.php#L103](https://github.com/thephpleague/oauth2-server/blob/master/src/AuthorizationServer.php#L103).

This pull request add possibility to override default "BearerTokenResponse" to custom schema (for example to add new extra parameters to support OpenID Connect flow...).

To override response need add to service provider:
```php
Passport::$authorizationServerResponseType = new CustomResponse();
```