### PR TITLE
[10.x] Allow to use custom authorization server response

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -37,6 +37,13 @@ class Passport
     ];
 
     /**
+     * The authorization server response formatter.
+     *
+     * @var \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface|null
+     */
+    public static $authorizationServerResponseType = null;
+
+    /**
      * The date when access tokens expire.
      *
      * @var \DateTimeInterface|null

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -37,13 +37,6 @@ class Passport
     ];
 
     /**
-     * The authorization server response formatter.
-     *
-     * @var \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface|null
-     */
-    public static $authorizationServerResponseType;
-
-    /**
      * The date when access tokens expire.
      *
      * @var \DateTimeInterface|null
@@ -188,6 +181,13 @@ class Passport
      * @var bool
      */
     public static $withInheritedScopes = false;
+
+    /**
+     * The authorization server response type.
+     *
+     * @var \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface|null
+     */
+    public static $authorizationServerResponseType;
 
     /**
      * Enable the implicit grant type.

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -41,7 +41,7 @@ class Passport
      *
      * @var \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface|null
      */
-    public static $authorizationServerResponseType = null;
+    public static $authorizationServerResponseType;
 
     /**
      * The date when access tokens expire.

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -212,7 +212,8 @@ class PassportServiceProvider extends ServiceProvider
             $this->app->make(Bridge\AccessTokenRepository::class),
             $this->app->make(Bridge\ScopeRepository::class),
             $this->makeCryptKey('private'),
-            app('encrypter')->getKey()
+            app('encrypter')->getKey(),
+            Passport::$authorizationServerResponseType
         );
     }
 


### PR DESCRIPTION
**league/oauth2-server** supports custom response type [https://github.com/thephpleague/oauth2-server/blob/master/src/AuthorizationServer.php#L103](https://github.com/thephpleague/oauth2-server/blob/master/src/AuthorizationServer.php#L103).

This pull request add possibility to override default "BearerTokenResponse" to custom schema (for example to add new extra parameters to support OpenID Connect flow...).

To override response need add to service provider:

```php
Passport::$authorizationServerResponseType = new CustomResponse();
```