### PR TITLE
Minor documentation tweak to UPGRADE.md

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,7 +16,7 @@ Laravel 8.0 is now the minimum required version.
 
 PR: https://github.com/laravel/passport/pull/1325
 
-The personal client configuration methods have been removed from the `Passport` class since they are no longer necessary. You should remove any calls to these methods from your `AuthServiceProvider` and `AppServiceProvider`.
+The personal client configuration methods have been removed from the `Passport` class since they are no longer necessary. You should remove any calls to these methods from your application's service providers.
 
 ## Upgrading To 9.0 From 8.x
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,7 +16,7 @@ Laravel 8.0 is now the minimum required version.
 
 PR: https://github.com/laravel/passport/pull/1325
 
-The personal client configuration methods have been removed from the `Passport` class since they are no longer necessary. You should remove calls to these methods from your `AuthServiceProvider`.
+The personal client configuration methods have been removed from the `Passport` class since they are no longer necessary. You should remove any calls to these methods from your `AuthServiceProvider` and `AppServiceProvider`.
 
 ## Upgrading To 9.0 From 8.x
 


### PR DESCRIPTION
I just went through the steps of upgrading passport from v8 to v10 and hit a minor snag that could have been solved by a tweak to the documentation.
When upgrading from v8 to v9 it says place two Passport static calls "within the `boot` method of your `AppServiceProvider`"
When upgrading from v9 to v10 it says you can remove the calls from your `AuthServiceProvider`.

I don't claim to know where those calls belonged in the first place, so this proposal just updates the documentation to list them both.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
