### PR TITLE
[10.x] Fix Faker deprecations

### DIFF
--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -25,9 +25,9 @@ class ClientFactory extends Factory
     {
         return $this->ensurePrimaryKeyIsSet([
             'user_id' => null,
-            'name' => $this->faker->company,
+            'name' => $this->faker->company(),
             'secret' => Str::random(40),
-            'redirect' => $this->faker->url,
+            'redirect' => $this->faker->url(),
             'personal_access_client' => false,
             'password_client' => false,
             'revoked' => false,


### PR DESCRIPTION
When using this factory in feature tests with `$this->withoutDeprecationHandling();` call the test fails as the deprecation gets converted to an exception:

```
Since fakerphp/faker 1.14: Accessing property "company" is deprecated, use "company()" instead.
```

https://github.com/FakerPHP/Faker/pull/164