### PR TITLE
Changed id column type to string in create_oauth_clients_table migrat…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -41,7 +41,7 @@ return new class extends Migration
     public function up()
     {
         $this->schema->create('oauth_clients', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->string('id');
             $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->string('name');
             $table->string('secret', 100)->nullable();


### PR DESCRIPTION
…ion to fix data truncated bug in creating new client via cli. Ref #1532

Fixed `SQLSTATE[01000]: Warning: 1265 Data truncated for column 'id' at row 1` error for `oauth_clients` table