### PR TITLE
Upgrade firebase/php-jwt to ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
-        "firebase/php-jwt": "^5.0",
+        "firebase/php-jwt": "^6.0",
         "illuminate/auth": "^8.37|^9.0",
         "illuminate/console": "^8.37|^9.0",
         "illuminate/container": "^8.37|^9.0",

--- a/src/ApiTokenCookieFactory.php
+++ b/src/ApiTokenCookieFactory.php
@@ -77,6 +77,6 @@ class ApiTokenCookieFactory
             'sub' => $userId,
             'csrf' => $csrfToken,
             'expiry' => $expiration->getTimestamp(),
-        ], Passport::tokenEncryptionKey($this->encrypter));
+        ], Passport::tokenEncryptionKey($this->encrypter), 'HS256');
     }
 }

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -4,6 +4,7 @@ namespace Laravel\Passport\Guards;
 
 use Exception;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Encryption\Encrypter;
@@ -269,8 +270,7 @@ class TokenGuard
     {
         return (array) JWT::decode(
             CookieValuePrefix::remove($this->encrypter->decrypt($request->cookie(Passport::cookie()), Passport::$unserializesCookies)),
-            Passport::tokenEncryptionKey($this->encrypter),
-            ['HS256']
+            new Key(Passport::tokenEncryptionKey($this->encrypter), 'HS256')
         );
     }
 

--- a/tests/Unit/TokenGuardTest.php
+++ b/tests/Unit/TokenGuardTest.php
@@ -134,7 +134,7 @@ class TokenGuardTest extends TestCase
                 'aud' => 1,
                 'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)), false)
+            ], str_repeat('a', 16), 'HS256'), false)
         );
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
@@ -167,7 +167,7 @@ class TokenGuardTest extends TestCase
                 'aud' => 1,
                 'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)), false)
+            ], str_repeat('a', 16), 'HS256'), false)
         );
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
@@ -196,7 +196,7 @@ class TokenGuardTest extends TestCase
                 'aud' => 1,
                 'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)))
+            ], str_repeat('a', 16), 'HS256'))
         );
 
         $userProvider->shouldReceive('retrieveById')->never();
@@ -222,7 +222,7 @@ class TokenGuardTest extends TestCase
                 'aud' => 1,
                 'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)))
+            ], str_repeat('a', 16), 'HS256'))
         );
 
         $userProvider->shouldReceive('retrieveById')->never();
@@ -256,7 +256,7 @@ class TokenGuardTest extends TestCase
                 'aud' => 1,
                 'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], Passport::tokenEncryptionKey($encrypter)), false)
+            ], Passport::tokenEncryptionKey($encrypter), 'HS256'), false)
         );
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
@@ -288,7 +288,7 @@ class TokenGuardTest extends TestCase
                 'aud' => 1,
                 'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)))
+            ], str_repeat('a', 16), 'HS256'))
         );
 
         $userProvider->shouldReceive('retrieveById')->never();
@@ -314,7 +314,7 @@ class TokenGuardTest extends TestCase
                 'aud' => 1,
                 'csrf' => 'token',
                 'expiry' => Carbon::now()->subMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)))
+            ], str_repeat('a', 16), 'HS256'))
         );
 
         $userProvider->shouldReceive('retrieveById')->never();
@@ -344,7 +344,7 @@ class TokenGuardTest extends TestCase
                 'sub' => 1,
                 'aud' => 1,
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)), false)
+            ], str_repeat('a', 16), 'HS256'), false)
         );
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
@@ -443,7 +443,7 @@ class TokenGuardTest extends TestCase
                 'aud' => 1,
                 'csrf' => 'token',
                 'expiry' => Carbon::now()->addMinutes(10)->getTimestamp(),
-            ], str_repeat('a', 16)), false)
+            ], str_repeat('a', 16), 'HS256'), false)
         );
 
         $clients->shouldReceive('findActive')->with(1)->andReturn($expectedClient = new TokenGuardTestClient);


### PR DESCRIPTION
The firebase/php-jwt package recently had to make breaking changes to resolve a security flaw in their library. This change upgrades that library and fixes the code that broke with the upgrade.

You can find more information about the fixes to the firebase/php-jwt here:
https://github.com/firebase/php-jwt/releases/tag/v6.0.0
https://github.com/firebase/php-jwt/issues/351
https://security.snyk.io/vuln/SNYK-PHP-FIREBASEPHPJWT-2434829

Hope this helps! Let me know if there's something else I can do to get this merged. Thanks! 😄 
