### PR TITLE
[10.x] Add new URI Rule to validate URI and use it to RedirectRule.

### DIFF
--- a/src/Http/Rules/RedirectRule.php
+++ b/src/Http/Rules/RedirectRule.php
@@ -4,6 +4,7 @@ namespace Laravel\Passport\Http\Rules;
 
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Contracts\Validation\Rule;
+use Laravel\Passport\Http\Rules\UriRule;
 
 class RedirectRule implements Rule
 {
@@ -31,7 +32,7 @@ class RedirectRule implements Rule
     public function passes($attribute, $value)
     {
         foreach (explode(',', $value) as $redirect) {
-            $validator = $this->validator->make(['redirect' => $redirect], ['redirect' => 'url']);
+            $validator = $this->validator->make(['redirect' => $redirect], ['redirect' => new UriRule]);
 
             if ($validator->fails()) {
                 return false;
@@ -46,6 +47,6 @@ class RedirectRule implements Rule
      */
     public function message()
     {
-        return 'One or more redirects have an invalid url format.';
+        return 'One or more redirects have an invalid URI format.';
     }
 }

--- a/src/Http/Rules/UriRule.php
+++ b/src/Http/Rules/UriRule.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Passport\Http\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class UriRule implements Rule
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function passes($attribute, $value): bool
+    {
+        if (filter_var($value, FILTER_VALIDATE_URL)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function message(): string
+    {
+        return 'The :attribute must be valid URI.';
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/laravel/passport/issues/1542

This PR add the support for URI e.g. `scheme://home-mobile` in `redirect` field for `\Laravel\Passport\Client`.