### PR TITLE
[10.x] Fix scope inheritance when using Passport::actingAs()

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -390,11 +390,8 @@ class Passport
      */
     public static function actingAs($user, $scopes = [], $guard = 'api')
     {
-        $token = Mockery::mock(self::tokenModel())->shouldIgnoreMissing(false);
-
-        foreach ($scopes as $scope) {
-            $token->shouldReceive('can')->with($scope)->andReturn(true);
-        }
+        $token = app(self::tokenModel());
+        $token->scopes = $scopes;
 
         $user->withAccessToken($token);
 

--- a/tests/Feature/ActingAsTest.php
+++ b/tests/Feature/ActingAsTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Passport\Tests\Feature;
 
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Route;
 use Laravel\Passport\HasApiTokens;
 use Laravel\Passport\Http\Middleware\CheckForAnyScope;
 use Laravel\Passport\Http\Middleware\CheckScopes;
@@ -59,6 +60,40 @@ class ActingAsTest extends PassportTestCase
         })->middleware(CheckForAnyScope::class.':admin,footest');
 
         Passport::actingAs(new PassportUser(), ['footest']);
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
+
+    public function testActingAsWhenTheRouteIsProtectedByCheckScopesMiddlewareWithInheritance()
+    {
+        Passport::$withInheritedScopes = true;
+
+        $this->withoutExceptionHandling();
+
+        Route::middleware(CheckScopes::class.':foo:bar,baz:qux')->get('/foo', function () {
+            return 'bar';
+        });
+
+        Passport::actingAs(new PassportUser(), ['foo', 'baz']);
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
+
+    public function testActingAsWhenTheRouteIsProtectedByCheckForAnyScopeMiddlewareWithInheritance()
+    {
+        Passport::$withInheritedScopes = true;
+
+        $this->withoutExceptionHandling();
+
+        Route::middleware(CheckForAnyScope::class.':foo:baz,baz:qux')->get('/foo', function () {
+            return 'bar';
+        });
+
+        Passport::actingAs(new PassportUser(), ['foo']);
 
         $response = $this->get('/foo');
         $response->assertSuccessful();


### PR DESCRIPTION
Fixes #1138 

This fixes the issue of inherited scopes not working with `Passport::actingAs()`, by not mocking the Token model and just passing a real one with the requested scopes. I couldn't find any reason as to why the model is currently mocked, and all the tests still seem to pass fine.

(PS. When will Passport 11 be released? Passport did not get a new major when Laravel 9 came out, is there some stuff that still needs to be done?)