### PR TITLE
[10.x] Add a route and a controller to revoke current token

### DIFF
--- a/src/Http/Controllers/RevokeAccessTokenController.php
+++ b/src/Http/Controllers/RevokeAccessTokenController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Passport\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Laravel\Passport\RefreshTokenRepository;
+
+class RevokeAccessTokenController
+{
+    /**
+     * The refresh token repository implementation.
+     *
+     * @var \Laravel\Passport\RefreshTokenRepository
+     */
+    protected $refreshTokenRepository;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @param  \Laravel\Passport\RefreshTokenRepository  $refreshTokenRepository
+     * @return void
+     */
+    public function __construct(RefreshTokenRepository $refreshTokenRepository)
+    {
+        $this->refreshTokenRepository = $refreshTokenRepository;
+    }
+
+    /**
+     * Revoke the current access token being used by the user.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function revokeToken(Request $request)
+    {
+        $token = $request->user()->token();
+
+        $token->revoke();
+
+        $this->refreshTokenRepository->revokeRefreshTokensByAccessTokenId($token->getKey());
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -87,6 +87,12 @@ class RouteRegistrar
                 'as' => 'passport.tokens.destroy',
             ]);
         });
+
+        $this->router->delete('/token', [
+            'middleware' => 'auth:api',
+            'uses' => 'RevokeAccessTokenController@revokeToken',
+            'as' => 'passport.token.destroy',
+        ]);
     }
 
     /**

--- a/tests/Unit/RevokeAccessTokenControllerTest.php
+++ b/tests/Unit/RevokeAccessTokenControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Laravel\Passport\Tests\Unit;
+
+use Illuminate\Http\Request;
+use Laravel\Passport\Http\Controllers\RevokeAccessTokenController;
+use Laravel\Passport\RefreshTokenRepository;
+use Laravel\Passport\Token;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class RevokeAccessTokenControllerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function test_current_token_can_be_revoked2()
+    {
+        $request = Request::create('/', 'GET');
+
+        $request->setUserResolver(function () {
+            $user = m::mock();
+            $user->shouldReceive('token')->once()->andReturn($token = m::mock(Token::class.'[revoke]'));
+
+            $token->shouldReceive('revoke')->once();
+
+            return $user;
+        });
+
+        $refreshTokenRepository = m::mock(RefreshTokenRepository::class);
+        $refreshTokenRepository->shouldReceive('revokeRefreshTokensByAccessTokenId')->once();
+
+        $controller = new RevokeAccessTokenController($refreshTokenRepository);
+
+        $response = $controller->revokeToken($request);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->status());
+    }
+}


### PR DESCRIPTION
Related to #1466 and #1389

This PR adds a new `DELETE /oauth/token` route to revoke the current access token being used by the user. This will be used for logout. I think it's good to have a built-in method to be used in logout process.

