### PR TITLE
[11.x] Drop PHP 7.x and Laravel v8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, '8.0', 8.1]
-        laravel: [8, 9]
-        exclude:
-          - php: 7.3
-            laravel: 9
-          - php: 7.4
-            laravel: 9
+        php: ['8.0', 8.1]
+        laravel: [9]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,18 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "firebase/php-jwt": "^6.0",
-        "illuminate/auth": "^8.37|^9.0",
-        "illuminate/console": "^8.37|^9.0",
-        "illuminate/container": "^8.37|^9.0",
-        "illuminate/contracts": "^8.37|^9.0",
-        "illuminate/cookie": "^8.37|^9.0",
-        "illuminate/database": "^8.37|^9.0",
-        "illuminate/encryption": "^8.37|^9.0",
-        "illuminate/http": "^8.37|^9.0",
-        "illuminate/support": "^8.37|^9.0",
+        "illuminate/auth": "^9.0",
+        "illuminate/console": "^9.0",
+        "illuminate/container": "^9.0",
+        "illuminate/contracts": "^9.0",
+        "illuminate/cookie": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/encryption": "^9.0",
+        "illuminate/http": "^9.0",
+        "illuminate/support": "^9.0",
         "lcobucci/jwt": "^3.4|^4.0",
         "league/oauth2-server": "^8.2",
         "nyholm/psr7": "^1.3",
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^6.0|^7.0",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.3"
     },
     "autoload": {


### PR DESCRIPTION
Dropping legacy PHP and Laravel versions in preparation for the next release.