### PR TITLE
[11.x] Remove deprecated functionality and simplify some feature tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/encryption": "^9.0",
         "illuminate/http": "^9.0",
         "illuminate/support": "^9.0",
-        "lcobucci/jwt": "^4.1.5",
+        "lcobucci/jwt": "^3.4|^4.0",
         "league/oauth2-server": "^8.2",
         "nyholm/psr7": "^1.3",
         "phpseclib/phpseclib": "^2.0|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/encryption": "^9.0",
         "illuminate/http": "^9.0",
         "illuminate/support": "^9.0",
-        "lcobucci/jwt": "^3.4|^4.0",
+        "lcobucci/jwt": "^4.1.5",
         "league/oauth2-server": "^8.2",
         "nyholm/psr7": "^1.3",
         "phpseclib/phpseclib": "^2.0|^3.0",

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -3,7 +3,6 @@
 namespace Laravel\Passport\Http\Controllers;
 
 use Laravel\Passport\TokenRepository;
-use Lcobucci\JWT\Parser as JwtParser;
 use League\OAuth2\Server\AuthorizationServer;
 use Nyholm\Psr7\Response as Psr7Response;
 use Psr\Http\Message\ServerRequestInterface;
@@ -27,27 +26,15 @@ class AccessTokenController
     protected $tokens;
 
     /**
-     * The JWT parser instance.
-     *
-     * @var \Lcobucci\JWT\Parser
-     *
-     * @deprecated This property will be removed in a future Passport version.
-     */
-    protected $jwt;
-
-    /**
      * Create a new controller instance.
      *
      * @param  \League\OAuth2\Server\AuthorizationServer  $server
      * @param  \Laravel\Passport\TokenRepository  $tokens
-     * @param  \Lcobucci\JWT\Parser  $jwt
      * @return void
      */
     public function __construct(AuthorizationServer $server,
-                                TokenRepository $tokens,
-                                JwtParser $jwt)
+                                TokenRepository $tokens)
     {
-        $this->jwt = $jwt;
         $this->server = $server;
         $this->tokens = $tokens;
     }

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -35,8 +35,6 @@ class PersonalAccessTokenFactory
      * The JWT token parser instance.
      *
      * @var \Lcobucci\JWT\Parser
-     *
-     * @deprecated This property will be removed in a future Passport version.
      */
     protected $jwt;
 
@@ -126,7 +124,7 @@ class PersonalAccessTokenFactory
      * @param  array  $response
      * @return \Laravel\Passport\Token
      */
-    protected function findAccessToken(array $response)
+    public function findAccessToken(array $response)
     {
         return $this->tokens->find(
             $this->jwt->parse($response['access_token'])->claims()->get('jti')

--- a/tests/Unit/AccessTokenControllerTest.php
+++ b/tests/Unit/AccessTokenControllerTest.php
@@ -5,7 +5,6 @@ namespace Laravel\Passport\Tests\Unit;
 use Laravel\Passport\Exceptions\OAuthServerException;
 use Laravel\Passport\Http\Controllers\AccessTokenController;
 use Laravel\Passport\TokenRepository;
-use Lcobucci\JWT\Parser;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException as LeagueException;
 use Mockery as m;
@@ -26,7 +25,6 @@ class AccessTokenControllerTest extends TestCase
         $request = m::mock(ServerRequestInterface::class);
         $response = m::type(ResponseInterface::class);
         $tokens = m::mock(TokenRepository::class);
-        $jwt = m::mock(Parser::class);
 
         $psrResponse = new Response();
         $psrResponse->getBody()->write(json_encode(['access_token' => 'access-token']));
@@ -36,7 +34,7 @@ class AccessTokenControllerTest extends TestCase
             ->with($request, $response)
             ->andReturn($psrResponse);
 
-        $controller = new AccessTokenController($server, $tokens, $jwt);
+        $controller = new AccessTokenController($server, $tokens);
 
         $this->assertSame('{"access_token":"access-token"}', $controller->issueToken($request)->getContent());
     }
@@ -44,14 +42,13 @@ class AccessTokenControllerTest extends TestCase
     public function test_exceptions_are_handled()
     {
         $tokens = m::mock(TokenRepository::class);
-        $jwt = m::mock(Parser::class);
 
         $server = m::mock(AuthorizationServer::class);
         $server->shouldReceive('respondToAccessTokenRequest')->with(
             m::type(ServerRequestInterface::class), m::type(ResponseInterface::class)
         )->andThrow(LeagueException::invalidCredentials());
 
-        $controller = new AccessTokenController($server, $tokens, $jwt);
+        $controller = new AccessTokenController($server, $tokens);
 
         $this->expectException(OAuthServerException::class);
 


### PR DESCRIPTION
I wanted to drop JWT v3 as well but given that `league/oauth2-server` still allows for it I guess it's best to wait until they drop it.