### PR TITLE
[11.x] Custom days and hours to passport purge command

### DIFF
--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -31,7 +31,7 @@ class PurgeCommand extends Command
      */
     public function handle()
     {
-        if($this->option('hours')){
+        if ($this->option('hours')) {
             $expired = Carbon::now()->subHours($this->option('hours'));
         } else {
             $expired = Carbon::now()->subHours($this->option('days'));

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -15,9 +15,8 @@ class PurgeCommand extends Command
      */
     protected $signature = 'passport:purge
                             {--revoked : Only purge revoked tokens and authentication codes}
-                            {--days=7 : Days expired tokens will be kept}
-                            {--hours= : Hours expired tokens will be kept}
-                            {--expired : Only purge expired tokens and authentication codes}';
+                            {--expired : Only purge expired tokens and authentication codes}
+                            {--hours= : The number of hours to retain expired tokens}';
 
     /**
      * The console command description.
@@ -31,11 +30,9 @@ class PurgeCommand extends Command
      */
     public function handle()
     {
-        if ($this->option('hours')) {
-            $expired = Carbon::now()->subHours($this->option('hours'));
-        } else {
-            $expired = Carbon::now()->subHours($this->option('days'));
-        }
+        $expired = $this->option('hours')
+            ? Carbon::now()->subHours($this->option('hours'))
+            : Carbon::now()->subDays(7);
 
         if (($this->option('revoked') && $this->option('expired')) ||
             (! $this->option('revoked') && ! $this->option('expired'))) {

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -15,6 +15,8 @@ class PurgeCommand extends Command
      */
     protected $signature = 'passport:purge
                             {--revoked : Only purge revoked tokens and authentication codes}
+                            {--days=7 : Days expired tokens will be kept}
+                            {--hours= : Hours expired tokens will be kept}
                             {--expired : Only purge expired tokens and authentication codes}';
 
     /**
@@ -29,7 +31,11 @@ class PurgeCommand extends Command
      */
     public function handle()
     {
-        $expired = Carbon::now()->subDays(7);
+        if($this->option('hours')){
+            $expired = Carbon::now()->subHours($this->option('hours'));
+        } else {
+            $expired = Carbon::now()->subHours($this->option('days'));
+        }
 
         if (($this->option('revoked') && $this->option('expired')) ||
             (! $this->option('revoked') && ! $this->option('expired'))) {


### PR DESCRIPTION
For some deploys, especially big projects/companies with a lot of traffic, the default days in passport:purge command is not enough. 

The solution is setting a --days and --hours parameter, to set the custom times. By default the behaviour is not changing and still being the default 7 days
