### PR TITLE
[11.x] Allow for bootstrapping without loading routes

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -162,6 +162,13 @@ class Passport
     public static $authorizationServerResponseType;
 
     /**
+     * Indicates if Passport routes will be registered.
+     *
+     * @var bool
+     */
+    public static $registersRoutes = true;
+
+    /**
      * Enable the implicit grant type.
      *
      * @return static
@@ -662,6 +669,18 @@ class Passport
     public static function withoutCookieSerialization()
     {
         static::$unserializesCookies = false;
+
+        return new static;
+    }
+
+    /**
+     * Configure Passport to not register its routes.
+     *
+     * @return static
+     */
+    public static function ignoreRoutes()
+    {
+        static::$registersRoutes = false;
 
         return new static;
     }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -638,6 +638,18 @@ class Passport
     }
 
     /**
+     * Configure Passport to not register its routes.
+     *
+     * @return static
+     */
+    public static function ignoreRoutes()
+    {
+        static::$registersRoutes = false;
+
+        return new static;
+    }
+
+    /**
      * Configure Passport to not register its migrations.
      *
      * @return static
@@ -669,18 +681,6 @@ class Passport
     public static function withoutCookieSerialization()
     {
         static::$unserializesCookies = false;
-
-        return new static;
-    }
-
-    /**
-     * Configure Passport to not register its routes.
-     *
-     * @return static
-     */
-    public static function ignoreRoutes()
-    {
-        static::$registersRoutes = false;
 
         return new static;
     }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -50,13 +50,15 @@ class PassportServiceProvider extends ServiceProvider
      */
     protected function registerRoutes()
     {
-        Route::group([
-            'as' => 'passport.',
-            'prefix' => config('passport.path', 'oauth'),
-            'namespace' => 'Laravel\Passport\Http\Controllers',
-        ], function () {
-            $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
-        });
+        if (Passport::$registersRoutes) {
+            Route::group([
+                'as' => 'passport.',
+                'prefix' => config('passport.path', 'oauth'),
+                'namespace' => 'Laravel\Passport\Http\Controllers',
+            ], function () {
+                $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Passport's bootstrapping of routes was changed recently (https://github.com/laravel/passport/pull/1464), this PR aims to make it a little easier for developers to disable the routes that ship with Passport (which currently requires disabling its service provider and replacing it with a custom one).

PS. I lifted this code from Fortify