### PR TITLE
[11.x] Support prompting re-consent when redirecting for authorization

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -99,7 +99,7 @@ class AuthorizationController
     }
 
     /**
-     * Check if a valid token exists for the given user, client and scopes.
+     * Determine if a valid token exists for the given user, client, and scopes.
      *
      * @param  \Laravel\Passport\TokenRepository  $tokens
      * @param  \Illuminate\Database\Eloquent\Model  $user

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -63,14 +63,11 @@ class AuthorizationController
         });
 
         $scopes = $this->parseScopes($authRequest);
+        $user = $request->user();
+        $client = $clients->find($authRequest->getClient()->getIdentifier());
 
-        $token = $tokens->findValidToken(
-            $user = $request->user(),
-            $client = $clients->find($authRequest->getClient()->getIdentifier())
-        );
-
-        if (($token && $token->scopes === collect($scopes)->pluck('id')->all()) ||
-            $client->skipsAuthorization()) {
+        if ($request->get('prompt') !== 'consent' &&
+            ($client->skipsAuthorization() || $this->hasValidToken($tokens, $user, $client, $scopes))) {
             return $this->approveRequest($authRequest, $user);
         }
 
@@ -99,6 +96,22 @@ class AuthorizationController
                 return $scope->getIdentifier();
             })->unique()->all()
         );
+    }
+
+    /**
+     * Check if a valid token exists for the given user, client and scopes.
+     *
+     * @param  \Laravel\Passport\TokenRepository  $tokens
+     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @param  \Laravel\Passport\Client  $client
+     * @param  array  $scopes
+     * @return bool
+     */
+    protected function hasValidToken($tokens, $user, $client, $scopes)
+    {
+        $token = $tokens->findValidToken($user, $client);
+
+        return $token && $token->scopes === collect($scopes)->pluck('id')->all();
     }
 
     /**


### PR DESCRIPTION
### The problem
Related to #1389 

Let's assume we have a 3rd-party app that uses our API via authorization code grant (w/ or w/o PKCE) and a user that is signed in on several devices (i.e. has already several valid tokens) tries to switch his account (logout on the 3rd-party app and sign-in with a different account). 

Currently **it is impossible**, because after he logs out (we revoke the current token) and wants to login again (we redirect to authorization route), the user is automatically signed in again, which leads to a **dead-loop UX**.

### The Solution
In most authorization servers, there is a `prompt` parameter that specifies whether the authorization server prompts the user for reauthentication and consent. The most common `prompt` values are `none`, `login` and `consent`.

This PR implements the `prompt=consent` that causes the authorization server always prompts the user for consent.

PS 1: If you a agree with these changes I can also add support for `prompt=none` and `prompt=login`.
PS 2: Here are the related explanations on Google authentication docs:
* https://developers.google.com/identity/gsi/web/guides/automatic-sign-in-sign-out#sign-out
* https://developers.google.com/identity/protocols/oauth2/openid-connect#re-consent



