### PR TITLE
[11.x] Support prompting login when redirecting for authorization

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -8,15 +8,16 @@ Route::post('/token', [
     'middleware' => 'throttle',
 ]);
 
+Route::get('/authorize', [
+    'uses' => 'AuthorizationController@authorize',
+    'as' => 'authorizations.authorize',
+    'middleware' => 'web',
+]);
+
 Route::middleware(['web', 'auth'])->group(function () {
     Route::post('/token/refresh', [
         'uses' => 'TransientTokenController@refresh',
         'as' => 'token.refresh',
-    ]);
-
-    Route::get('/authorize', [
-        'uses' => 'AuthorizationController@authorize',
-        'as' => 'authorizations.authorize',
     ]);
 
     Route::post('/authorize', [

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -188,7 +188,9 @@ class AuthorizationController
                     ? $authRequest->getClient()->getRedirectUri()[0]
                     : $authRequest->getClient()->getRedirectUri());
 
-            $uri = $uri.(str_contains($uri, '?') ? '&' : '?').'state='.$authRequest->getState();
+            $separator = $authRequest->getGrantTypeId() === 'implicit' ? '#' : '?';
+
+            $uri = $uri.(str_contains($uri, $separator) ? '&' : $separator).'state='.$authRequest->getState();
 
             return $this->withErrorHandling(function () use ($uri) {
                 throw OAuthServerException::accessDenied('Unauthenticated', $uri);

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -318,6 +318,7 @@ class AuthorizationControllerTest extends TestCase
         $authRequest->shouldReceive('getRedirectUri')->andReturn('http://localhost');
         $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn('http://localhost');
         $authRequest->shouldReceive('getState')->andReturn('state');
+        $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
 
         $clients = m::mock(ClientRepository::class);
         $tokens = m::mock(TokenRepository::class);


### PR DESCRIPTION
Related to #1389

As explained on #1567 and in addition to #1569, this PR adds support for `prompt=login` that causes the authorization server to display the login page first.

This PR also causes `prompt=none` to return an error if the user is not already authenticated instead of prompting the login page, which is the expected behavior (to prompt nothing).

PS: I'll send a PR to laravel/docs to explain `prompt` after this.