### PR TITLE
[11.x] Let OAuth2 server handle the denying response

### DIFF
--- a/src/Http/Controllers/ApproveAuthorizationController.php
+++ b/src/Http/Controllers/ApproveAuthorizationController.php
@@ -8,7 +8,7 @@ use Nyholm\Psr7\Response as Psr7Response;
 
 class ApproveAuthorizationController
 {
-    use ConvertsPsrResponses, RetrievesAuthRequestFromSession;
+    use ConvertsPsrResponses, HandlesOAuthErrors, RetrievesAuthRequestFromSession;
 
     /**
      * The authorization server.
@@ -40,8 +40,12 @@ class ApproveAuthorizationController
 
         $authRequest = $this->getAuthRequestFromSession($request);
 
-        return $this->convertResponse(
-            $this->server->completeAuthorizationRequest($authRequest, new Psr7Response)
-        );
+        $authRequest->setAuthorizationApproved(true);
+
+        return $this->withErrorHandling(function () use ($authRequest) {
+            return $this->convertResponse(
+                $this->server->completeAuthorizationRequest($authRequest, new Psr7Response)
+            );
+        });
     }
 }

--- a/src/Http/Controllers/RetrievesAuthRequestFromSession.php
+++ b/src/Http/Controllers/RetrievesAuthRequestFromSession.php
@@ -42,8 +42,6 @@ trait RetrievesAuthRequestFromSession
             }
 
             $authRequest->setUser(new User($request->user()->getAuthIdentifier()));
-
-            $authRequest->setAuthorizationApproved(true);
         });
     }
 }


### PR DESCRIPTION
This PR uses OAuth2 server to handle denying the authorization request instead of manually generating the redirect response. The OAuth2 Server handles the `access_denied` status and also sets a proper `error_description` in the returned query string for both implicit and authorization code grants.

This PR also fixes another minor issue; Every call to OAuth2 server is wrapped by `HandlesOAuthErrors` but it wasn't the case on `ApproveAuthorizationController`; It is handled now.