### PR TITLE
[11.x] Add the ability to regenerate client secret

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,11 @@ Route::middleware(['web', 'auth'])->group(function () {
         'as' => 'clients.update',
     ]);
 
+    Route::put('/clients/{client_id}/generate-secret', [
+        'uses' => 'ClientController@generateSecret',
+        'as' => 'clients.update.secret',
+    ]);
+
     Route::delete('/clients/{client_id}', [
         'uses' => 'ClientController@destroy',
         'as' => 'clients.destroy',

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -97,7 +97,7 @@ class ClientRepository implements ClientRepositoryInterface
      * @param  string  $storedHash
      * @return bool
      */
-    protected function verifySecret($clientSecret, $storedHash)
+    public function verifySecret($clientSecret, $storedHash)
     {
         return Passport::$hashesClientSecrets
                     ? password_verify($clientSecret, $storedHash)


### PR DESCRIPTION
As discussed several days ago at #1568 , this PR allows users to generate a new client secret. These changes are fully backward compatible and the tests are included.

[This comment](https://github.com/laravel/passport/issues/1568#issuecomment-1237116832) explains the benefits of having this feature.

### Considerations
- Updating a client secret will require an authenticated user to provide the previous client secret. This stays consistent with the behavior of getting a new auth token which requires a refresh token.
- I have covered 3 different scenarios of the feature that I added in one test while ensuring everything is still neat, readable, and comprehensive. This allowed me to avoid repeating a dozen lines of test boilerplate code. It may be split to multiple tests if preferred.
