### PR TITLE
[11.x] Support prompting login when redirecting for authorization

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -8,15 +8,16 @@ Route::post('/token', [
     'middleware' => 'throttle',
 ]);
 
+Route::get('/authorize', [
+    'uses' => 'AuthorizationController@authorize',
+    'as' => 'authorizations.authorize',
+    'middleware' => 'web',
+]);
+
 Route::middleware(['web', 'auth'])->group(function () {
     Route::post('/token/refresh', [
         'uses' => 'TransientTokenController@refresh',
         'as' => 'token.refresh',
-    ]);
-
-    Route::get('/authorize', [
-        'uses' => 'AuthorizationController@authorize',
-        'as' => 'authorizations.authorize',
     ]);
 
     Route::post('/authorize', [

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -188,7 +188,9 @@ class AuthorizationController
                     ? $authRequest->getClient()->getRedirectUri()[0]
                     : $authRequest->getClient()->getRedirectUri());
 
-            $uri = $uri.(str_contains($uri, '?') ? '&' : '?').'state='.$authRequest->getState();
+            $separator = $authRequest->getGrantTypeId() === 'implicit' ? '#' : '?';
+
+            $uri = $uri.(str_contains($uri, $separator) ? '&' : $separator).'state='.$authRequest->getState();
 
             return $this->withErrorHandling(function () use ($uri) {
                 throw OAuthServerException::accessDenied('Unauthenticated', $uri);

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport;
 use DateInterval;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Config\Repository as Config;
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Event;
@@ -133,6 +134,10 @@ class PassportServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/passport.php', 'passport');
 
         Passport::setClientUuids($this->app->make(Config::class)->get('passport.client_uuids', false));
+
+        $this->app->bind(StatefulGuard::class, function () {
+            return Auth::guard();
+        });
 
         $this->registerAuthorizationServer();
         $this->registerClientRepository();

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -15,6 +15,7 @@ use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Bridge\PersonalAccessGrant;
 use Laravel\Passport\Bridge\RefreshTokenRepository;
 use Laravel\Passport\Guards\TokenGuard;
+use Laravel\Passport\Http\Controllers\AuthorizationController;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Parser;
 use League\OAuth2\Server\AuthorizationServer;
@@ -135,9 +136,9 @@ class PassportServiceProvider extends ServiceProvider
 
         Passport::setClientUuids($this->app->make(Config::class)->get('passport.client_uuids', false));
 
-        $this->app->bind(StatefulGuard::class, function () {
-            return Auth::guard();
-        });
+        $this->app->when(AuthorizationController::class)
+                ->needs(StatefulGuard::class)
+                ->give(fn () => Auth::guard(config('passport.guard', null)));
 
         $this->registerAuthorizationServer();
         $this->registerClientRepository();

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -48,7 +48,7 @@ class AuthorizationControllerTest extends TestCase
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
         $session->shouldReceive('put')->with('authRequest', $authRequest);
-        $session->shouldReceive('forget')->with('authLoginPrompted')->once();
+        $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $request->shouldReceive('user')->andReturn($user = m::mock());
         $request->shouldReceive('get')->with('prompt')->andReturn(null);
 
@@ -124,7 +124,7 @@ class AuthorizationControllerTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
-        $session->shouldReceive('forget')->with('authLoginPrompted')->once();
+        $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $request->shouldReceive('user')->once()->andReturn($user = m::mock());
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldNotReceive('session');
@@ -174,7 +174,7 @@ class AuthorizationControllerTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
-        $session->shouldReceive('forget')->with('authLoginPrompted')->once();
+        $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $request->shouldReceive('user')->once()->andReturn($user = m::mock());
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldNotReceive('session');
@@ -220,7 +220,7 @@ class AuthorizationControllerTest extends TestCase
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
         $session->shouldReceive('put')->with('authRequest', $authRequest);
-        $session->shouldReceive('forget')->with('authLoginPrompted')->once();
+        $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $request->shouldReceive('user')->andReturn($user = m::mock());
         $request->shouldReceive('get')->with('prompt')->andReturn('consent');
 
@@ -272,7 +272,7 @@ class AuthorizationControllerTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
-        $session->shouldReceive('forget')->with('authLoginPrompted')->once();
+        $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $request->shouldReceive('user')->andReturn($user = m::mock());
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldReceive('get')->with('prompt')->andReturn('none');
@@ -353,9 +353,9 @@ class AuthorizationControllerTest extends TestCase
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('invalidate')->once();
         $session->shouldReceive('regenerateToken')->once();
-        $session->shouldReceive('get')->with('authLoginPrompted', false)->once()->andReturn(false);
-        $session->shouldReceive('put')->with('authLoginPrompted', true)->once();
-        $session->shouldNotReceive('forget')->with('authLoginPrompted');
+        $session->shouldReceive('get')->with('promptedForLogin', false)->once()->andReturn(false);
+        $session->shouldReceive('put')->with('promptedForLogin', true)->once();
+        $session->shouldNotReceive('forget')->with('promptedForLogin');
         $request->shouldReceive('get')->with('prompt')->andReturn('login');
 
         $clients = m::mock(ClientRepository::class);
@@ -382,8 +382,8 @@ class AuthorizationControllerTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldNotReceive('user');
         $request->shouldReceive('session')->andReturn($session = m::mock());
-        $session->shouldReceive('put')->with('authLoginPrompted', true)->once();
-        $session->shouldNotReceive('forget')->with('authLoginPrompted');
+        $session->shouldReceive('put')->with('promptedForLogin', true)->once();
+        $session->shouldNotReceive('forget')->with('promptedForLogin');
         $request->shouldReceive('get')->with('prompt')->andReturn(null);
 
         $clients = m::mock(ClientRepository::class);

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -318,6 +318,7 @@ class AuthorizationControllerTest extends TestCase
         $authRequest->shouldReceive('getRedirectUri')->andReturn('http://localhost');
         $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn('http://localhost');
         $authRequest->shouldReceive('getState')->andReturn('state');
+        $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
 
         $clients = m::mock(ClientRepository::class);
         $tokens = m::mock(TokenRepository::class);


### PR DESCRIPTION
According to #1571, This PP also binds `StatefulGaurd` to the default auth guard (same as before using `auth` middleware on the route).

The same approach is already used on Laravel Fortify: https://github.com/laravel/fortify/blob/ebc9045ef7bd2a2a37d54dde9c5df7d1b9d48780/src/FortifyServiceProvider.php#L61-L63

----

Related to #1389

As explained on #1567 and in addition to #1569, this PR adds support for `prompt=login` that causes the authorization server to display the login page first.

This PR also causes `prompt=none` to return an error if the user is not already authenticated instead of prompting the login page, which is the expected behavior (to prompt nothing).
