### PR TITLE
[11.x] Removed deprecated `dates` property from `Token` model

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -42,15 +42,7 @@ class Token extends Model
     protected $casts = [
         'scopes' => 'array',
         'revoked' => 'bool',
-    ];
-
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'expires_at',
+        'expires_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
Use `casts` instead of `dates` property.
