### PR TITLE
[11.x] Removed deprecated `dates` property from `RefreshToken` model

### DIFF
--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -41,15 +41,7 @@ class RefreshToken extends Model
      */
     protected $casts = [
         'revoked' => 'bool',
-    ];
-
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'expires_at',
+        'expires_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
Use `casts` instead of `dates` property.