### PR TITLE
Added passport:ready console command

### DIFF
--- a/src/Console/ReadyCommand.php
+++ b/src/Console/ReadyCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Laravel\Passport\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Laravel\Passport\Passport;
+
+class ReadyCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'passport:ready';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Checks if Passport has already been installed in this environment';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        [$publicKey, $privateKey] = [
+            Passport::keyPath('oauth-public.key'),
+            Passport::keyPath('oauth-private.key'),
+        ];
+
+        if (! (file_exists($publicKey) && file_exists($privateKey))) {
+            $this->error('Passport keys are missing. Please run "php artisan passport:install" to generate them.');
+
+            return Command::FAILURE;
+        }
+
+        $accessExists = $this->clientExists('Personal Access Client');
+        $grantExists = $this->clientExists('Password Grant Client');
+
+        if (! ($accessExists && $grantExists)) {
+            $this->error('Passport clients are missing. Please run "php artisan passport:install" to generate them');
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function clientExists(string $name)
+    {
+        try {
+            return DB::table("oauth_clients")
+                ->where("name", config('app.name').' '.$name)
+                ->exists();
+        } catch (QueryException $e) {
+            $this->error('Passport migrations have not been run. Please run "php artisan migrate" to run them');
+        }
+
+        return false;
+    }
+}

--- a/src/Console/ReadyCommand.php
+++ b/src/Console/ReadyCommand.php
@@ -55,8 +55,8 @@ class ReadyCommand extends Command
     private function clientExists(string $name)
     {
         try {
-            return DB::table("oauth_clients")
-                ->where("name", config('app.name').' '.$name)
+            return DB::table('oauth_clients')
+                ->where('name', config('app.name').' '.$name)
                 ->exists();
         } catch (QueryException $e) {
             $this->error('Passport migrations have not been run. Please run "php artisan migrate" to run them');

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -121,6 +121,7 @@ class PassportServiceProvider extends ServiceProvider
                 Console\HashCommand::class,
                 Console\KeysCommand::class,
                 Console\PurgeCommand::class,
+                Console\ReadyCommand::class,
             ]);
         }
     }

--- a/tests/Feature/Console/ReadyCommandTest.php
+++ b/tests/Feature/Console/ReadyCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Passport\Tests\Feature\Console;
 
-use Laravel\Passport\Passport;
 use Laravel\Passport\Tests\Feature\PassportTestCase;
 use Mockery as m;
 

--- a/tests/Feature/Console/ReadyCommandTest.php
+++ b/tests/Feature/Console/ReadyCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature\Console;
+
+use Laravel\Passport\Passport;
+use Laravel\Passport\Tests\Feature\PassportTestCase;
+use Mockery as m;
+
+class ReadyCommandTest extends PassportTestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        @unlink(self::PUBLIC_KEY);
+        @unlink(self::PRIVATE_KEY);
+    }
+
+    public function testNotReadyWithoutClients()
+    {
+        $this->artisan('passport:ready')
+            ->assertFailed()
+            ->expectsOutput('Passport clients are missing. Please run "php artisan passport:install" to generate them');
+    }
+
+    public function testNotReadyWithoutKeys()
+    {
+        @unlink(self::PUBLIC_KEY);
+        @unlink(self::PRIVATE_KEY);
+
+        $this->artisan('passport:ready')
+            ->assertFailed()
+            ->expectsOutput('Passport keys are missing. Please run "php artisan passport:install" to generate them.');
+    }
+
+    public function testReadyAfterInstall()
+    {
+        $this->artisan('passport:install');
+
+        $this->artisan('passport:ready')
+            ->assertSuccessful();
+    }
+}

--- a/tests/Unit/PassportTest.php
+++ b/tests/Unit/PassportTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Tests\Unit;
 
+use Exception;
 use Laravel\Passport\AuthCode;
 use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
@@ -50,12 +51,17 @@ class PassportTest extends TestCase
 
     public function test_missing_personal_access_client_is_reported()
     {
-        $this->expectException('RuntimeException');
-
         Passport::usePersonalAccessClientModel(PersonalAccessClientStub::class);
 
         $clientRepository = new ClientRepository;
-        $clientRepository->personalAccessClient();
+
+        try {
+            $clientRepository->personalAccessClient();
+        } catch (Exception $e) {
+            $this->assertInstanceOf('RuntimeException', $e);
+        }
+
+        Passport::usePersonalAccessClientModel(PersonalAccessClient::class);
     }
 
     public function test_token_instance_can_be_created()

--- a/tests/Unit/PassportTest.php
+++ b/tests/Unit/PassportTest.php
@@ -57,6 +57,7 @@ class PassportTest extends TestCase
 
         try {
             $clientRepository->personalAccessClient();
+            $this->fail('Exception was not thrown');
         } catch (Exception $e) {
             $this->assertInstanceOf('RuntimeException', $e);
         }


### PR DESCRIPTION
Added a new console command, `passport:ready` which can be used by automated deployments to detect if `passport:install` has already been run in an environment or not.

This solves an issue reported here: https://laracasts.com/discuss/channels/laravel/running-laravel-passport-install-on-production-server

---

The issue is primarily with the `oauth_clients`. If you run `passport:install` each time you deploy, it adds new clients and the tokens created with the older clients are no longer valid. This just gives a simple way to check if the environment has already been setup.

```bash
    php artisan passport:ready

    if [[ $? -eq 1 ]] ; then
        echo "installing passport"
        php artisan passport:install
    fi
```

---

Additionally, I refactored the test `PassportTest::test_missing_personal_access_client_is_reported` to restore the **PersonalAccessClientModel** after its assertion because the static reference to **PersonalAccessClientStub** was being carried over to subsequent tests.
