### PR TITLE
[11.x] Add a way to customize the `redirectTo` when prompt for login

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -46,4 +46,17 @@ return [
         'secret' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Authorize Login Redirection
+    |--------------------------------------------------------------------------
+    |
+    | By default, Passport will redirect to the `login` named route when the
+    | user is not authenticated. However, you can configure Passport to
+    | redirect to a specific URL when prompt for logging in.
+    |
+    */
+
+    'login_url' => null,
+
 ];

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -42,6 +42,13 @@ class AuthorizationController
     protected $guard;
 
     /**
+     * The login url to redirect to.
+     *
+     * @var ?string
+     */
+    protected $loginUrl;
+
+    /**
      * Create a new controller instance.
      *
      * @param  \League\OAuth2\Server\AuthorizationServer  $server
@@ -49,13 +56,16 @@ class AuthorizationController
      * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
-    public function __construct(AuthorizationServer $server,
-                                ResponseFactory $response,
-                                StatefulGuard $guard)
-    {
+    public function __construct(
+        AuthorizationServer $server,
+        ResponseFactory $response,
+        StatefulGuard $guard,
+        ?string $loginUrl = null,
+    ) {
         $this->server = $server;
         $this->response = $response;
         $this->guard = $guard;
+        $this->loginUrl = $loginUrl;
     }
 
     /**
@@ -215,6 +225,8 @@ class AuthorizationController
     {
         $request->session()->put('promptedForLogin', true);
 
-        throw new AuthenticationException;
+        throw new AuthenticationException(
+            redirectTo: $this->loginUrl,
+        );
     }
 }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -140,6 +140,10 @@ class PassportServiceProvider extends ServiceProvider
                 ->needs(StatefulGuard::class)
                 ->give(fn () => Auth::guard(config('passport.guard', null)));
 
+        $this->app->when(AuthorizationController::class)
+            ->needs('$loginUrl')
+            ->give(config('passport.login_url'));
+
         $this->registerAuthorizationServer();
         $this->registerClientRepository();
         $this->registerJWTParser();

--- a/tests/Feature/AuthorizeRequestTest.php
+++ b/tests/Feature/AuthorizeRequestTest.php
@@ -16,12 +16,12 @@ class AuthorizeRequestTest extends PassportTestCase
             ->needs('$loginUrl')
             ->give($redirectTo);
 
-        /** @var Registrar $router */
-        $router = $this->app->make(Registrar::class);
+        // /** @var Registrar $router */
+        // $router = $this->app->make(Registrar::class);
 
-        $router->get('/login', function () {
-            return 'login';
-        })->name('login');
+        // $router->get('/login', function () {
+        //     return 'login';
+        // })->name('login');
 
         $client = Client::factory()->create();
 

--- a/tests/Feature/AuthorizeRequestTest.php
+++ b/tests/Feature/AuthorizeRequestTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Passport\Tests\Feature;
 
-use Illuminate\Contracts\Routing\Registrar;
 use Laravel\Passport\Client;
 use Laravel\Passport\Http\Controllers\AuthorizationController;
 
@@ -15,13 +14,6 @@ class AuthorizeRequestTest extends PassportTestCase
         $this->app->when(AuthorizationController::class)
             ->needs('$loginUrl')
             ->give($redirectTo);
-
-        // /** @var Registrar $router */
-        // $router = $this->app->make(Registrar::class);
-
-        // $router->get('/login', function () {
-        //     return 'login';
-        // })->name('login');
 
         $client = Client::factory()->create();
 
@@ -41,4 +33,3 @@ class AuthorizeRequestTest extends PassportTestCase
         $response->assertRedirect($redirectTo);
     }
 }
-

--- a/tests/Feature/AuthorizeRequestTest.php
+++ b/tests/Feature/AuthorizeRequestTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature;
+
+use Laravel\Passport\Client;
+use Laravel\Passport\Http\Controllers\AuthorizationController;
+use Illuminate\Contracts\Routing\Registrar;
+
+class AuthorizeRequestTest extends PassportTestCase
+{
+    public function testActingAsWhenTheRouteIsProtectedByAuthMiddleware()
+    {
+        $redirectTo = '/auth/login';
+
+        $this->app->when(AuthorizationController::class)
+            ->needs('$loginUrl')
+            ->give($redirectTo);
+
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('/login', function () {
+            return 'login';
+        })->name('login');
+
+        $client = Client::factory()->create();
+
+        $query = http_build_query([
+            'client_id' => $client->id,
+            'redirect_uri' => $client->redirect_uri,
+            'response_type' => 'code',
+            'scope' => '',
+            'state' => $client->secret,
+        ]);
+
+        $url = "/oauth/authorize?{$query}";
+
+        $response = $this->get($url);
+
+        $response->assertStatus(302);
+        $response->assertRedirect($redirectTo);
+    }
+}
+

--- a/tests/Feature/AuthorizeRequestTest.php
+++ b/tests/Feature/AuthorizeRequestTest.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Passport\Tests\Feature;
 
+use Illuminate\Contracts\Routing\Registrar;
 use Laravel\Passport\Client;
 use Laravel\Passport\Http\Controllers\AuthorizationController;
-use Illuminate\Contracts\Routing\Registrar;
 
 class AuthorizeRequestTest extends PassportTestCase
 {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR is to address #1598.

Now you can customize the redirection setting up the `login_url` config on the `passport.php` config file. Example:

```php
<?php

return [
   ...

    'login_url' => '/auth/login',

];
```
