### PR TITLE
[11.x] Add auth guard to routes

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -4,6 +4,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Passport Guard
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which authentication guard Passport will use when
+    | authenticating users. This value should correspond with one of your
+    | guards that is already present in your "auth" configuration file.
+    |
+    */
+
+    'guard' => 'web',
+
+    /*
+    |--------------------------------------------------------------------------
     | Encryption Keys
     |--------------------------------------------------------------------------
     |

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,7 +14,9 @@ Route::get('/authorize', [
     'middleware' => 'web',
 ]);
 
-Route::middleware(['web', 'auth'])->group(function () {
+$guard = config('passport.guard', null);
+
+Route::middleware(['web', $guard ? 'auth:'.$guard : 'auth'])->group(function () {
     Route::post('/token/refresh', [
         'uses' => 'TransientTokenController@refresh',
         'as' => 'token.refresh',


### PR DESCRIPTION
Related to #1602, We have already defined and used `passport.guard` config here: https://github.com/laravel/passport/blob/662325a90b8c3184c548eaf66ce971925f2b90dc/src/PassportServiceProvider.php#L140-L141

This PR adds a default value for `guard` to `config/passport.php` and also uses this guard on predefined Passport routes. This change is totally backward compatible and if `passport.guard` is not defined or `null`, the Passport will use `auth.defaults.guard` config value by default.

PS: The same approach is used on Fortify:
- https://github.com/laravel/fortify/blob/eb97f088c2a3e010e76cb58e9406427d1cee8de3/routes/routes.php
- https://github.com/laravel/fortify/blob/eb97f088c2a3e010e76cb58e9406427d1cee8de3/config/fortify.php#L6