### PR TITLE
New authorization view response for custom views

### DIFF
--- a/src/Contracts/AuthorizationViewResponse.php
+++ b/src/Contracts/AuthorizationViewResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Passport\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface AuthorizationViewResponse extends Responsable
+{
+	//
+}

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -66,12 +66,12 @@ class AuthorizationController
      * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Passport\ClientRepository  $clients
      * @param  \Laravel\Passport\TokenRepository  $tokens
-     * @return \Laravel\Passport\Contracts\AuthorizationViewResponse
+     * @return \Laravel\Passport\Contracts\AuthorizationViewResponse|mixed|void
      */
     public function authorize(ServerRequestInterface $psrRequest,
                               Request $request,
                               ClientRepository $clients,
-                              TokenRepository $tokens): AuthorizationViewResponse
+                              TokenRepository $tokens)
     {
         $authRequest = $this->withErrorHandling(function () use ($psrRequest) {
             return $this->server->validateAuthorizationRequest($psrRequest);

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Laravel\Passport\Bridge\User;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Contracts\AuthorizationViewResponse;
 use Laravel\Passport\Passport;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\AuthorizationServer;
@@ -65,12 +66,12 @@ class AuthorizationController
      * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Passport\ClientRepository  $clients
      * @param  \Laravel\Passport\TokenRepository  $tokens
-     * @return \Illuminate\Http\Response
+     * @return \Laravel\Passport\Contracts\AuthorizationViewResponse
      */
     public function authorize(ServerRequestInterface $psrRequest,
                               Request $request,
                               ClientRepository $clients,
-                              TokenRepository $tokens)
+                              TokenRepository $tokens): AuthorizationViewResponse
     {
         $authRequest = $this->withErrorHandling(function () use ($psrRequest) {
             return $this->server->validateAuthorizationRequest($psrRequest);
@@ -108,6 +109,14 @@ class AuthorizationController
 
         $request->session()->put('authToken', $authToken = Str::random());
         $request->session()->put('authRequest', $authRequest);
+
+        return app(AuthorizationViewResponse::class, [
+	        'client' => $client,
+	        'user' => $user,
+	        'scopes' => $scopes,
+	        'request' => $request,
+	        'authToken' => $authToken,
+        ]);
 
         return $this->response->view('passport::authorize', [
             'client' => $client,

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -117,14 +117,6 @@ class AuthorizationController
 	        'request' => $request,
 	        'authToken' => $authToken,
         ]);
-
-        return $this->response->view('passport::authorize', [
-            'client' => $client,
-            'user' => $user,
-            'scopes' => $scopes,
-            'request' => $request,
-            'authToken' => $authToken,
-        ]);
     }
 
     /**

--- a/src/Http/Responses/AuthorizationViewResponse.php
+++ b/src/Http/Responses/AuthorizationViewResponse.php
@@ -14,40 +14,11 @@ class AuthorizationViewResponse implements AuthorizationViewResponseContract
 	protected $view;
 
 	/**
-	 * The name of the view or the callable used to generate the view.
+	 * An array of arguments that may be passed to the view response and used in the view.
 	 *
 	 * @var string
 	 */
-	protected $client;
-
-	/**
-	 * The name of the view or the callable used to generate the view.
-	 *
-	 * @var string
-	 */
-	protected $user;
-
-	/**
-	 * The name of the view or the callable used to generate the view.
-	 *
-	 * @var string
-	 */
-	protected $scopes;
-
-	/**
-	 * The name of the view or the callable used to generate the view.
-	 *
-	 * @var string
-	 */
-	protected $request;
-
-	/**
-	 * The name of the view or the callable used to generate the view.
-	 *
-	 * @var string
-	 */
-	protected $authToken;
-
+	protected $parameters;
 
 	/**
 	 * Create a new response instance.
@@ -55,14 +26,10 @@ class AuthorizationViewResponse implements AuthorizationViewResponseContract
 	 * @param  callable|string  $view
 	 * @return void
 	 */
-	public function __construct($view, $client = null, $user = null, $scopes = null, $request = null, $authToken = null)
+	public function __construct($view, $parameters = array())
 	{
 		$this->view = $view;
-		$this->client = $client;
-		$this->user = $user;
-		$this->scopes = $scopes;
-		$this->request = $request;
-		$this->authToken = $authToken;
+		$this->parameters = $parameters;
 	}
 
 	/**
@@ -74,10 +41,10 @@ class AuthorizationViewResponse implements AuthorizationViewResponseContract
 	public function toResponse($request)
 	{
 		if (! is_callable($this->view) || is_string($this->view)) {
-			return view($this->view, ['request' => $request]);
+			return view($this->view, $this->parameters);
 		}
 
-		$response = call_user_func($this->view, $this->client, $this->user, $this->scopes, $this->request, $this->authToken);
+		$response = call_user_func($this->view, $this->parameters);
 
 		if ($response instanceof Responsable) {
 			return $response->toResponse($request);

--- a/src/Http/Responses/AuthorizationViewResponse.php
+++ b/src/Http/Responses/AuthorizationViewResponse.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Laravel\Passport\Http\Controllers\Responses;
+
+class AuthorizationViewResponse
+{
+	/**
+	 * The name of the view or the callable used to generate the view.
+	 *
+	 * @var string
+	 */
+	protected $view;
+
+	/**
+	 * The name of the view or the callable used to generate the view.
+	 *
+	 * @var string
+	 */
+	protected $client;
+
+	/**
+	 * The name of the view or the callable used to generate the view.
+	 *
+	 * @var string
+	 */
+	protected $user;
+
+	/**
+	 * The name of the view or the callable used to generate the view.
+	 *
+	 * @var string
+	 */
+	protected $scopes;
+
+	/**
+	 * The name of the view or the callable used to generate the view.
+	 *
+	 * @var string
+	 */
+	protected $request;
+
+	/**
+	 * The name of the view or the callable used to generate the view.
+	 *
+	 * @var string
+	 */
+	protected $authToken;
+
+
+	/**
+	 * Create a new response instance.
+	 *
+	 * @param  callable|string  $view
+	 * @return void
+	 */
+	public function __construct($view, $client = null, $user = null, $scopes = null, $request = null, $authToken = null)
+	{
+		$this->view = $view;
+		$this->client = $client;
+		$this->user = $user;
+		$this->scopes = $scopes;
+		$this->request = $request;
+		$this->authToken = $authToken;
+	}
+
+	/**
+	 * Create an HTTP response that represents the object.
+	 *
+	 * @param  \Illuminate\Http\Request  $request
+	 * @return \Symfony\Component\HttpFoundation\Response
+	 */
+	public function toResponse($request)
+	{
+		if (! is_callable($this->view) || is_string($this->view)) {
+			return view($this->view, ['request' => $request]);
+		}
+
+		$response = call_user_func($this->view, $this->client, $this->user, $this->scopes, $this->request, $this->authToken);
+
+		if ($response instanceof Responsable) {
+			return $response->toResponse($request);
+		}
+
+		return $response;
+	}
+}

--- a/src/Http/Responses/AuthorizationViewResponse.php
+++ b/src/Http/Responses/AuthorizationViewResponse.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Passport\Http\Responses;
 
-class AuthorizationViewResponse
+use Laravel\Passport\Contracts\AuthorizationViewResponse as AuthorizationViewResponseContract;
+
+class AuthorizationViewResponse implements AuthorizationViewResponseContract
 {
 	/**
 	 * The name of the view or the callable used to generate the view.

--- a/src/Http/Responses/AuthorizationViewResponse.php
+++ b/src/Http/Responses/AuthorizationViewResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Passport\Http\Controllers\Responses;
+namespace Laravel\Passport\Http\Responses;
 
 class AuthorizationViewResponse
 {

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -688,28 +688,6 @@ class Passport
     }
 
 	/**
-	 * Register the views for Passport using conventional names under the given namespace.
-	 *
-	 * @param  string  $namespace
-	 * @return void
-	 */
-	public static function viewNamespace(string $namespace)
-	{
-		static::viewPrefix($namespace.'::');
-	}
-
-	/**
-	 * Register the views for Passport using conventional names under the given prefix.
-	 *
-	 * @param  string  $prefix
-	 * @return void
-	 */
-	public static function viewPrefix(string $prefix)
-	{
-		static::authorizationView($prefix.'authorize');
-	}
-
-	/**
 	 * Specify which view should be used as the authorization view.
 	 *
 	 * @param  callable|string  $view
@@ -717,8 +695,8 @@ class Passport
 	 */
 	public static function authorizationView($view)
 	{
-		app()->singleton(AuthorizationViewResponseContract::class, function () use ($view) {
-			return new AuthorizationViewResponse($view);
+		app()->singleton(AuthorizationViewResponseContract::class, function ($app, $parameters) use ($view) {
+			return new AuthorizationViewResponse($view, $parameters);
 		});
 	}
 }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -7,7 +7,7 @@ use DateInterval;
 use DateTimeInterface;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Laravel\Passport\Contracts\AuthorizationViewResponse as AuthorizationViewResponseContract;
-use Laravel\Passport\Http\Controllers\Responses\AuthorizationViewResponse;
+use Laravel\Passport\Http\Responses\AuthorizationViewResponse;
 use League\OAuth2\Server\ResourceServer;
 use Mockery;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -6,6 +6,8 @@ use Carbon\Carbon;
 use DateInterval;
 use DateTimeInterface;
 use Illuminate\Contracts\Encryption\Encrypter;
+use Laravel\Passport\Contracts\AuthorizationViewResponse as AuthorizationViewResponseContract;
+use Laravel\Passport\Http\Controllers\Responses\AuthorizationViewResponse;
 use League\OAuth2\Server\ResourceServer;
 use Mockery;
 use Psr\Http\Message\ServerRequestInterface;
@@ -684,4 +686,39 @@ class Passport
 
         return new static;
     }
+
+	/**
+	 * Register the views for Passport using conventional names under the given namespace.
+	 *
+	 * @param  string  $namespace
+	 * @return void
+	 */
+	public static function viewNamespace(string $namespace)
+	{
+		static::viewPrefix($namespace.'::');
+	}
+
+	/**
+	 * Register the views for Passport using conventional names under the given prefix.
+	 *
+	 * @param  string  $prefix
+	 * @return void
+	 */
+	public static function viewPrefix(string $prefix)
+	{
+		static::authorizationView($prefix.'authorize');
+	}
+
+	/**
+	 * Specify which view should be used as the authorization view.
+	 *
+	 * @param  callable|string  $view
+	 * @return void
+	 */
+	public static function authorizationView($view)
+	{
+		app()->singleton(AuthorizationViewResponseContract::class, function () use ($view) {
+			return new AuthorizationViewResponse($view);
+		});
+	}
 }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -145,10 +145,12 @@ class PassportServiceProvider extends ServiceProvider
         $this->registerJWTParser();
         $this->registerResourceServer();
         $this->registerGuard();
+
+	    Passport::authorizationView('passport::authorize');
     }
 
     /**
-     * Register the authorization server.
+     * Register the authorization server.`
      *
      * @return void
      */


### PR DESCRIPTION
The following PR allows customization of the view used for authorization. While you can publish Passport's views and edit them to your needs, unfortunately, this limits you to only the blade. This PR follows Fortify's precedence and allows you to pass a callback or string to a new Passport::authorizationView() function. The following example is how one would return and render an Inertia component for use with authorization.

Example:
```
AppServiceProvider.php

public function register() {

    // Return and render our custom Inertia component for authorization
    Passport::authorizationView(function ($parameters) {
        return Inertia::render('Passport/Authorize', [
            'client' => $parameters['client']->id,
            'name' => $parameters['client']->name,
            'scopes' => $parameters['scopes'],
            'state' => $parameters['request']->state,
            'authToken' => $parameters['authToken'],
            'csrfToken' => csrf_token(),
        ])->toResponse($parameters['request']);
    });
}
```