### PR TITLE
[11.x] Get authenticated user from the guard

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -94,7 +94,7 @@ class AuthorizationController
         $request->session()->forget('promptedForLogin');
 
         $scopes = $this->parseScopes($authRequest);
-        $user = $request->user();
+        $user = $this->guard->user();
         $client = $clients->find($authRequest->getClient()->getIdentifier());
 
         if ($request->get('prompt') !== 'consent' &&
@@ -137,7 +137,7 @@ class AuthorizationController
      * Determine if a valid token exists for the given user, client, and scopes.
      *
      * @param  \Laravel\Passport\TokenRepository  $tokens
-     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Laravel\Passport\Client  $client
      * @param  array  $scopes
      * @return bool
@@ -153,7 +153,7 @@ class AuthorizationController
      * Approve the authorization request.
      *
      * @param  \League\OAuth2\Server\RequestTypes\AuthorizationRequest  $authRequest
-     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return \Illuminate\Http\Response
      */
     protected function approveRequest($authRequest, $user)
@@ -173,7 +173,7 @@ class AuthorizationController
      * Deny the authorization request.
      *
      * @param  \League\OAuth2\Server\RequestTypes\AuthorizationRequest  $authRequest
-     * @param  \Illuminate\Database\Eloquent\Model|null  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @return \Illuminate\Http\Response
      */
     protected function denyRequest($authRequest, $user = null)

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -54,7 +54,7 @@ class TokenRepository
     /**
      * Get a valid token instance for the given user and client.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Laravel\Passport\Client  $client
      * @return \Laravel\Passport\Token|null
      */
@@ -107,7 +107,7 @@ class TokenRepository
     /**
      * Find a valid token for the given user and client.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Laravel\Passport\Client  $client
      * @return \Laravel\Passport\Token|null
      */

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -42,6 +42,7 @@ class AuthorizationControllerTest extends TestCase
         $controller = new AuthorizationController($server, $response, $guard);
 
         $guard->shouldReceive('guest')->andReturn(false);
+        $guard->shouldReceive('user')->andReturn($user = m::mock());
         $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest = m::mock());
 
         $request = m::mock(Request::class);
@@ -49,7 +50,6 @@ class AuthorizationControllerTest extends TestCase
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
         $session->shouldReceive('put')->with('authRequest', $authRequest);
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
-        $request->shouldReceive('user')->andReturn($user = m::mock());
         $request->shouldReceive('get')->with('prompt')->andReturn(null);
 
         $authRequest->shouldReceive('getClient->getIdentifier')->andReturn(1);
@@ -114,6 +114,7 @@ class AuthorizationControllerTest extends TestCase
         $controller = new AuthorizationController($server, $response, $guard);
 
         $guard->shouldReceive('guest')->andReturn(false);
+        $guard->shouldReceive('user')->andReturn($user = m::mock());
         $psrResponse = new Response();
         $psrResponse->getBody()->write('approved');
         $server->shouldReceive('validateAuthorizationRequest')
@@ -125,7 +126,6 @@ class AuthorizationControllerTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
-        $request->shouldReceive('user')->once()->andReturn($user = m::mock());
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldNotReceive('session');
         $request->shouldReceive('get')->with('prompt')->andReturn(null);
@@ -164,6 +164,7 @@ class AuthorizationControllerTest extends TestCase
         $controller = new AuthorizationController($server, $response, $guard);
 
         $guard->shouldReceive('guest')->andReturn(false);
+        $guard->shouldReceive('user')->andReturn($user = m::mock());
         $psrResponse = new Response();
         $psrResponse->getBody()->write('approved');
         $server->shouldReceive('validateAuthorizationRequest')
@@ -175,7 +176,6 @@ class AuthorizationControllerTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
-        $request->shouldReceive('user')->once()->andReturn($user = m::mock());
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldNotReceive('session');
         $request->shouldReceive('get')->with('prompt')->andReturn(null);
@@ -213,6 +213,7 @@ class AuthorizationControllerTest extends TestCase
         $controller = new AuthorizationController($server, $response, $guard);
 
         $guard->shouldReceive('guest')->andReturn(false);
+        $guard->shouldReceive('user')->andReturn($user = m::mock());
         $server->shouldReceive('validateAuthorizationRequest')
             ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
 
@@ -221,7 +222,6 @@ class AuthorizationControllerTest extends TestCase
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
         $session->shouldReceive('put')->with('authRequest', $authRequest);
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
-        $request->shouldReceive('user')->andReturn($user = m::mock());
         $request->shouldReceive('get')->with('prompt')->andReturn('consent');
 
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
@@ -263,6 +263,7 @@ class AuthorizationControllerTest extends TestCase
         $controller = new AuthorizationController($server, $response, $guard);
 
         $guard->shouldReceive('guest')->andReturn(false);
+        $guard->shouldReceive('user')->andReturn($user = m::mock());
         $server->shouldReceive('validateAuthorizationRequest')
             ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
         $server->shouldReceive('completeAuthorizationRequest')
@@ -273,7 +274,6 @@ class AuthorizationControllerTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
-        $request->shouldReceive('user')->andReturn($user = m::mock());
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldReceive('get')->with('prompt')->andReturn('none');
 


### PR DESCRIPTION
This is not a breaking change, fixes #1616 and fixes #1609. This PR fixes the authorization issue for those who want to use a non-default guard when customizing the `passport.guard` config param.

PS: This also fixes some doc blocks.