### PR TITLE
Update ClientCommand.php's user_id description

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -133,7 +133,7 @@ class ClientCommand extends Command
     protected function createAuthCodeClient(ClientRepository $clients)
     {
         $userId = $this->option('user_id') ?: $this->ask(
-            'Which user ID should the client be assigned to? (optional)'
+            'Which user ID should the client be assigned to? (Optional)'
         );
 
         $name = $this->option('name') ?: $this->ask(

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -133,7 +133,7 @@ class ClientCommand extends Command
     protected function createAuthCodeClient(ClientRepository $clients)
     {
         $userId = $this->option('user_id') ?: $this->ask(
-            'Which user ID should the client be assigned to?'
+            'Which user ID should the client be assigned to? (optional)'
         );
 
         $name = $this->option('name') ?: $this->ask(


### PR DESCRIPTION
We get a fair amount of confused passport users on the laravel discord wondering what this user_id is even for. It might help to indicate that the input is optional.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
