### PR TITLE
[11.x] Fix doc block for `withAccessToken()`

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -71,7 +71,7 @@ trait HasApiTokens
     /**
      * Set the current access token for the user.
      *
-     * @param  \Laravel\Passport\Token  $accessToken
+     * @param  \Laravel\Passport\Token|\Laravel\Passport\TransientToken  $accessToken
      * @return $this
      */
     public function withAccessToken($accessToken)


### PR DESCRIPTION
Fixes an incorrect doc block, this is currently already used this way in Passport:

https://github.com/laravel/passport/blob/3ac7b1e8f9814e47af5a9d5ab88c415060d5c782/src/Guards/TokenGuard.php#L258

PS. I think a common interface should be introduced for `Token` and `TransientToken` so the user's token can be typed properly across the board, but that should probably go to master as it is a bigger change