### PR TITLE
feat: allow XSRF token read from cookies

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -329,6 +329,10 @@ class TokenGuard implements Guard
             $token = CookieValuePrefix::remove($this->encrypter->decrypt($header, static::serialized()));
         }
 
+        if (! $token && $encrypted = $request->cookie('X-XSRF-TOKEN')) {
+            $token = CookieValuePrefix::remove($this->encrypter->decrypt($encrypted, static::serialized()));
+        }
+
         return $token;
     }
 


### PR DESCRIPTION
Feature: try to acquire xsrf-token from cookies, in the case when it is absent from the headers.

Use case: [navigator.sendBeacon](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) does not support headers. When the system needs to gather statistical data, passport authentication currently does not work with the sendBeacon method.