### PR TITLE
[11.x] Get model PK instead of forcibly id column

### DIFF
--- a/resources/views/authorize.blade.php
+++ b/resources/views/authorize.blade.php
@@ -68,7 +68,7 @@
                                 @csrf
 
                                 <input type="hidden" name="state" value="{{ $request->state }}">
-                                <input type="hidden" name="client_id" value="{{ $client->id }}">
+                                <input type="hidden" name="client_id" value="{{ $client->getKey() }}">
                                 <input type="hidden" name="auth_token" value="{{ $authToken }}">
                                 <button type="submit" class="btn btn-success btn-approve">Authorize</button>
                             </form>
@@ -79,7 +79,7 @@
                                 @method('DELETE')
 
                                 <input type="hidden" name="state" value="{{ $request->state }}">
-                                <input type="hidden" name="client_id" value="{{ $client->id }}">
+                                <input type="hidden" name="client_id" value="{{ $client->getKey() }}">
                                 <input type="hidden" name="auth_token" value="{{ $authToken }}">
                                 <button class="btn btn-danger">Cancel</button>
                             </form>

--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -167,7 +167,7 @@ class ClientRepository
     {
         return tap($this->create($userId, $name, $redirect, null, true), function ($client) {
             $accessClient = Passport::personalAccessClient();
-            $accessClient->client_id = $client->id;
+            $accessClient->client_id = $client->getKey();
             $accessClient->save();
         });
     }

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -167,7 +167,7 @@ class ClientCommand extends Command
             $this->line('');
         }
 
-        $this->line('<comment>Client ID:</comment> '.$client->id);
+        $this->line('<comment>Client ID:</comment> '.$client->getKey());
         $this->line('<comment>Client secret:</comment> '.$client->plainSecret);
     }
 }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -370,7 +370,7 @@ class Passport
     {
         $token = app(self::tokenModel());
 
-        $token->client_id = $client->id;
+        $token->client_id = $client->getKey();
         $token->setRelation('client', $client);
 
         $token->scopes = $scopes;

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -98,7 +98,7 @@ class PersonalAccessTokenFactory
 
         return (new ServerRequest('POST', 'not-important'))->withParsedBody([
             'grant_type' => 'personal_access',
-            'client_id' => $client->id,
+            'client_id' => $client->getKey(),
             'client_secret' => $secret,
             'user_id' => $userId,
             'scope' => implode(' ', $scopes),

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -50,13 +50,13 @@ class AccessTokenControllerTest extends PassportTestCase
         $user->save();
 
         /** @var Client $client */
-        $client = ClientFactory::new()->asClientCredentials()->create(['user_id' => $user->id]);
+        $client = ClientFactory::new()->asClientCredentials()->create(['user_id' => $user->getKey()]);
 
         $response = $this->post(
             '/oauth/token',
             [
                 'grant_type' => 'client_credentials',
-                'client_id' => $client->id,
+                'client_id' => $client->getKey(),
                 'client_secret' => $client->secret,
             ]
         );
@@ -93,13 +93,13 @@ class AccessTokenControllerTest extends PassportTestCase
         $user->save();
 
         /** @var Client $client */
-        $client = ClientFactory::new()->asClientCredentials()->create(['user_id' => $user->id]);
+        $client = ClientFactory::new()->asClientCredentials()->create(['user_id' => $user->getKey()]);
 
         $response = $this->post(
             '/oauth/token',
             [
                 'grant_type' => 'client_credentials',
-                'client_id' => $client->id,
+                'client_id' => $client->getKey(),
                 'client_secret' => $client->secret.'foo',
             ]
         );
@@ -137,13 +137,13 @@ class AccessTokenControllerTest extends PassportTestCase
         $user->save();
 
         /** @var Client $client */
-        $client = ClientFactory::new()->asPasswordClient()->create(['user_id' => $user->id]);
+        $client = ClientFactory::new()->asPasswordClient()->create(['user_id' => $user->getKey()]);
 
         $response = $this->post(
             '/oauth/token',
             [
                 'grant_type' => 'password',
-                'client_id' => $client->id,
+                'client_id' => $client->getKey(),
                 'client_secret' => $client->secret,
                 'username' => $user->email,
                 'password' => $password,
@@ -184,13 +184,13 @@ class AccessTokenControllerTest extends PassportTestCase
         $user->save();
 
         /** @var Client $client */
-        $client = ClientFactory::new()->asPasswordClient()->create(['user_id' => $user->id]);
+        $client = ClientFactory::new()->asPasswordClient()->create(['user_id' => $user->getKey()]);
 
         $response = $this->post(
             '/oauth/token',
             [
                 'grant_type' => 'password',
-                'client_id' => $client->id,
+                'client_id' => $client->getKey(),
                 'client_secret' => $client->secret,
                 'username' => $user->email,
                 'password' => $password.'foo',
@@ -227,13 +227,13 @@ class AccessTokenControllerTest extends PassportTestCase
         $user->save();
 
         /** @var Client $client */
-        $client = ClientFactory::new()->asPasswordClient()->create(['user_id' => $user->id]);
+        $client = ClientFactory::new()->asPasswordClient()->create(['user_id' => $user->getKey()]);
 
         $response = $this->post(
             '/oauth/token',
             [
                 'grant_type' => 'password',
-                'client_id' => $client->id,
+                'client_id' => $client->getKey(),
                 'client_secret' => $client->secret.'foo',
                 'username' => $user->email,
                 'password' => $password,
@@ -274,13 +274,13 @@ class AccessTokenControllerTest extends PassportTestCase
         $user->save();
 
         /** @var Client $client */
-        $client = ClientFactory::new()->asClientCredentials()->create(['user_id' => $user->id]);
+        $client = ClientFactory::new()->asClientCredentials()->create(['user_id' => $user->getKey()]);
 
         $response = $this->post(
             '/oauth/token',
             [
                 'grant_type' => 'client_credentials',
-                'client_id' => $client->id,
+                'client_id' => $client->getKey(),
                 'client_secret' => $client->secret,
             ]
         );

--- a/tests/Unit/PersonalAccessTokenFactoryTest.php
+++ b/tests/Unit/PersonalAccessTokenFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Tests\Unit;
 
+use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\PersonalAccessTokenFactory;
 use Laravel\Passport\PersonalAccessTokenResult;
@@ -15,7 +16,6 @@ use Lcobucci\JWT\Token\Signature;
 use League\OAuth2\Server\AuthorizationServer;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Laravel\Passport\Client;
 
 class PersonalAccessTokenFactoryTest extends TestCase
 {

--- a/tests/Unit/PersonalAccessTokenFactoryTest.php
+++ b/tests/Unit/PersonalAccessTokenFactoryTest.php
@@ -15,6 +15,7 @@ use Lcobucci\JWT\Token\Signature;
 use League\OAuth2\Server\AuthorizationServer;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Laravel\Passport\Client;
 
 class PersonalAccessTokenFactoryTest extends TestCase
 {
@@ -56,7 +57,7 @@ class PersonalAccessTokenFactoryTest extends TestCase
     }
 }
 
-class PersonalAccessTokenFactoryTestClientStub
+class PersonalAccessTokenFactoryTestClientStub extends Client
 {
     public $id = 1;
 


### PR DESCRIPTION
PR of the change presented here:
https://github.com/laravel/passport/issues/1624

This PR has the purpose of modifying the way that the oauth Client model is obtaining its primary key.

For most people it won't have any impact, for some people who use another column as the primary key (instead of ID) it will be fixed in this flow.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
