### PR TITLE
[11.x] Indicate current token can be `TransientToken`

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -9,7 +9,7 @@ trait HasApiTokens
     /**
      * The current access token for the authentication user.
      *
-     * @var \Laravel\Passport\Token
+     * @var \Laravel\Passport\Token|\Laravel\Passport\TransientToken|null
      */
     protected $accessToken;
 
@@ -36,7 +36,7 @@ trait HasApiTokens
     /**
      * Get the current access token being used by the user.
      *
-     * @return \Laravel\Passport\Token|null
+     * @return \Laravel\Passport\Token|\Laravel\Passport\TransientToken|null
      */
     public function token()
     {


### PR DESCRIPTION
Followup for #1620, forgot to update the docs in other places where the same token is referenced.

Passport sets the token to a transient token here:
https://github.com/laravel/passport/blob/3ac7b1e8f9814e47af5a9d5ab88c415060d5c782/src/Guards/TokenGuard.php#L258
