### PR TITLE
[11.x] Add support for `EncryptCookies` middleware

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -295,8 +295,12 @@ class TokenGuard implements Guard
      */
     protected function decodeJwtTokenCookie($request)
     {
+        $jwt = $request->cookie(Passport::cookie());
+
         return (array) JWT::decode(
-            CookieValuePrefix::remove($this->encrypter->decrypt($request->cookie(Passport::cookie()), Passport::$unserializesCookies)),
+            Passport::$decryptsCookies
+                ? CookieValuePrefix::remove($this->encrypter->decrypt($jwt, Passport::$unserializesCookies))
+                : $jwt,
             new Key(Passport::tokenEncryptionKey($this->encrypter), 'HS256')
         );
     }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -134,6 +134,13 @@ class Passport
     public static $unserializesCookies = false;
 
     /**
+     * Indicates if Passport should decrypt cookies.
+     *
+     * @var bool
+     */
+    public static $decryptsCookies = true;
+
+    /**
      * Indicates if client secrets will be hashed.
      *
      * @var bool
@@ -681,6 +688,30 @@ class Passport
     public static function withoutCookieSerialization()
     {
         static::$unserializesCookies = false;
+
+        return new static;
+    }
+
+    /**
+     * Instruct Passport to enable cookie encryption.
+     *
+     * @return static
+     */
+    public static function withCookieEncryption()
+    {
+        static::$decryptsCookies = true;
+
+        return new static;
+    }
+
+    /**
+     * Instruct Passport to disable cookie encryption.
+     *
+     * @return static
+     */
+    public static function withoutCookieEncryption()
+    {
+        static::$decryptsCookies = false;
 
         return new static;
     }


### PR DESCRIPTION
This PR adds a new option to Passport to not decrypt the JWT cookie when authenticating.

Currently when dealing with the JWT cookie Passport's behaviour is this:
- When creating the JWT cookie, Passport expects the `EncryptCookies` middleware to be active, and relies on it for encryption
- When reading the JWT cookie, Passport expects the `EncryptCookies` middleware to be inactive, it decrypts the cookie on its own

Because of this, implementing a middleware similar to Sanctum's [EnsureFrontendRequestsAreStateful](https://github.com/laravel/sanctum/blob/3.x/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php) is currently not possible, as it will cause the JWT token to be decrypted twice.

Note that this PR does not contain any breaking changes, Passport's current behaviour stays the default behaviour. This PR only adds the option to opt-out of this behaviour.