### PR TITLE
[11.x] Move AuthenticationException into the scope of Laravel Passport

### DIFF
--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Laravel\Passport\Exceptions;
+
+use Illuminate\Auth\AuthenticationException as Exception;
+
+class AuthenticationException extends Exception
+{
+}

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -2,13 +2,13 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
-use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Laravel\Passport\Bridge\User;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Passport;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\AuthorizationServer;
@@ -209,7 +209,7 @@ class AuthorizationController
      *
      * @param  \Illuminate\Http\Request  $request
      *
-     * @throws \Illuminate\Auth\AuthenticationException
+     * @throws \Laravel\Passport\Exceptions\AuthenticationException
      */
     protected function promptForLogin($request)
     {

--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Http\Middleware;
 
-use Illuminate\Auth\AuthenticationException;
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Exceptions\MissingScopeException;
 
 class CheckClientCredentials extends CheckCredentials
@@ -13,7 +13,7 @@ class CheckClientCredentials extends CheckCredentials
      * @param  \Laravel\Passport\Token  $token
      * @return void
      *
-     * @throws \Illuminate\Auth\AuthenticationException
+     * @throws \Laravel\Passport\Exceptions\AuthenticationException
      */
     protected function validateCredentials($token)
     {

--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Http\Middleware;
 
-use Illuminate\Auth\AuthenticationException;
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Exceptions\MissingScopeException;
 
 class CheckClientCredentialsForAnyScope extends CheckCredentials
@@ -13,7 +13,7 @@ class CheckClientCredentialsForAnyScope extends CheckCredentials
      * @param  \Laravel\Passport\Token  $token
      * @return void
      *
-     * @throws \Illuminate\Auth\AuthenticationException
+     * @throws \Laravel\Passport\Exceptions\AuthenticationException
      */
     protected function validateCredentials($token)
     {

--- a/src/Http/Middleware/CheckCredentials.php
+++ b/src/Http/Middleware/CheckCredentials.php
@@ -3,7 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
-use Illuminate\Auth\AuthenticationException;
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
@@ -47,7 +47,7 @@ abstract class CheckCredentials
      * @param  mixed  ...$scopes
      * @return mixed
      *
-     * @throws \Illuminate\Auth\AuthenticationException
+     * @throws \Laravel\Passport\Exceptions\AuthenticationException
      */
     public function handle($request, Closure $next, ...$scopes)
     {
@@ -93,7 +93,7 @@ abstract class CheckCredentials
      * @param  \Laravel\Passport\Token  $token
      * @return void
      *
-     * @throws \Illuminate\Auth\AuthenticationException
+     * @throws \Laravel\Passport\Exceptions\AuthenticationException
      */
     abstract protected function validateCredentials($token);
 

--- a/src/Http/Middleware/CheckForAnyScope.php
+++ b/src/Http/Middleware/CheckForAnyScope.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Http\Middleware;
 
-use Illuminate\Auth\AuthenticationException;
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Exceptions\MissingScopeException;
 
 class CheckForAnyScope
@@ -15,7 +15,7 @@ class CheckForAnyScope
      * @param  mixed  ...$scopes
      * @return \Illuminate\Http\Response
      *
-     * @throws \Illuminate\Auth\AuthenticationException|\Laravel\Passport\Exceptions\MissingScopeException
+     * @throws \Laravel\Passport\Exceptions\AuthenticationException|\Laravel\Passport\Exceptions\MissingScopeException
      */
     public function handle($request, $next, ...$scopes)
     {

--- a/src/Http/Middleware/CheckScopes.php
+++ b/src/Http/Middleware/CheckScopes.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Http\Middleware;
 
-use Illuminate\Auth\AuthenticationException;
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Exceptions\MissingScopeException;
 
 class CheckScopes
@@ -15,7 +15,7 @@ class CheckScopes
      * @param  mixed  ...$scopes
      * @return \Illuminate\Http\Response
      *
-     * @throws \Illuminate\Auth\AuthenticationException|\Laravel\Passport\Exceptions\MissingScopeException
+     * @throws \Laravel\Passport\Exceptions\AuthenticationException|\Laravel\Passport\Exceptions\MissingScopeException
      */
     public function handle($request, $next, ...$scopes)
     {

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Laravel\Passport\Bridge\Scope;
 use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Exceptions\OAuthServerException;
 use Laravel\Passport\Http\Controllers\AuthorizationController;
 use Laravel\Passport\Passport;
@@ -337,7 +338,7 @@ class AuthorizationControllerTest extends TestCase
 
     public function test_logout_and_prompt_login_if_request_has_prompt_equals_to_login()
     {
-        $this->expectException('Illuminate\Auth\AuthenticationException');
+        $this->expectException(AuthenticationException::class);
 
         $server = m::mock(AuthorizationServer::class);
         $response = m::mock(ResponseFactory::class);
@@ -368,7 +369,7 @@ class AuthorizationControllerTest extends TestCase
 
     public function test_user_should_be_authenticated()
     {
-        $this->expectException('Illuminate\Auth\AuthenticationException');
+        $this->expectException(AuthenticationException::class);
 
         $server = m::mock(AuthorizationServer::class);
         $response = m::mock(ResponseFactory::class);

--- a/tests/Unit/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/Unit/CheckClientCredentialsForAnyScopeTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Passport\Tests\Unit;
 
 use Illuminate\Http\Request;
 use Laravel\Passport\Client;
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
 use Laravel\Passport\Token;
 use Laravel\Passport\TokenRepository;
@@ -85,7 +86,7 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
 
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
-        $this->expectException('Illuminate\Auth\AuthenticationException');
+        $this->expectException(AuthenticationException::class);
 
         $tokenRepository = m::mock(TokenRepository::class);
         $resourceServer = m::mock(ResourceServer::class);

--- a/tests/Unit/CheckClientCredentialsTest.php
+++ b/tests/Unit/CheckClientCredentialsTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Passport\Tests\Unit;
 
 use Illuminate\Http\Request;
 use Laravel\Passport\Client;
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
 use Laravel\Passport\Token;
 use Laravel\Passport\TokenRepository;
@@ -84,7 +85,7 @@ class CheckClientCredentialsTest extends TestCase
 
     public function test_exception_is_thrown_when_oauth_throws_exception()
     {
-        $this->expectException('Illuminate\Auth\AuthenticationException');
+        $this->expectException(AuthenticationException::class);
 
         $tokenRepository = m::mock(TokenRepository::class);
         $resourceServer = m::mock(ResourceServer::class);

--- a/tests/Unit/CheckForAnyScopeTest.php
+++ b/tests/Unit/CheckForAnyScopeTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Tests\Unit;
 
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Http\Middleware\CheckForAnyScope as CheckScopes;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -47,7 +48,7 @@ class CheckForAnyScopeTest extends TestCase
 
     public function test_exception_is_thrown_if_no_authenticated_user()
     {
-        $this->expectException('Illuminate\Auth\AuthenticationException');
+        $this->expectException(AuthenticationException::class);
 
         $middleware = new CheckScopes;
         $request = m::mock();
@@ -60,7 +61,7 @@ class CheckForAnyScopeTest extends TestCase
 
     public function test_exception_is_thrown_if_no_token()
     {
-        $this->expectException('Illuminate\Auth\AuthenticationException');
+        $this->expectException(AuthenticationException::class);
 
         $middleware = new CheckScopes;
         $request = m::mock();

--- a/tests/Unit/CheckScopesTest.php
+++ b/tests/Unit/CheckScopesTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Tests\Unit;
 
+use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Http\Middleware\CheckScopes;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -46,7 +47,7 @@ class CheckScopesTest extends TestCase
 
     public function test_exception_is_thrown_if_no_authenticated_user()
     {
-        $this->expectException('Illuminate\Auth\AuthenticationException');
+        $this->expectException(AuthenticationException::class);
 
         $middleware = new CheckScopes;
         $request = m::mock();
@@ -59,7 +60,7 @@ class CheckScopesTest extends TestCase
 
     public function test_exception_is_thrown_if_no_token()
     {
-        $this->expectException('Illuminate\Auth\AuthenticationException');
+        $this->expectException(AuthenticationException::class);
 
         $middleware = new CheckScopes;
         $request = m::mock();


### PR DESCRIPTION
## The problem

After looking for an easy way to tap into Passport's behaviour to manipulate the destination path when unauthenticated, I found there wasn't a particularly clear route to do so.

When an authentication error occurs, the script simply throws an `Illuminate\Auth\AuthenticationException`, the same as any other authentication section within a Laravel project. When this generic is thrown, it's caught by the exception handler and simply redirected to `route('login')`.

I felt it'd be useful to have a simpler way to tap into this functionality and customise the redirect behaviour.

## The solution

To achieve this, I've simply created Passport's own AuthenticationException class that anyone can then catch further up the chain and then perform the logic required for their specific use case.

In my use case, I'll be returning them to the typical login route but with some additional query parameters such as `?type=oauth` for example, so that I can remove registration links from the form.