### PR TITLE
laravel10 The Eloquent model's deprecated $dates property has been removed.

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -42,15 +42,7 @@ class Token extends Model
     protected $casts = [
         'scopes' => 'array',
         'revoked' => 'bool',
-    ];
-
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'expires_at',
+        'expires_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
- Passport Version: 11.7.0
- Laravel Version: 10.0.3

### Description:
laravel 10 update:
![image](https://user-images.githubusercontent.com/33448724/219588858-b5c68382-875d-4411-8594-fc476e0208b7.png)

passport token model problem:
![image](https://user-images.githubusercontent.com/33448724/219589446-75ae9940-eef5-4836-8c56-b34666765143.png)
