### PR TITLE
[11.x] Allow overriding the `AccessToken` class

### DIFF
--- a/src/Bridge/AccessTokenRepository.php
+++ b/src/Bridge/AccessTokenRepository.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport\Bridge;
 use DateTime;
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Passport\Events\AccessTokenCreated;
+use Laravel\Passport\Passport;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
@@ -46,7 +47,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      */
     public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
     {
-        return new AccessToken($userIdentifier, $scopes, $clientEntity);
+        return new Passport::$accessTokenEntity($userIdentifier, $scopes, $clientEntity);
     }
 
     /**

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -80,6 +80,13 @@ class Passport
     public static $keyPath;
 
     /**
+     * The access token entity class name.
+     *
+     * @var string
+     */
+    public static $accessTokenEntity = 'Laravel\Passport\Bridge\AccessToken';
+
+    /**
      * The auth code model class name.
      *
      * @var string
@@ -430,6 +437,17 @@ class Passport
         return static::$keyPath
             ? rtrim(static::$keyPath, '/\\').DIRECTORY_SEPARATOR.$file
             : storage_path($file);
+    }
+
+    /**
+     * Set the access token entity class name.
+     *
+     * @param  string  $accessTokenEntity
+     * @return void
+     */
+    public static function useAccessTokenEntity($accessTokenEntity)
+    {
+        static::$accessTokenEntity = $accessTokenEntity;
     }
 
     /**


### PR DESCRIPTION
Related to #94, #1637, This PR allows overriding the `Laravel\Passport\Bridge\AccessToken` class by calling `Passport::useAccessTokenEntity`.

### Why?
This class has `convertToJWT` method that can be overridden to add custom claims to JWT token, as there seems to be no other way to do this atm.

PS: It may be even more convenient after this: thephpleague/oauth2-server#1328