### PR TITLE
[10.x] Fix migrations for Laravel 9.x

### DIFF
--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration {
+return new class() extends Migration {
     /**
      * Run the migrations.
      *

--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class() extends Migration
+{
     /**
      * Run the migrations.
      *

--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -4,25 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
-    /**
-     * The database schema.
-     *
-     * @var \Illuminate\Database\Schema\Builder
-     */
-    protected $schema;
-
-    /**
-     * Create a new migration instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->schema = Schema::connection($this->getConnection());
-    }
-
+return new class () extends Migration {
     /**
      * Run the migrations.
      *
@@ -30,7 +12,9 @@ return new class extends Migration
      */
     public function up()
     {
-        $this->schema->create('oauth_auth_codes', function (Blueprint $table) {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('oauth_auth_codes', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->unsignedBigInteger('user_id')->index();
             $table->unsignedBigInteger('client_id');
@@ -47,7 +31,9 @@ return new class extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('oauth_auth_codes');
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('oauth_auth_codes');
     }
 
     /**

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration {
+return new class() extends Migration {
     /**
      * Run the migrations.
      *

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class() extends Migration
+{
     /**
      * Run the migrations.
      *

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -4,25 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
-    /**
-     * The database schema.
-     *
-     * @var \Illuminate\Database\Schema\Builder
-     */
-    protected $schema;
-
-    /**
-     * Create a new migration instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->schema = Schema::connection($this->getConnection());
-    }
-
+return new class () extends Migration {
     /**
      * Run the migrations.
      *
@@ -30,7 +12,9 @@ return new class extends Migration
      */
     public function up()
     {
-        $this->schema->create('oauth_access_tokens', function (Blueprint $table) {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('oauth_access_tokens', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->unsignedBigInteger('client_id');
@@ -49,7 +33,9 @@ return new class extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('oauth_access_tokens');
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('oauth_access_tokens');
     }
 
     /**

--- a/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration {
+return new class() extends Migration {
     /**
      * Run the migrations.
      *

--- a/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class() extends Migration
+{
     /**
      * Run the migrations.
      *

--- a/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
@@ -4,25 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
-    /**
-     * The database schema.
-     *
-     * @var \Illuminate\Database\Schema\Builder
-     */
-    protected $schema;
-
-    /**
-     * Create a new migration instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->schema = Schema::connection($this->getConnection());
-    }
-
+return new class () extends Migration {
     /**
      * Run the migrations.
      *
@@ -30,7 +12,9 @@ return new class extends Migration
      */
     public function up()
     {
-        $this->schema->create('oauth_refresh_tokens', function (Blueprint $table) {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('oauth_refresh_tokens', function (Blueprint $table) {
             $table->string('id', 100)->primary();
             $table->string('access_token_id', 100)->index();
             $table->boolean('revoked');
@@ -45,7 +29,9 @@ return new class extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('oauth_refresh_tokens');
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('oauth_refresh_tokens');
     }
 
     /**

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -4,25 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
-    /**
-     * The database schema.
-     *
-     * @var \Illuminate\Database\Schema\Builder
-     */
-    protected $schema;
-
-    /**
-     * Create a new migration instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->schema = Schema::connection($this->getConnection());
-    }
-
+return new class () extends Migration {
     /**
      * Get the migration connection name.
      *
@@ -40,7 +22,9 @@ return new class extends Migration
      */
     public function up()
     {
-        $this->schema->create('oauth_clients', function (Blueprint $table) {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('oauth_clients', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->string('name');
@@ -61,6 +45,8 @@ return new class extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('oauth_clients');
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('oauth_clients');
     }
 };

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration {
+return new class() extends Migration {
     /**
      * Get the migration connection name.
      *

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class() extends Migration
+{
     /**
      * Get the migration connection name.
      *

--- a/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration {
+return new class() extends Migration {
     /**
      * Run the migrations.
      *

--- a/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class() extends Migration
+{
     /**
      * Run the migrations.
      *

--- a/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -4,25 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
-    /**
-     * The database schema.
-     *
-     * @var \Illuminate\Database\Schema\Builder
-     */
-    protected $schema;
-
-    /**
-     * Create a new migration instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->schema = Schema::connection($this->getConnection());
-    }
-
+return new class () extends Migration {
     /**
      * Run the migrations.
      *
@@ -30,7 +12,9 @@ return new class extends Migration
      */
     public function up()
     {
-        $this->schema->create('oauth_personal_access_clients', function (Blueprint $table) {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('oauth_personal_access_clients', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('client_id');
             $table->timestamps();
@@ -44,7 +28,9 @@ return new class extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('oauth_personal_access_clients');
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('oauth_personal_access_clients');
     }
 
     /**


### PR DESCRIPTION
I'm fairly sure this won't get merged, and I'm cool with that... but encountered an issue today where [recent changes made to Laravel 9](https://github.com/laravel/framework/pull/46073) have broken in memory tests when using anonymous migrations written in this style, as reported [here in Telescope](https://github.com/laravel/telescope/pull/1304).

I've aimed this PR at Passport v10, which is otherwise compatible with Laravel 9, and attempted to write it in a similar style to [Nuno's fix for the aforementioend Telescope issue](https://github.com/laravel/telescope/pull/1305)... but also know that a better fix is just to upgrade to Passport v11.

Hope this helps... and, even if it doesn't get merged, I hope it helps anyone else who bumps into the same problem.

✌️ 