### PR TITLE
Make `$userId` nullable in `ClientRepository->createPersonalAccessClient`

### DIFF
--- a/src/ClientRepository.php
+++ b/src/ClientRepository.php
@@ -158,7 +158,7 @@ class ClientRepository
     /**
      * Store a new personal access token client.
      *
-     * @param  int  $userId
+     * @param  int|null  $userId
      * @param  string  $name
      * @param  string  $redirect
      * @return \Laravel\Passport\Client
@@ -175,7 +175,7 @@ class ClientRepository
     /**
      * Store a new password grant client.
      *
-     * @param  int  $userId
+     * @param  int|null  $userId
      * @param  string  $name
      * @param  string  $redirect
      * @param  string|null  $provider


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Since `createPersonalAccessClient` and `createPasswordGrantClient` are both called with `null` as the `$userId` and the migrations support this, it would be good to have the docblock in-line with the actual usage of the code.

I'm trying to set up a personal access client in my tests to issue API tokens, and this docblock is incorrect.