### PR TITLE
[11.x] Removed deprecated `dates` property from `AuthCode` model

### DIFF
--- a/src/AuthCode.php
+++ b/src/AuthCode.php
@@ -34,15 +34,7 @@ class AuthCode extends Model
      */
     protected $casts = [
         'revoked' => 'bool',
-    ];
-
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'expires_at',
+        'expires_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
Use `casts` instead of `dates` property.