### PR TITLE
TokenGuard::validate() has an unstable interface

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -137,7 +137,7 @@ class TokenGuard implements Guard
             $this->tokens,
             $this->clients,
             $this->encrypter,
-            $credentials['request'],
+            $credentials['request'] ?? app()->make('request'),
         ))->user());
     }
 


### PR DESCRIPTION
TokenGuard::validate() has an unstable public interface if called with an empty array.
Consider a DTO if you expect a given data structure. 
My suggestion (or the easiest fix) is to use `$this->request` or `app()->make('request)` if an empty/unexpected Array was given on method call.

https://github.com/laravel/passport/blob/11.x/src/Guards/TokenGuard.php#L140

If you use multiple Guards (eg Keycloak or Zitadel), this can be a problem or lead into unnecessary passed objects anyway.

👋