### PR TITLE
[11.x] Allow using custom BearerTokenValidator

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -87,6 +87,13 @@ class Passport
     public static $accessTokenEntity = 'Laravel\Passport\Bridge\AccessToken';
 
     /**
+     * The bearer token validator class name.
+     *
+     * @var string
+     */
+    public static $bearerTokenValidator = 'League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator';
+
+    /**
      * The auth code model class name.
      *
      * @var string
@@ -448,6 +455,17 @@ class Passport
     public static function useAccessTokenEntity($accessTokenEntity)
     {
         static::$accessTokenEntity = $accessTokenEntity;
+    }
+
+    /**
+     * Set the custom bearer token validator class name.
+     *
+     * @param  string  $bearerTokenValidator
+     * @return void
+     */
+    public static function useBearerTokenValidator($bearerTokenValidator)
+    {
+        static::$bearerTokenValidator = $bearerTokenValidator;
     }
 
     /**

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -308,9 +308,12 @@ class PassportServiceProvider extends ServiceProvider
     protected function registerResourceServer()
     {
         $this->app->singleton(ResourceServer::class, function ($container) {
+            $accessTokenRepository = $container->make(Bridge\AccessTokenRepository::class);
+
             return new ResourceServer(
-                $container->make(Bridge\AccessTokenRepository::class),
-                $this->makeCryptKey('public')
+                $accessTokenRepository,
+                $this->makeCryptKey('public'),
+                new Passport::$bearerTokenValidator($accessTokenRepository)
             );
         });
     }


### PR DESCRIPTION
**This PR does not break any existing features**

This PR allows overriding the default [BearerTokenValidator](https://github.com/thephpleague/oauth2-server/blob/master/src/AuthorizationValidators/BearerTokenValidator.php) class by calling `Passport::useBearerTokenValidator`.

`BearerTokenValidator` could be extended or could be used with [AuthorizationValidatorInterface](https://github.com/thephpleague/oauth2-server/blob/43cd4d406906c6be5c8de2cee9bd3ad3753544ef/src/AuthorizationValidators/AuthorizationValidatorInterface.php)

### Why?

Because [ResourceServer](https://github.com/thephpleague/oauth2-server/blob/43cd4d406906c6be5c8de2cee9bd3ad3753544ef/src/ResourceServer.php#L45) supports custom authorization validators but actually we have to overwrite `PassportServiceProvider ` just for use this functionality

Complement of #1638

