### PR TITLE
[11.x] Allow using custom authorization validator

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -178,6 +178,13 @@ class Passport
     public static $authorizationServerResponseType;
 
     /**
+     * The authorization validator.
+     *
+     * @var \League\OAuth2\Server\AuthorizationValidators\AuthorizationValidatorInterface|null
+     */
+    public static $authorizationValidator;
+
+    /**
      * Indicates if Passport routes will be registered.
      *
      * @var bool

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -310,7 +310,8 @@ class PassportServiceProvider extends ServiceProvider
         $this->app->singleton(ResourceServer::class, function ($container) {
             return new ResourceServer(
                 $container->make(Bridge\AccessTokenRepository::class),
-                $this->makeCryptKey('public')
+                $this->makeCryptKey('public'),
+                Passport::$authorizationValidator
             );
         });
     }


### PR DESCRIPTION
Oauth2 Server allows passing a custom authorization validator (instance of `AuthorizationValidatorInterface`) to the constructor of `ResourceServer` class or pass `null` to use the default `BearerTokenValidator`.

Devs usually override `BearerTokenValidator` class to add additional params to the request when validating the token with custom claims, e.g. as this PR intends to make this easier:
* https://github.com/thephpleague/oauth2-server/pull/851

Or as mentioned here:
* https://github.com/thephpleague/oauth2-server/issues/885#issuecomment-708501516

This PR allows using custom authorization validator.