### PR TITLE
Add generics to client factory

### DIFF
--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Str;
 use Laravel\Passport\Client;
 use Laravel\Passport\Passport;
 
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Laravel\Passport\Client>
+ */
 class ClientFactory extends Factory
 {
     /**


### PR DESCRIPTION
This allows tools like PHPStan and PHPStorm to understand what object is created by this factory