### PR TITLE
Fix 'revoked' datatype consistency

### DIFF
--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -48,6 +48,6 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function isAuthCodeRevoked($codeId)
     {
-        return Passport::authCode()->where('id', $codeId)->where('revoked', 1)->exists();
+        return Passport::authCode()->where('id', $codeId)->where('revoked', true)->exists();
     }
 }

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -33,15 +33,15 @@ class PurgeCommand extends Command
 
         if (($this->option('revoked') && $this->option('expired')) ||
             (! $this->option('revoked') && ! $this->option('expired'))) {
-            Passport::token()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
-            Passport::authCode()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
-            Passport::refreshToken()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
+            Passport::token()->where('revoked', true)->orWhereDate('expires_at', '<', $expired)->delete();
+            Passport::authCode()->where('revoked', true)->orWhereDate('expires_at', '<', $expired)->delete();
+            Passport::refreshToken()->where('revoked', true)->orWhereDate('expires_at', '<', $expired)->delete();
 
             $this->info('Purged revoked items and items expired for more than seven days.');
         } elseif ($this->option('revoked')) {
-            Passport::token()->where('revoked', 1)->delete();
-            Passport::authCode()->where('revoked', 1)->delete();
-            Passport::refreshToken()->where('revoked', 1)->delete();
+            Passport::token()->where('revoked', true)->delete();
+            Passport::authCode()->where('revoked', true)->delete();
+            Passport::refreshToken()->where('revoked', true)->delete();
 
             $this->info('Purged revoked items.');
         } elseif ($this->option('expired')) {

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -62,7 +62,7 @@ class TokenRepository
     {
         return $client->tokens()
                     ->whereUserId($user->getAuthIdentifier())
-                    ->where('revoked', 0)
+                    ->where('revoked', false)
                     ->where('expires_at', '>', Carbon::now())
                     ->first();
     }
@@ -115,7 +115,7 @@ class TokenRepository
     {
         return $client->tokens()
                       ->whereUserId($user->getAuthIdentifier())
-                      ->where('revoked', 0)
+                      ->where('revoked', false)
                       ->where('expires_at', '>', Carbon::now())
                       ->latest('expires_at')
                       ->first();

--- a/tests/Unit/TokenGuardTest.php
+++ b/tests/Unit/TokenGuardTest.php
@@ -49,7 +49,7 @@ class TokenGuardTest extends TestCase
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
         $tokens->shouldReceive('find')->once()->with('token')->andReturn($token = m::mock());
-        $clients->shouldReceive('revoked')->with(1)->andReturn(false);
+        $clients->shouldReceive('revoked')->with(true)->andReturn(false);
         $clients->shouldReceive('findActive')->with(1)->andReturn(new TokenGuardTestClient);
 
         $user = $guard->user($request);


### PR DESCRIPTION
### Summary
Column `revoked` within database is created with datatype boolean.

When using JWT library together with pgbouncer which is running in transaction pooling mode and db(postgres) configuration within laravel with options:
```
            'options' => [
                PDO::ATTR_CASE => PDO::CASE_NATURAL,
                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
                PDO::ATTR_STRINGIFY_FETCHES => false,
                PDO::ATTR_EMULATE_PREPARES => true,
                PDO::ATTR_PERSISTENT => true
            ]
```


throws error:

```
{"message":"[2023-07-12T10:06:14.957012+00:00] production.ERROR: SQLSTATE[42883]: 
Undefined function: 7 ERROR:  operator does not exist: boolean = integer LINE 1: ... 
not null and \"user_id\" = 123 and \"revoked\" = 0 and \"e...
^ HINT:  No operator matches the given name and argument types. 
You might need to add explicit type casts. 
(SQL: select * from \"oauth_access_tokens\" where \"oauth_access_tokens\".\"client_id\" = 4 and \"oauth_access_tokens\".\"client_id\" is not null and 
\"user_id\" = 123 and \"revoked\" = 0 and \"expires_at\" > 2023-07-12 10:06:14 order by \"expires_at\" desc limit 1) 
{\"userId\":123,\"exception\":\"[object] 
(Illuminate\\\\Database\\\\QueryException(code: 42883): SQLSTATE[42883]: Undefined function: 7 ERROR:  operator does not exist: boolean = integer\\nLINE 1: ... 
not null and \\\"user_id\\\" = 123 and \\\"revoked\\\" = 0 and \\\"e...
```

### Problem:
In the current code, there are some calls where the column 'revoked' is addressed using integers, while in other places, it is addressed using booleans.

### Solution:
This fix ensures consistency within the PHP code by ensuring that all calls using the `revoked` column utilize the boolean data type, thereby maintaining a uniform coding style and preventing the switching between different data types.