### PR TITLE
Add default scopes to issued token

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -22,11 +22,13 @@ class Passport
     public static $implicitGrantEnabled = false;
 
     /**
-     * The default scope.
+     * The default(s) scope(s) defined for the application.
      *
-     * @var string
+     * @var array
      */
-    public static $defaultScope;
+    public static $defaultScope = [
+        //
+    ];
 
     /**
      * All of the scopes defined for the application.
@@ -199,12 +201,12 @@ class Passport
     /**
      * Set the default scope(s). Multiple scopes may be an array or specified delimited by spaces.
      *
-     * @param  array|string  $scope
+     * @param  array $scopes
      * @return void
      */
-    public static function setDefaultScope($scope)
+    public static function setDefaultScope($scopes)
     {
-        static::$defaultScope = is_array($scope) ? implode(' ', $scope) : $scope;
+        static::$defaultScope = $scopes;
     }
 
     /**
@@ -225,7 +227,7 @@ class Passport
      */
     public static function hasScope($id)
     {
-        return $id === '*' || array_key_exists($id, static::$scopes);
+        return $id === '*' || array_key_exists($id, static::$scopes) || array_key_exists($id, static::$defaultScope);
     }
 
     /**
@@ -237,7 +239,22 @@ class Passport
     {
         return collect(static::$scopes)->map(function ($description, $id) {
             return new Scope($id, $description);
-        })->values();
+        })->when(
+            !blank(static::$defaultScope),
+            fn ($collection, $scope) => $collection->merge(static::defaultScopes())
+        )->values();
+    }
+
+    /**
+     * Get all of the default scopes defined for the application.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public static function defaultScopes()
+    {
+        return collect(static::$defaultScope)->map(function ($description, $id) {
+            return new Scope($id, $description);
+        });
     }
 
     /**

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -187,7 +187,7 @@ class Passport
     public static $registersRoutes = true;
 
     /**
-     * Indicates if Passport validates and uses default scopes within the issued token
+     * Indicates if Passport validates and uses default scopes within the issued token.
      *
      * @var bool
      */
@@ -206,7 +206,7 @@ class Passport
     }
 
     /**
-     * Use and validate default scopes
+     * Use and validate default scopes.
      *
      * @return void
      */
@@ -218,7 +218,7 @@ class Passport
     /**
      * Set the default scope(s). Multiple scopes may be an array or specified delimited by spaces.
      *
-     * @param  array $scopes
+     * @param  array  $scopes
      * @return void
      */
     public static function setDefaultScope($scopes)
@@ -259,7 +259,7 @@ class Passport
         return collect(static::$scopes)->map(function ($description, $id) {
             return new Scope($id, $description);
         })->when(
-            static::$useDefaultScopes && !blank(static::$defaultScope),
+            static::$useDefaultScopes && ! blank(static::$defaultScope),
             fn ($collection, $scope) => $collection->merge(static::defaultScopes())
         )->values();
     }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -187,6 +187,13 @@ class Passport
     public static $registersRoutes = true;
 
     /**
+     * Indicates if Passport validates and uses default scopes within the issued token
+     *
+     * @var bool
+     */
+    public static $useDefaultScopes = false;
+
+    /**
      * Enable the implicit grant type.
      *
      * @return static
@@ -196,6 +203,16 @@ class Passport
         static::$implicitGrantEnabled = true;
 
         return new static;
+    }
+
+    /**
+     * Use and validate default scopes
+     *
+     * @return void
+     */
+    public static function useDefaultScopes()
+    {
+        static::$useDefaultScopes = true;
     }
 
     /**
@@ -227,7 +244,9 @@ class Passport
      */
     public static function hasScope($id)
     {
-        return $id === '*' || array_key_exists($id, static::$scopes) || array_key_exists($id, static::$defaultScope);
+        $hasDefaultScope = static::$useDefaultScopes && array_key_exists($id, static::$defaultScope);
+
+        return $id === '*' || array_key_exists($id, static::$scopes) || $hasDefaultScope;
     }
 
     /**
@@ -240,7 +259,7 @@ class Passport
         return collect(static::$scopes)->map(function ($description, $id) {
             return new Scope($id, $description);
         })->when(
-            !blank(static::$defaultScope),
+            static::$useDefaultScopes && !blank(static::$defaultScope),
             fn ($collection, $scope) => $collection->merge(static::defaultScopes())
         )->values();
     }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -159,7 +159,8 @@ class PassportServiceProvider extends ServiceProvider
     {
         $this->app->singleton(AuthorizationServer::class, function () {
             return tap($this->makeAuthorizationServer(), function ($server) {
-                $server->setDefaultScope(Passport::$defaultScope);
+                $defaultScope = Passport::defaultScopes()->map(fn (Scope $scope) => $scope->id)->values()->implode(' ');
+                $server->setDefaultScope($defaultScope);
 
                 $server->enableGrantType(
                     $this->makeAuthCodeGrant(), Passport::tokensExpireIn()

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -139,7 +139,7 @@ class AccessTokenControllerTest extends PassportTestCase
         Passport::useDefaultScopes();
         Passport::setDefaultScope([
             'foo' => 'It requests foo access',
-            'bar' => 'it requests bar access'
+            'bar' => 'it requests bar access',
         ]);
 
         /** @var Client $client */

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -136,6 +136,7 @@ class AccessTokenControllerTest extends PassportTestCase
         $user->password = $this->app->make(Hasher::class)->make('foobar123');
         $user->save();
 
+        Passport::useDefaultScopes();
         Passport::setDefaultScope([
             'foo' => 'It requests foo access',
             'bar' => 'it requests bar access'

--- a/tests/Feature/ActingAsClientTest.php
+++ b/tests/Feature/ActingAsClientTest.php
@@ -10,6 +10,12 @@ use Laravel\Passport\Passport;
 
 class ActingAsClientTest extends PassportTestCase
 {
+    protected function tearDown(): void
+    {
+        Passport::setDefaultScope([]);
+        parent::tearDown();
+    }
+
     public function testActingAsClientWhenTheRouteIsProtectedByCheckClientCredentialsMiddleware()
     {
         $this->withoutExceptionHandling();
@@ -40,6 +46,55 @@ class ActingAsClientTest extends PassportTestCase
         })->middleware(CheckClientCredentialsForAnyScope::class.':testFoo');
 
         Passport::actingAsClient(new Client(), ['testFoo']);
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
+
+    public function testActingAsClientWhenTheRouteIsProtectedByCheckClientCredentialsMiddlewareWithDefaultScope()
+    {
+        $this->withoutExceptionHandling();
+
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        Passport::setDefaultScope([
+            'foo' => 'It requests foo access',
+            'bar' => 'it requests bar access'
+        ]);
+
+        $router->get('/foo', function () {
+            return 'bar';
+        })->middleware(CheckClientCredentials::class);
+
+        Passport::actingAsClient(new Client(), Passport::defaultScopes()->pluck('id')->toArray());
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
+
+    public function testActingAsClientWhenTheRouteIsProtectedByCheckClientCredentialsForAnyScopeWithDefaultScope()
+    {
+        $this->withoutExceptionHandling();
+
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        Passport::setDefaultScope([
+            'foo' => 'It requests foo access',
+            'bar' => 'it requests bar access'
+        ]);
+
+        $defaultScopes = Passport::defaultScopes()->pluck('id')->values()->toArray();
+        $middlewareScopes = implode(',', $defaultScopes);
+
+        $router->get('/foo', function () {
+            return 'bar';
+        })->middleware(CheckClientCredentialsForAnyScope::class.':'.$middlewareScopes);
+
+        Passport::actingAsClient(new Client(), $defaultScopes);
 
         $response = $this->get('/foo');
         $response->assertSuccessful();

--- a/tests/Feature/ActingAsClientTest.php
+++ b/tests/Feature/ActingAsClientTest.php
@@ -61,7 +61,7 @@ class ActingAsClientTest extends PassportTestCase
 
         Passport::setDefaultScope([
             'foo' => 'It requests foo access',
-            'bar' => 'it requests bar access'
+            'bar' => 'it requests bar access',
         ]);
 
         $router->get('/foo', function () {
@@ -84,7 +84,7 @@ class ActingAsClientTest extends PassportTestCase
 
         Passport::setDefaultScope([
             'foo' => 'It requests foo access',
-            'bar' => 'it requests bar access'
+            'bar' => 'it requests bar access',
         ]);
 
         $defaultScopes = Passport::defaultScopes()->pluck('id')->values()->toArray();

--- a/tests/Unit/PassportTest.php
+++ b/tests/Unit/PassportTest.php
@@ -13,6 +13,12 @@ use PHPUnit\Framework\TestCase;
 
 class PassportTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Passport::setDefaultScope([]);
+        parent::tearDown();
+    }
+
     public function test_scopes_can_be_managed()
     {
         Passport::tokensCan([
@@ -84,6 +90,15 @@ class PassportTest extends TestCase
         $this->assertInstanceOf(Passport::refreshTokenModel(), $refreshToken);
 
         Passport::useRefreshTokenModel(RefreshToken::class);
+    }
+
+    public function test_default_scopes_can_be_managed()
+    {
+        Passport::setDefaultScope([
+            'foo' => 'It requests foo access'
+        ]);
+
+        $this->assertTrue(Passport::hasScope('foo'));
     }
 }
 

--- a/tests/Unit/PassportTest.php
+++ b/tests/Unit/PassportTest.php
@@ -96,7 +96,7 @@ class PassportTest extends TestCase
     {
         Passport::useDefaultScopes();
         Passport::setDefaultScope([
-            'foo' => 'It requests foo access'
+            'foo' => 'It requests foo access',
         ]);
 
         $this->assertTrue(Passport::hasScope('foo'));
@@ -106,7 +106,7 @@ class PassportTest extends TestCase
     {
         Passport::$useDefaultScopes = false;
         Passport::setDefaultScope([
-            'foo' => 'It requests foo access'
+            'foo' => 'It requests foo access',
         ]);
 
         $this->assertFalse(Passport::hasScope('foo'));

--- a/tests/Unit/PassportTest.php
+++ b/tests/Unit/PassportTest.php
@@ -94,11 +94,22 @@ class PassportTest extends TestCase
 
     public function test_default_scopes_can_be_managed()
     {
+        Passport::useDefaultScopes();
         Passport::setDefaultScope([
             'foo' => 'It requests foo access'
         ]);
 
         $this->assertTrue(Passport::hasScope('foo'));
+    }
+
+    public function test_default_scopes_are_not_included_if_use_default_is_not_true()
+    {
+        Passport::$useDefaultScopes = false;
+        Passport::setDefaultScope([
+            'foo' => 'It requests foo access'
+        ]);
+
+        $this->assertFalse(Passport::hasScope('foo'));
     }
 }
 


### PR DESCRIPTION
Hi there,

This PR is related to passport default scopes. 

I was working on a project using Laravel Passport and after I register the default scopes in `AuthServiceProvider.php` with `Passport::setDefaultScope()` the returned token didn't have the scopes defined in the payload. Thus, I decided to make some changes which are:

1. Default scopes are now part of the token if they are defined with Passport::setDefaultScope()`.
2. Given the premise of the RFC about [Access Token Scope](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3), specially in this part
> "The authorization server MAY fully or partially ignore the scope requested by the client, based on the authorization server policy or the resource owner's instructions.  If the issued access token scope is different from the one requested by the client, the authorization server MUST include the "scope" response parameter to inform the client of the actual scope granted"

when validating scopes, Passport should add the `defaultScope` as part of the validation `hasScope()` and methods like `scopeIds()` and `scopes()`. For that matter, I added a new Passport static method called `useDefaultScopes()` that sets a boolean static attribute to true in case default scopes MAY want to be included in issued token.

For this, I am not quite sure if this method is useful and always add default scopes if `defaultScope` is not empty 🤔 trying to adhere to the RFC fragment I addressed in this numeral.

3. I believe that `Passport::$defaultScope` should follow the same data type as `Passport::$scopes` regarding of one of the reasons of what scopes are for: ["displaying the description on the authorization approval screen"](https://laravel.com/docs/10.x/passport#defining-scopes)


Hope this helps 😃, if this PR is approved, I think that the only part where Laravel Passport docs may change is here [Default Scope](https://laravel.com/docs/10.x/passport#default-scope) and also within an upgrade docs.