### PR TITLE
for Laravel 9.x set the client on the TokenGuard when mocking the client

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Http\Request;
+use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Laravel\Passport\PassportUserProvider;
@@ -57,6 +58,13 @@ class TokenGuard
      * @var \Illuminate\Contracts\Encryption\Encrypter
      */
     protected $encrypter;
+
+    /**
+     * The currently authenticated client.
+     *
+     * @var \Laravel\Passport\Client|null
+     */
+    protected $client;
 
     /**
      * Create a new token guard instance.
@@ -122,6 +130,10 @@ class TokenGuard
      */
     public function client(Request $request)
     {
+        if (! is_null($this->client)) {
+            return $this->client;
+        }
+
         if ($request->bearerToken()) {
             if (! $psr = $this->getPsrRequestViaBearerToken($request)) {
                 return;
@@ -313,5 +325,18 @@ class TokenGuard
     public static function serialized()
     {
         return EncryptCookies::serialized('XSRF-TOKEN');
+    }
+
+    /**
+     * Set the client for the current request.
+     *
+     * @param  \Laravel\Passport\Client  $client
+     * @return $this
+     */
+    public function setClient(Client $client)
+    {
+        $this->client = $client;
+
+        return $this;
     }
 }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -414,9 +414,10 @@ class Passport
      *
      * @param  \Laravel\Passport\Client  $client
      * @param  array  $scopes
+     * @param  string  $guard
      * @return \Laravel\Passport\Client
      */
-    public static function actingAsClient($client, $scopes = [])
+    public static function actingAsClient($client, $scopes = [], $guard = null)
     {
         $token = app(self::tokenModel());
 
@@ -439,6 +440,11 @@ class Passport
         $mock->shouldReceive('find')->andReturn($token);
 
         app()->instance(TokenRepository::class, $mock);
+
+        if ($guard) {
+            app('auth')->guard($guard)->setClient($client);
+            app('auth')->shouldUse($guard);
+        }
 
         return $client;
     }

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -75,7 +75,7 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertArrayHasKey('expires_in', $decodedResponse);
         $this->assertArrayHasKey('access_token', $decodedResponse);
         $this->assertSame('Bearer', $decodedResponse['token_type']);
-        $expiresInSeconds = 31536000;
+        $expiresInSeconds = 31622400;
         $this->assertEqualsWithDelta($expiresInSeconds, $decodedResponse['expires_in'], 5);
 
         $jwtAccessToken = Configuration::forUnsecuredSigner()->parser()->parse($decodedResponse['access_token']);
@@ -168,7 +168,7 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $decodedResponse);
         $this->assertArrayHasKey('refresh_token', $decodedResponse);
         $this->assertSame('Bearer', $decodedResponse['token_type']);
-        $expiresInSeconds = 31536000;
+        $expiresInSeconds = 31622400;
         $this->assertEqualsWithDelta($expiresInSeconds, $decodedResponse['expires_in'], 5);
 
         $jwtAccessToken = Configuration::forUnsecuredSigner()->parser()->parse($decodedResponse['access_token']);


### PR DESCRIPTION
Same as _#1519 Stub client on guard when calling Passport::actingAsClient()_

I'm trying testing a package laravel 9.x with passport 10.x  (it has support for 10.x and 11.x)

This PR changes the Passport::actingAsClient() method. Currently when stubbing the client via Passport, the guard doesn't actually reflect the stub:
```php
>>> $client = Laravel\Passport\Database\Factories\ClientFactory::new()->createOne()
=> Laravel\Passport\Client {#4807}
>>> Laravel\Passport\Passport::actingAsClient($client)
=> Laravel\Passport\Client {#4807}
>>> auth()->guard('api')->client()
=> null
```

After this PR the following happens:
```php
>>> $client = Laravel\Passport\Database\Factories\ClientFactory::new()->createOne()
=> Laravel\Passport\Client {#4807}
>>> Laravel\Passport\Passport::actingAsClient($client, [], 'api')
=> Laravel\Passport\Client {#4807}
>>> auth()->guard('api')->client()
=> Laravel\Passport\Client {#4807}
```

I'm fairly sure this won't get merged 😖