### PR TITLE
[11.x] Add support for inherited scopes when limiting scopes on clients

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -10,6 +10,7 @@ use Laravel\Passport\Database\Factories\ClientFactory;
 class Client extends Model
 {
     use HasFactory;
+    use ResolvesInheritedScopes;
 
     /**
      * The database table used by the model.
@@ -163,7 +164,21 @@ class Client extends Model
      */
     public function hasScope($scope)
     {
-        return ! is_array($this->scopes) || in_array($scope, $this->scopes);
+        if (! is_array($this->scopes)) {
+            return true;
+        }
+
+        $scopes = Passport::$withInheritedScopes
+            ? $this->resolveInheritedScopes($scope)
+            : [$scope];
+
+        foreach ($scopes as $scope) {
+            if (in_array($scope, $this->scopes)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/ResolvesInheritedScopes.php
+++ b/src/ResolvesInheritedScopes.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Passport;
+
+trait ResolvesInheritedScopes
+{
+    /**
+     * Resolve all possible scopes.
+     *
+     * @param  string  $scope
+     * @return array
+     */
+    protected function resolveInheritedScopes($scope)
+    {
+        $parts = explode(':', $scope);
+
+        $partsCount = count($parts);
+
+        $scopes = [];
+
+        for ($i = 1; $i <= $partsCount; $i++) {
+            $scopes[] = implode(':', array_slice($parts, 0, $i));
+        }
+
+        return $scopes;
+    }
+}

--- a/src/Token.php
+++ b/src/Token.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Token extends Model
 {
+    use ResolvesInheritedScopes;
+
     /**
      * The database table used by the model.
      *
@@ -92,27 +94,6 @@ class Token extends Model
         }
 
         return false;
-    }
-
-    /**
-     * Resolve all possible scopes.
-     *
-     * @param  string  $scope
-     * @return array
-     */
-    protected function resolveInheritedScopes($scope)
-    {
-        $parts = explode(':', $scope);
-
-        $partsCount = count($parts);
-
-        $scopes = [];
-
-        for ($i = 1; $i <= $partsCount; $i++) {
-            $scopes[] = implode(':', array_slice($parts, 0, $i));
-        }
-
-        return $scopes;
     }
 
     /**


### PR DESCRIPTION
This PR is a minor improvement to #1682.

This PR makes scope inheritance work with limiting scope access for clients.

As an example, let's say we have the following scopes:

```text
user       update the user's info
user:read  read the user's info
```

And we have the following client:

```php
Passport::$withInheritedScopes = true;

$client = new Client();
$client->scopes = ['user'];
```

Before this PR: The `user:read` scope cannot be granted to the client, because the client doesn't have access to it
After this PR: Both of the scopes can be granted to the client if requested
