### PR TITLE
[11.x] Allow scope repository to be constructed without parameters

### DIFF
--- a/tests/Unit/BridgeScopeRepositoryTest.php
+++ b/tests/Unit/BridgeScopeRepositoryTest.php
@@ -38,6 +38,21 @@ class BridgeScopeRepositoryTest extends TestCase
         $this->assertEquals([$scope1], $scopes);
     }
 
+    public function test_invalid_scopes_are_removed_without_a_client_repository()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+        ]);
+
+        $repository = new ScopeRepository();
+
+        $scopes = $repository->finalizeScopes(
+            [$scope1 = new Scope('scope-1'), new Scope('scope-2')], 'client_credentials', new Client('id', 'name', 'http://localhost'), 1
+        );
+
+        $this->assertEquals([$scope1], $scopes);
+    }
+
     public function test_clients_do_not_restrict_scopes_by_default()
     {
         Passport::tokensCan([
@@ -119,6 +134,21 @@ class BridgeScopeRepositoryTest extends TestCase
         $clients->shouldReceive('findActive')->withAnyArgs()->andReturn($client);
 
         $repository = new ScopeRepository($clients);
+
+        $scopes = $repository->finalizeScopes(
+            [$scope1 = new Scope('*')], 'refresh_token', new Client('id', 'name', 'http://localhost'), 1
+        );
+
+        $this->assertEquals([], $scopes);
+    }
+
+    public function test_superuser_scope_cant_be_applied_if_wrong_grant_without_a_client_repository()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+        ]);
+
+        $repository = new ScopeRepository();
 
         $scopes = $repository->finalizeScopes(
             [$scope1 = new Scope('*')], 'refresh_token', new Client('id', 'name', 'http://localhost'), 1


### PR DESCRIPTION
This fixes a breaking change introduced by #1682 