### PR TITLE
[11.x] Named static methods for middleware

### DIFF
--- a/src/Http/Middleware/CheckCredentials.php
+++ b/src/Http/Middleware/CheckCredentials.php
@@ -72,12 +72,12 @@ abstract class CheckCredentials
     /**
      * Generate a string representation of the middleware with specified scopes.
      *
-     * @param  array  $scopes 
+     * @param  array  $scopes
      * @return string
      */
     public static function using(...$scopes)
     {
-        return static::class . ':' . implode(',', $scopes);
+        return static::class.':'.implode(',', $scopes);
     }
 
     /**

--- a/src/Http/Middleware/CheckCredentials.php
+++ b/src/Http/Middleware/CheckCredentials.php
@@ -72,12 +72,12 @@ abstract class CheckCredentials
     /**
      * Generate a string representation of the middleware with specified scopes.
      *
-     * @param  array  $scopes
+     * @param  array|string  $scopes
      * @return string
      */
-    public static function using(...$scopes)
+    public static function using($scopes)
     {
-        return static::class.':'.implode(',', $scopes);
+        return static::class.':'.implode(',', func_get_args());
     }
 
     /**

--- a/src/Http/Middleware/CheckCredentials.php
+++ b/src/Http/Middleware/CheckCredentials.php
@@ -40,6 +40,21 @@ abstract class CheckCredentials
     }
 
     /**
+     * Specify the scopes for the middleware.
+     *
+     * @param  array|string  $scopes
+     * @return string
+     */
+    public static function using(...$scopes)
+    {
+        if (is_array($scopes[0])) {
+            return static::class.':'.implode(',', $scopes[0]);
+        } else {
+            return static::class.':'.implode(',', $scopes);
+        }
+    }
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -67,17 +82,6 @@ abstract class CheckCredentials
         $this->validate($psr, $scopes);
 
         return $next($request);
-    }
-
-    /**
-     * Generate a string representation of the middleware with specified scopes.
-     *
-     * @param  array|string  $scopes
-     * @return string
-     */
-    public static function using($scopes)
-    {
-        return static::class.':'.implode(',', func_get_args());
     }
 
     /**

--- a/src/Http/Middleware/CheckCredentials.php
+++ b/src/Http/Middleware/CheckCredentials.php
@@ -70,6 +70,17 @@ abstract class CheckCredentials
     }
 
     /**
+     * Generate a string representation of the middleware with specified scopes.
+     *
+     * @param  array  $scopes 
+     * @return string
+     */
+    public static function using(...$scopes)
+    {
+        return static::class . ':' . implode(',', $scopes);
+    }
+
+    /**
      * Validate the scopes and token on the incoming request.
      *
      * @param  \Psr\Http\Message\ServerRequestInterface  $psr

--- a/src/Http/Middleware/CheckForAnyScope.php
+++ b/src/Http/Middleware/CheckForAnyScope.php
@@ -35,11 +35,11 @@ class CheckForAnyScope
     /**
      * Generate a string representation of the middleware with specified scopes.
      *
-     * @param  array  $scopes 
+     * @param  array  $scopes
      * @return string
      */
     public static function using(...$scopes)
     {
-        return static::class . ':' . implode(',', $scopes);
+        return static::class.':'.implode(',', $scopes);
     }
 }

--- a/src/Http/Middleware/CheckForAnyScope.php
+++ b/src/Http/Middleware/CheckForAnyScope.php
@@ -8,6 +8,21 @@ use Laravel\Passport\Exceptions\MissingScopeException;
 class CheckForAnyScope
 {
     /**
+     * Specify the scopes for the middleware.
+     *
+     * @param  array|string  $scopes
+     * @return string
+     */
+    public static function using(...$scopes)
+    {
+        if (is_array($scopes[0])) {
+            return static::class.':'.implode(',', $scopes[0]);
+        } else {
+            return static::class.':'.implode(',', $scopes);
+        }
+    }
+
+    /**
      * Handle the incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -30,16 +45,5 @@ class CheckForAnyScope
         }
 
         throw new MissingScopeException($scopes);
-    }
-
-    /**
-     * Generate a string representation of the middleware with specified scopes.
-     *
-     * @param  array|string  $scopes
-     * @return string
-     */
-    public static function using($scopes)
-    {
-        return static::class.':'.implode(',', func_get_args());
     }
 }

--- a/src/Http/Middleware/CheckForAnyScope.php
+++ b/src/Http/Middleware/CheckForAnyScope.php
@@ -31,4 +31,15 @@ class CheckForAnyScope
 
         throw new MissingScopeException($scopes);
     }
+
+    /**
+     * Generate a string representation of the middleware with specified scopes.
+     *
+     * @param  array  $scopes 
+     * @return string
+     */
+    public static function using(...$scopes)
+    {
+        return static::class . ':' . implode(',', $scopes);
+    }
 }

--- a/src/Http/Middleware/CheckForAnyScope.php
+++ b/src/Http/Middleware/CheckForAnyScope.php
@@ -35,11 +35,11 @@ class CheckForAnyScope
     /**
      * Generate a string representation of the middleware with specified scopes.
      *
-     * @param  array  $scopes
+     * @param  array|string  $scopes
      * @return string
      */
-    public static function using(...$scopes)
+    public static function using($scopes)
     {
-        return static::class.':'.implode(',', $scopes);
+        return static::class.':'.implode(',', func_get_args());
     }
 }

--- a/src/Http/Middleware/CheckScopes.php
+++ b/src/Http/Middleware/CheckScopes.php
@@ -35,11 +35,11 @@ class CheckScopes
     /**
      * Generate a string representation of the middleware with specified scopes.
      *
-     * @param  array  $scopes 
+     * @param  array  $scopes
      * @return string
      */
     public static function using(...$scopes)
     {
-        return static::class . ':' . implode(',', $scopes);
+        return static::class.':'.implode(',', $scopes);
     }
 }

--- a/src/Http/Middleware/CheckScopes.php
+++ b/src/Http/Middleware/CheckScopes.php
@@ -31,4 +31,15 @@ class CheckScopes
 
         return $next($request);
     }
+
+    /**
+     * Generate a string representation of the middleware with specified scopes.
+     *
+     * @param  array  $scopes 
+     * @return string
+     */
+    public static function using(...$scopes)
+    {
+        return static::class . ':' . implode(',', $scopes);
+    }
 }

--- a/src/Http/Middleware/CheckScopes.php
+++ b/src/Http/Middleware/CheckScopes.php
@@ -8,6 +8,21 @@ use Laravel\Passport\Exceptions\MissingScopeException;
 class CheckScopes
 {
     /**
+     * Specify the scopes for the middleware.
+     *
+     * @param  array|string  $scopes
+     * @return string
+     */
+    public static function using(...$scopes)
+    {
+        if (is_array($scopes[0])) {
+            return static::class.':'.implode(',', $scopes[0]);
+        } else {
+            return static::class.':'.implode(',', $scopes);
+        }
+    }
+
+    /**
      * Handle the incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -30,16 +45,5 @@ class CheckScopes
         }
 
         return $next($request);
-    }
-
-    /**
-     * Generate a string representation of the middleware with specified scopes.
-     *
-     * @param  array|string  $scopes
-     * @return string
-     */
-    public static function using($scopes)
-    {
-        return static::class.':'.implode(',', func_get_args());
     }
 }

--- a/src/Http/Middleware/CheckScopes.php
+++ b/src/Http/Middleware/CheckScopes.php
@@ -40,6 +40,6 @@ class CheckScopes
      */
     public static function using($scopes)
     {
-        return static::class.':'. implode(',', func_get_args());
+        return static::class.':'.implode(',', func_get_args());
     }
 }

--- a/src/Http/Middleware/CheckScopes.php
+++ b/src/Http/Middleware/CheckScopes.php
@@ -35,11 +35,11 @@ class CheckScopes
     /**
      * Generate a string representation of the middleware with specified scopes.
      *
-     * @param  array  $scopes
+     * @param  array|string  $scopes
      * @return string
      */
-    public static function using(...$scopes)
+    public static function using($scopes)
     {
-        return static::class.':'.implode(',', $scopes);
+        return static::class.':'. implode(',', func_get_args());
     }
 }

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -36,6 +36,19 @@ class CreateFreshApiToken
     }
 
     /**
+     * Specify the guard for the middleware.
+     *
+     * @param  string|null  $guard
+     * @return string
+     */
+    public static function using($guard = null)
+    {
+        $guard = is_null($guard) ? '' : ':'.$guard;
+
+        return static::class.$guard;
+    }
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -56,19 +69,6 @@ class CreateFreshApiToken
         }
 
         return $response;
-    }
-
-    /**
-     * Specify the guard for the middleware.
-     *
-     * @param  string|null  $guard
-     * @return string
-     */
-    public static function using($guard = null)
-    {
-        $args = is_null($guard) ? '' : ':'.$guard;
-
-        return static::class.$args;
     }
 
     /**

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -61,14 +61,14 @@ class CreateFreshApiToken
     /**
      * Specify the guard for the middleware.
      *
-     * @param  string|null  $guard 
+     * @param  string|null  $guard
      * @return string
      */
     public static function using($guard = null)
     {
-        $args = is_null($guard) ? '' : ':' . $guard;
+        $args = is_null($guard) ? '' : ':'.$guard;
 
-        return static::class . $args;
+        return static::class.$args;
     }
 
     /**

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -59,6 +59,19 @@ class CreateFreshApiToken
     }
 
     /**
+     * Specify the guard for the middleware.
+     *
+     * @param  string|null  $guard 
+     * @return string
+     */
+    public static function using($guard = null)
+    {
+        $args = is_null($guard) ? '' : ':' . $guard;
+
+        return static::class . $args;
+    }
+
+    /**
      * Determine if the given request should receive a fresh token.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/tests/Feature/ActingAsTest.php
+++ b/tests/Feature/ActingAsTest.php
@@ -48,6 +48,27 @@ class ActingAsTest extends PassportTestCase
         $response->assertSee('bar');
     }
 
+    public function testItCanGenerateDefinitionViaStaticMethod()
+    {
+        $signature = (string) CheckScopes::using();
+        $this->assertSame('Laravel\Passport\Http\Middleware\CheckScopes', $signature);
+
+        $signature = (string) CheckScopes::using('admin');
+        $this->assertSame('Laravel\Passport\Http\Middleware\CheckScopes:admin', $signature);
+
+        $signature = (string) CheckScopes::using('admin', 'footest');
+        $this->assertSame('Laravel\Passport\Http\Middleware\CheckScopes:admin,footest', $signature);
+
+        $signature = (string) CheckForAnyScope::using('admin', 'footest');
+        $this->assertSame('Laravel\Passport\Http\Middleware\CheckForAnyScope:admin,footest', $signature);
+
+        $signature = (string) CheckForAnyScope::using('admin', 'footest');
+        $this->assertSame('Laravel\Passport\Http\Middleware\CheckForAnyScope:admin,footest', $signature);
+
+        $signature = (string) CheckForAnyScope::using('admin', 'footest');
+        $this->assertSame('Laravel\Passport\Http\Middleware\CheckForAnyScope:admin,footest', $signature);
+    }
+
     public function testActingAsWhenTheRouteIsProtectedByCheckForAnyScopeMiddleware()
     {
         $this->withoutExceptionHandling();

--- a/tests/Feature/ActingAsTest.php
+++ b/tests/Feature/ActingAsTest.php
@@ -50,20 +50,14 @@ class ActingAsTest extends PassportTestCase
 
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) CheckScopes::using();
-        $this->assertSame('Laravel\Passport\Http\Middleware\CheckScopes', $signature);
-
         $signature = (string) CheckScopes::using('admin');
         $this->assertSame('Laravel\Passport\Http\Middleware\CheckScopes:admin', $signature);
 
         $signature = (string) CheckScopes::using('admin', 'footest');
         $this->assertSame('Laravel\Passport\Http\Middleware\CheckScopes:admin,footest', $signature);
 
-        $signature = (string) CheckForAnyScope::using('admin', 'footest');
-        $this->assertSame('Laravel\Passport\Http\Middleware\CheckForAnyScope:admin,footest', $signature);
-
-        $signature = (string) CheckForAnyScope::using('admin', 'footest');
-        $this->assertSame('Laravel\Passport\Http\Middleware\CheckForAnyScope:admin,footest', $signature);
+        $signature = (string) CheckForAnyScope::using('admin');
+        $this->assertSame('Laravel\Passport\Http\Middleware\CheckForAnyScope:admin', $signature);
 
         $signature = (string) CheckForAnyScope::using('admin', 'footest');
         $this->assertSame('Laravel\Passport\Http\Middleware\CheckForAnyScope:admin,footest', $signature);


### PR DESCRIPTION
This PR introduces a more "typed" API for all the first-party middleware - which gives a nicer DX than the "stringy" API, in my opinion.