### PR TITLE
[11.x] Allow unsetting a user's access token

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -71,7 +71,7 @@ trait HasApiTokens
     /**
      * Set the current access token for the user.
      *
-     * @param  \Laravel\Passport\Token|\Laravel\Passport\TransientToken  $accessToken
+     * @param  \Laravel\Passport\Token|\Laravel\Passport\TransientToken|null  $accessToken
      * @return $this
      */
     public function withAccessToken($accessToken)


### PR DESCRIPTION
Small PHPDoc fix to allow the following

```php
$user->withAccessToken(null);
```

https://github.com/laravel/passport/blob/6dab7d087ef933d6ca4cc0038d10571d8a886b8a/src/HasApiTokens.php#L9-L14