### PR TITLE
[11.x] Add getGrantTypesAttribute method to fix Eloquent strict mode error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -106,6 +106,16 @@ class Client extends Model
     }
 
     /**
+     * Get the grant types the client can use.
+     *
+     * @return array|null
+     */
+    public function getGrantTypesAttribute()
+    {
+        return $this->attributes['grant_types'] ?? null;
+    }
+
+    /**
      * The temporary non-hashed client secret.
      *
      * This is only available once during the request that created the client.


### PR DESCRIPTION
Since Laravel v10.40, Eloquent strict mode throws an error because "grant_types" does not exist on the Client model. This is caused by https://github.com/laravel/framework/pull/49480. By adding a getter-method for the attribute, the error disappears