### PR TITLE
Consistently retrieve client uuids value from Passport

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -65,7 +65,7 @@ class Client extends Model
         parent::boot();
 
         static::creating(function ($model) {
-            if (config('passport.client_uuids')) {
+            if (Passport::clientUuids()) {
                 $model->{$model->getKeyName()} = $model->{$model->getKeyName()} ?: (string) Str::orderedUuid();
             }
         });

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -81,7 +81,7 @@ class PassportServiceProvider extends ServiceProvider
      */
     protected function registerMigrations()
     {
-        if ($this->app->runningInConsole() && Passport::$runsMigrations && ! config('passport.client_uuids')) {
+        if ($this->app->runningInConsole() && Passport::$runsMigrations && ! Passport::clientUuids()) {
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         }
     }


### PR DESCRIPTION
I noticed while developing an internal package where I pre-configure Passport from the `boot` method of a service provider that there were some inconsistencies. 

In some places `config('passport.client_uuids')` is used while in other places `Passport::clientUuids()` is used.

Because I only used `Passport::setClientUuids(true)` this resulted in an error due to the uuid not being set in the creating event.


