### PR TITLE
[11.x] Allow developers to disable the password grant type

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -22,6 +22,13 @@ class Passport
     public static $implicitGrantEnabled = false;
 
     /**
+     * Indicates if the password grant type is enabled.
+     *
+     * @var bool|null
+     */
+    public static $passwordGrantEnabled = true;
+
+    /**
      * The default scope.
      *
      * @var string

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -169,9 +169,11 @@ class PassportServiceProvider extends ServiceProvider
                     $this->makeRefreshTokenGrant(), Passport::tokensExpireIn()
                 );
 
-                $server->enableGrantType(
-                    $this->makePasswordGrant(), Passport::tokensExpireIn()
-                );
+                if (Passport::$passwordGrantEnabled) {
+                    $server->enableGrantType(
+                        $this->makePasswordGrant(), Passport::tokensExpireIn()
+                    );
+                }
 
                 $server->enableGrantType(
                     new PersonalAccessGrant, Passport::personalAccessTokensExpireIn()


### PR DESCRIPTION
The password grant type (a.k.a. Resource Owner Credentials grant type) is no longer recommended for use, due to user credentials having to be handled by a client directly. It, alongside the implicit grant type, has been omitted from the [OAuth 2.1 RFC](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-10) (which is still in draft).

This PR allows developers to easily disable this grant type within Laravel Passport. Its still enabled by default for backward compatibility purposes, but should probably default to disabled in the next major version of Passport