### PR TITLE
Add `path` option to publishable config file

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -59,4 +59,15 @@ return [
         'secret' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Route prefix
+    |--------------------------------------------------------------------------
+    |
+    | All routes start with this. Default is `oauth`.
+    |
+    */
+
+    'path' => 'oauth',
+
 ];


### PR DESCRIPTION
All `config('passport.*')` values should be represented in the template config file. `path` was the only one missing.

In context, I have spent a good deal of time today trying to determine how to modify Passport's route prefix, and most web articles are before July 2021 when the PR to [refactor routes to dedicated file](https://github.com/laravel/passport/pull/1464) was accepted. It's not clear to me when the static `routes()` function was removed, but most online instructions reference using that in the `boot()` function of `AuthServiceProvider.php` to modify the route prefix (e.g. https://pownall.dev/post/prefix-laravel-passport-routes).

I am also planning to open a PR to update the [official Laravel Passport docs](https://laravel.com/docs/10.x/passport#overriding-routes), to clarify this there as well. But having this represented in the publishable config file is, imo, a necessary regardless so all calls to `config('passport.*')` in Passport's code are visible in the template file.