### PR TITLE
[12.x] Make `Client::$plainSecret` public

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -51,9 +51,11 @@ class Client extends Model
     /**
      * The temporary plain-text client secret.
      *
+     * This is only available during the request that created the client.
+     *
      * @var string|null
      */
-    protected $plainSecret;
+    public $plainSecret;
 
     /**
      * Bootstrap the model and its traits.
@@ -134,18 +136,6 @@ class Client extends Model
     public function setScopesAttribute(?array $scopes)
     {
         $this->attributes['scopes'] = $scopes;
-    }
-
-    /**
-     * The temporary non-hashed client secret.
-     *
-     * This is only available once during the request that created the client.
-     *
-     * @return string|null
-     */
-    public function getPlainSecretAttribute()
-    {
-        return $this->plainSecret;
     }
 
     /**


### PR DESCRIPTION
This PR changes the visibility of the client plain secret to public. Due to the accessor that is present on the client model this property is already public for reading, but static analysis tools like PHPStan don't recognize this.