### PR TITLE
[12.x] Use more secure key permissions

### DIFF
--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -55,6 +55,11 @@ class KeysCommand extends Command
                 file_put_contents($privateKey, (string) $key);
             }
 
+            if (! windows_os()) {
+                chmod($publicKey, 0660);
+                chmod($privateKey, 0600);
+            }
+
             $this->info('Encryption keys generated successfully.');
         }
 

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -15,11 +15,11 @@ use Psr\Http\Message\ServerRequestInterface;
 class Passport
 {
     /**
-     * Indicates if Passport should verify the permissions of its encryption keys.
+     * Indicates if Passport should validate the permissions of its encryption keys.
      *
      * @var bool
      */
-    public static $checkKeyPermissions = true;
+    public static $validateKeyPermissions = true;
 
     /**
      * Indicates if the implicit grant type is enabled.

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -15,6 +15,13 @@ use Psr\Http\Message\ServerRequestInterface;
 class Passport
 {
     /**
+     * Indicates if Passport should verify the permissions of its encryption keys.
+     *
+     * @var bool
+     */
+    public static $checkKeyPermissions = true;
+
+    /**
      * Indicates if the implicit grant type is enabled.
      *
      * @var bool|null

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -322,7 +322,7 @@ class PassportServiceProvider extends ServiceProvider
             $key = 'file://'.Passport::keyPath('oauth-'.$type.'.key');
         }
 
-        return new CryptKey($key, null, Passport::$checkKeyPermissions && ! windows_os());
+        return new CryptKey($key, null, Passport::$validateKeyPermissions && ! windows_os());
     }
 
     /**

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -309,7 +309,7 @@ class PassportServiceProvider extends ServiceProvider
     }
 
     /**
-     * Create a CryptKey instance without permissions check.
+     * Create a CryptKey instance.
      *
      * @param  string  $type
      * @return \League\OAuth2\Server\CryptKey
@@ -322,7 +322,7 @@ class PassportServiceProvider extends ServiceProvider
             $key = 'file://'.Passport::keyPath('oauth-'.$type.'.key');
         }
 
-        return new CryptKey($key, null, false);
+        return new CryptKey($key, null, Passport::$checkKeyPermissions && ! windows_os());
     }
 
     /**

--- a/tests/Unit/PassportServiceProviderTest.php
+++ b/tests/Unit/PassportServiceProviderTest.php
@@ -11,6 +11,13 @@ use PHPUnit\Framework\TestCase;
 
 class PassportServiceProviderTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        @unlink(__DIR__.'/../keys/oauth-private.key');
+    }
+
     public function test_can_use_crypto_keys_from_config()
     {
         $privateKey = openssl_pkey_new();
@@ -46,6 +53,7 @@ class PassportServiceProviderTest extends TestCase
 
         openssl_pkey_export_to_file($privateKey, __DIR__.'/../keys/oauth-private.key');
         openssl_pkey_export($privateKey, $privateKeyString);
+        chmod(__DIR__.'/../keys/oauth-private.key', 0600);
 
         $config = m::mock(Config::class, function ($config) {
             $config->shouldReceive('get')->with('passport.private_key')->andReturn(null);
@@ -64,7 +72,5 @@ class PassportServiceProviderTest extends TestCase
             $privateKeyString,
             file_get_contents($cryptKey->getKeyPath())
         );
-
-        @unlink(__DIR__.'/../keys/oauth-private.key');
     }
 }


### PR DESCRIPTION
Passport currently does not check filesystem permissions of the keys it uses, per https://github.com/laravel/passport/pull/454. Passport also doesn't set the correct permissions on the keys it creates.

This PR aims to have Passport use more secure permissions by default, whilst still allowing developers to opt out.

Passport will now:
- Automatically use stricter permissions when creating keys through the `passport:keys` command
- Check key permissions before using them
  - This may be toggled off by setting `Passport::$checkKeyPermissions` to `false`
  - This check is disabled on Windows, because it does not support this
