### PR TITLE
Check that properties `grant_types` and  `scopes` exist

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -179,7 +179,7 @@ class Client extends Model
      */
     public function hasScope($scope)
     {
-        if (! isset($this->scopes) || ! is_array($this->scopes)) {
+        if (! isset($this->attributes['scopes']) || ! is_array($this->scopes)) {
             return true;
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -164,7 +164,7 @@ class Client extends Model
      */
     public function hasGrantType($grantType)
     {
-        if (! isset($this->grant_types) || ! is_array($this->grant_types)) {
+        if (! isset($this->attributes['grant_types']) || ! is_array($this->grant_types)) {
             return true;
         }
 


### PR DESCRIPTION
Calling `isset` on a property that doesn't exist triggers strict mode violations.  We should check that the attribute isset exists instead.  
