### PR TITLE
[12.x] Cast session lifetime to int

### DIFF
--- a/src/ApiTokenCookieFactory.php
+++ b/src/ApiTokenCookieFactory.php
@@ -48,7 +48,7 @@ class ApiTokenCookieFactory
     {
         $config = $this->config->get('session');
 
-        $expiration = Carbon::now()->addMinutes($config['lifetime']);
+        $expiration = Carbon::now()->addMinutes((int) $config['lifetime']);
 
         return new Cookie(
             Passport::cookie(),


### PR DESCRIPTION
Laravel 11 with Passport has error cause Carbon needs int|float but the config passes as string.

this is the error https://flareapp.io/share/NPLWwVQm#context-request-browser

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
