### PR TITLE
Adjust newFactory method visibility

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -233,7 +233,7 @@ class Client extends Model
      *
      * @return \Illuminate\Database\Eloquent\Factories\Factory
      */
-    public static function newFactory()
+    protected static function newFactory()
     {
         return ClientFactory::new();
     }


### PR DESCRIPTION
PHP: 8.3.4
Laravel Framework: 11.2.0
Laravel Passport: 12.0.2

At command line, attempting to create a client_credentials client from instructions in the documentation results in a PHP Fatal error.

```
 ~/Documents/GitHub/project/ [main*] sail artisan passport:client --client

 What should we name the client? [Project ClientCredentials Grant Client]:
 > API

PHP Fatal error:  Access level to Illuminate\Database\Eloquent\Factories\HasFactory::newFactory() must be public (as in class Laravel\Passport\Client) in /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Factories/HasFactory.php on line 28

   Symfony\Component\ErrorHandler\Error\FatalError 

  Access level to Illuminate\Database\Eloquent\Factories\HasFactory::newFactory() must be public (as in class Laravel\Passport\Client)

  at vendor/laravel/framework/src/Illuminate/Database/Eloquent/Factories/HasFactory.php:28
     24▕      * Create a new factory instance for the model.
     25▕      *
     26▕      * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
     27▕      */
  ➜  28▕     protected static function newFactory()
     29▕     {
     30▕         //
     31▕     }
     32▕ }


   Whoops\Exception\ErrorException 

  Access level to Illuminate\Database\Eloquent\Factories\HasFactory::newFactory() must be public (as in class Laravel\Passport\Client)

  at vendor/laravel/framework/src/Illuminate/Database/Eloquent/Factories/HasFactory.php:28
     24▕      * Create a new factory instance for the model.
     25▕      *
     26▕      * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
     27▕      */
  ➜  28▕     protected static function newFactory()
     29▕     {
     30▕         //
     31▕     }
     32▕ }

      +1 vendor frames 

  2   [internal]:0
      Whoops\Run::handleShutdown()

```

The newFactory() method defined in the trait has a protected visibility, while the method has a public visibility in this class implementing the trait, resulting in a visibility compatibility error. The `as` operator could be used to adjust the method visibility, but this seemed like the better, clearer and more straightforward approach.

