### PR TITLE
Don't ignore `force` option in InstallCommand

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -31,7 +31,7 @@ class InstallCommand extends Command
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
         $this->call('passport:keys', ['--force' => $this->option('force'), '--length' => $this->option('length')]);
 
@@ -41,10 +41,10 @@ class InstallCommand extends Command
             $this->configureUuids();
         }
 
-        if ($this->confirm('Would you like to run all pending database migrations?', true)) {
+        if ($this->option('force') || $this->confirm('Would you like to run all pending database migrations?', true)) {
             $this->call('migrate');
 
-            if ($this->confirm('Would you like to create the "personal access" and "password grant" clients?', true)) {
+            if ($this->option('force') || $this->confirm('Would you like to create the "personal access" and "password grant" clients?', true)) {
                 $provider = in_array('users', array_keys(config('auth.providers'))) ? 'users' : null;
 
                 $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client']);


### PR DESCRIPTION
The new Interactions from #1724 break some console interactions by scripts - this change should fix this while reusing the `--force` option.

It may be discussed whether to include `--no-interaction` here too, as this is mentioned in the `--help` section of this command.

```
Usage:
  passport:install [options]

Options:
      ...
      --force            Overwrite keys they already exist
      ...
      -n, --no-interaction   Do not ask any interactive question
      ...
```