### PR TITLE
[12.x] Make Passport's database connection configurable

### DIFF
--- a/config/passport.php
+++ b/config/passport.php
@@ -32,6 +32,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Passport Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | By default, Passport's models will use your application's default
+    | database connection. If you wish to use a different connection
+    | you may specify it here.
+    |
+    */
+
+    'connection' => env('PASSPORT_CONNECTION'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Client UUIDs
     |--------------------------------------------------------------------------
     |

--- a/config/passport.php
+++ b/config/passport.php
@@ -35,9 +35,9 @@ return [
     | Passport Database Connection
     |--------------------------------------------------------------------------
     |
-    | By default, Passport's models will use your application's default
-    | database connection. If you wish to use a different connection
-    | you may specify it here.
+    | By default, Passport's models will utilize your application's default
+    | database connection. If you wish to use a different connection you
+    | may specify the configured name of the database connection here.
     |
     */
 

--- a/src/AuthCode.php
+++ b/src/AuthCode.php
@@ -60,4 +60,14 @@ class AuthCode extends Model
     {
         return $this->belongsTo(Passport::clientModel());
     }
+
+    /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return $this->connection ?? config('passport.connection');
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -229,6 +229,16 @@ class Client extends Model
     }
 
     /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+
+    /**
      * Create a new factory instance for the model.
      *
      * @return \Illuminate\Database\Eloquent\Factories\Factory

--- a/src/PersonalAccessClient.php
+++ b/src/PersonalAccessClient.php
@@ -29,4 +29,14 @@ class PersonalAccessClient extends Model
     {
         return $this->belongsTo(Passport::clientModel());
     }
+
+    /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return $this->connection ?? config('passport.connection');
+    }
 }

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -80,4 +80,14 @@ class RefreshToken extends Model
     {
         return false;
     }
+
+    /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return $this->connection ?? config('passport.connection');
+    }
 }

--- a/src/Token.php
+++ b/src/Token.php
@@ -126,4 +126,14 @@ class Token extends Model
     {
         return false;
     }
+
+    /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return $this->connection ?? config('passport.connection');
+    }
 }


### PR DESCRIPTION
This PR allows developers to configure Passport's database connection without having to extend all of Passport's models.

This change should be fully backwards compatible because:
- Omitting this configuration will have Laravel use the default connection of the application (which is the current behavior)
- If someone has extended one of (or multiple of) Passport's models and has overwritten the `$connection` property, that will take precedence over the config
- If someone has extended one of (or multiple of) Passport's models and has overwritten the `getConnectionName()` method this new logic won't be executed at all