### PR TITLE
[12.x] Add `refreshToken` relation to `Token` model

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -58,7 +58,7 @@ class Token extends Model
     }
 
     /**
-     * Get the refresh token that the token belongs to.
+     * Get the refresh token associated with the token.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */

--- a/src/Token.php
+++ b/src/Token.php
@@ -58,6 +58,16 @@ class Token extends Model
     }
 
     /**
+     * Get the refresh token that the token belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function refreshToken()
+    {
+        return $this->hasOne(Passport::refreshTokenModel(), 'access_token_id');
+    }
+
+    /**
      * Get the user that the token belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo


### PR DESCRIPTION
In my project, when I user logs out, I need to revoke the access token and the refresh token linked to that access token. Currently I have to this in the following way:
```php
auth()->user()->token()->revoke();
RefreshToken::where('access_token_id', auth()->user()->token()->id)->first()->revoke();
```
This PR makes that a bit easier by adding a 'refreshToken' relation to the access token model:
```php
auth()->user()->token()->revoke();
auth()->user()->token()->refreshToken->revoke();
```