### PR TITLE
[12.x] Create access and refresh token in `Passport::actingAs()`

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use DateInterval;
 use DateTimeInterface;
 use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Support\Str;
 use Laravel\Passport\Contracts\AuthorizationViewResponse as AuthorizationViewResponseContract;
 use Laravel\Passport\Http\Responses\AuthorizationViewResponse;
 use League\OAuth2\Server\ResourceServer;
@@ -382,7 +383,22 @@ class Passport
      */
     public static function actingAs($user, $scopes = [], $guard = 'api')
     {
-        $token = app(self::tokenModel());
+        $token = app(self::tokenModel())::create([
+            'id' => Str::random(),
+            'user_id' => $user->id,
+            'client_id' => Client::factory()->create()->id,
+            'scopes' => $scopes,
+            'revoked' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'expires_at' => now()->addYear(),
+        ]);
+        app(self::refreshTokenModel())::create([
+            'id' => Str::random(),
+            'access_token_id' => $token->id,
+            'revoked' => false,
+            'expires_at' => now()->addYear(),
+        ]);
 
         $token->scopes = $scopes;
 

--- a/tests/Feature/ActingAsTest.php
+++ b/tests/Feature/ActingAsTest.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Route;
 use Laravel\Passport\Http\Middleware\CheckForAnyScope;
 use Laravel\Passport\Http\Middleware\CheckScopes;
 use Laravel\Passport\Passport;
+use Laravel\Passport\RefreshToken;
+use Laravel\Passport\Token;
 use Workbench\App\Models\User;
 
 class ActingAsTest extends PassportTestCase
@@ -112,5 +114,17 @@ class ActingAsTest extends PassportTestCase
         $response = $this->get('/foo');
         $response->assertSuccessful();
         $response->assertSee('bar');
+    }
+
+    public function testActingAsCreatesAccessTokenAndRefreshToken()
+    {
+        Passport::actingAs(new User(), ['foo']);
+
+        $this->assertInstanceOf(User::class, auth()->user());
+        $this->assertInstanceOf(Token::class, auth()->user()->token());
+        $this->assertTrue(auth()->user()->token()->exists);
+        $this->assertSame(['foo'], auth()->user()->token()->scopes);
+        $this->assertInstanceOf(RefreshToken::class, $refreshToken = RefreshToken::firstWhere('access_token_id', auth()->user()->token()->id));
+        $this->assertTrue($refreshToken->exists);
     }
 }


### PR DESCRIPTION
If you use `Passport::actingAs()` in a test while in the tested API route needs to revoke the authenticated user's current access token, then that causes an error in the test. That is because Eloquent can not revoke a token that does not exist in database.
```php
Passport::actingAs($user);

auth()->user()->token()->revoke(); // This currently causes an error
```
This PR fixes that by creating and saving an access and refresh token in the database.

I also create a refresh token because of #1739 so the following works as well:

```php
Passport::actingAs($user);

auth()->user()->token()->refreshToken->revoke();
```
