### PR TITLE
Update InstallCommand.php

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -35,8 +35,6 @@ class InstallCommand extends Command
     {
         $this->call('passport:keys', ['--force' => $this->option('force'), '--length' => $this->option('length')]);
 
-        $this->call('vendor:publish', ['--tag' => 'passport-migrations']);
-
         if ($this->option('uuids')) {
             $this->configureUuids();
         }


### PR DESCRIPTION
The documentations says that passport no longer publishes migrations (it did not publish in version 11.x) here https://github.com/laravel/passport/blob/12.x/UPGRADE.md#migration-changes

However the code in InstallCommand.php clearly has publish migrations, so or documentation is wrong, or code should be removed, i prefer the latter though, as always publishing migrations into a default directory is not good practice.

Please and thank you 
