### PR TITLE
[12.x] Support rehash on login

### DIFF
--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -29,7 +29,6 @@ class UserRepository implements UserRepositoryInterface
      *
      * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
      * @param  bool  $rehashOnLogin
-     *
      * @return void
      */
     public function __construct(Hasher $hasher, bool $rehashOnLogin = true)

--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -27,8 +27,8 @@ class UserRepository implements UserRepositoryInterface
     /**
      * Create a new repository instance.
      *
-     * @param \Illuminate\Contracts\Hashing\Hasher $hasher
-     * @param bool $rehashOnLogin
+     * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
+     * @param  bool  $rehashOnLogin
      *
      * @return void
      */
@@ -75,7 +75,7 @@ class UserRepository implements UserRepositoryInterface
             return;
         }
 
-        if ($this->rehashOnLogin) {
+        if ($this->rehashOnLogin && method_exists(Auth::createUserProvider($provider), 'rehashPasswordIfRequired')) {
             Auth::createUserProvider($provider)->rehashPasswordIfRequired($user, ['password' => $password]);
         }
 

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -231,7 +231,9 @@ class PassportServiceProvider extends ServiceProvider
     protected function makePasswordGrant()
     {
         $grant = new PasswordGrant(
-            $this->app->make(Bridge\UserRepository::class),
+            $this->app->make(Bridge\UserRepository::class, [
+                'rehashOnLogin' => $this->app['config']->get('hashing.rehash_on_login', true),
+            ]),
             $this->app->make(Bridge\RefreshTokenRepository::class)
         );
 

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Passport\Tests\Feature;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Foundation\Application;
 use Laravel\Passport\Client;
 use Laravel\Passport\Database\Factories\ClientFactory;
 use Laravel\Passport\Passport;
@@ -277,6 +278,10 @@ class AccessTokenControllerTest extends PassportTestCase
 
     public function testRehashPasswordOnLoginWithPasswordGrant()
     {
+        if (version_compare(Application::VERSION, '11.0.0', '<')) {
+            $this->markTestSkipped('Only on Laravel 11 and later');
+        }
+
         $this->withoutExceptionHandling();
 
         $this->app['config']->set('hashing.rehash_on_login', true);
@@ -310,6 +315,10 @@ class AccessTokenControllerTest extends PassportTestCase
 
     public function testNoRehashPasswordOnLoginWithPasswordGrant()
     {
+        if (version_compare(Application::VERSION, '11.0.0', '<')) {
+            $this->markTestSkipped('Only on Laravel 11 and later');
+        }
+
         $this->withoutExceptionHandling();
 
         $this->app['config']->set('hashing.rehash_on_login', false);

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -10,7 +10,6 @@ use Laravel\Passport\Passport;
 use Laravel\Passport\PersonalAccessTokenFactory;
 use Laravel\Passport\Token;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
-use Workbench\App\Models\User;
 use Workbench\Database\Factories\UserFactory;
 
 class AccessTokenControllerTest extends PassportTestCase


### PR DESCRIPTION
In Laravel 11, "automatic rehashing of user passwords when validating credentials" was added as a feature (https://github.com/laravel/framework/pull/48665). This PR ensures that this feature also works when a user provides its credentials to passport (this is the case when using the password oauth grant type)