### PR TITLE
[12.x] Provide a default client name to avoid QueryException

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -139,7 +139,8 @@ class ClientCommand extends Command
         );
 
         $name = $this->option('name') ?: $this->ask(
-            'What should we name the client?'
+            'What should we name the client?',
+            config('app.name').' Auth Code Client'
         );
 
         $redirect = $this->option('redirect_uri') ?: $this->ask(


### PR DESCRIPTION
Creating a new client without specifying a name throws the following exception:

```php
   Illuminate\Database\QueryException

  SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'name' cannot be null

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:829
    825▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    826▕                 );
    827▕             }
    828▕
  ➜ 829▕             throw new QueryException(
    830▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    831▕             );
    832▕         }
    833▕     }

      +27 vendor frames
```