### PR TITLE
[13.x] Fix issue with ClientRepository::handlesGrant method

### DIFF
--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -72,7 +72,7 @@ class ClientRepository implements ClientRepositoryInterface
      */
     protected function handlesGrant($record, $grantType)
     {
-        if (! $record->hasGrantType($grantType)) {
+        if (is_array($record->grant_types) && ! in_array($grantType, $record->grant_types)) {
             return false;
         }
 


### PR DESCRIPTION
This pull request resolves an issue where calling createToken('admin_token')->accessToken resulted in a **"Call to undefined method" error due to the hasGrantType() method being incorrectly referenced in the ClientRepository**. The proposed fix updates the handlesGrant method in the ClientRepository to address this error by replacing the erroneous method call with the correct logic to handle grant types.

### **Changes:**
- Updated the handlesGrant method in the ClientRepository to resolve the "Call to undefined method" error.
- Replaced the incorrect hasGrantType() method call with logic to check grant types using is_array() and in_array().

**Replaced** 

> if (! $record->hasGrantType($grantType)) {
>             return false;
>         }

**with**
> if (is_array($record->grant_types) && ! in_array($grantType, $record->grant_types)) {
>             return false;
>         }

### **Testing:**
- Tested and verified that calling createToken('admin_token')->accessToken produces the expected result without errors.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
