### PR TITLE
[13.x] Use the `oauth_scopes` property of the bearer token on `TokenGuard`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,6 +26,12 @@ Passport now always hashes client secrets using Laravel's `Hash` facade. If you 
 
 In light of this change, the `Passport::$hashesClientSecrets` property and `Passport::hashClientSecrets()` method has been removed.
 
+### The User's Token Instance
+
+PR: https://github.com/laravel/passport/pull/1755
+
+When authenticating users via bearer tokens, the `User` model's `token` method now returns an instance of `Laravel\Passport\AccessToken` class instead of `Laravel\Passport\Token`.
+
 ### Personal Access Client Table and Model Removal
 
 PR: https://github.com/laravel/passport/pull/1749
@@ -35,12 +41,6 @@ Passport's `oauth_personal_access_clients` table has been redundant and unnecess
     Schema::drop('oauth_personal_access_clients');
 
 In addition, the `Laravel\Passport\PersonalAccessClient` model, `Passport::$personalAccessClientModel` property, `Passport::usePersonalAccessClientModel()`, `Passport::personalAccessClientModel()`, and `Passport::personalAccessClient()` methods have been removed.
-
-### The User's Token Instance
-
-PR: https://github.com/laravel/passport/pull/1755
-
-When authenticating user via bearer token, the `App\Models\User` model's `token` method now returns an instance of `Laravel\Passport\AccessToken` class instead of `Laravel\Passport\Token`.
 
 ## Upgrading To 12.0 From 11.x
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,6 +36,12 @@ Passport's `oauth_personal_access_clients` table has been redundant and unnecess
 
 In addition, the `Laravel\Passport\PersonalAccessClient` model, `Passport::$personalAccessClientModel` property, `Passport::usePersonalAccessClientModel()`, `Passport::personalAccessClientModel()`, and `Passport::personalAccessClient()` methods have been removed.
 
+### The User's Token Instance
+
+PR: https://github.com/laravel/passport/pull/1755
+
+When authenticating user via bearer token, the `App\Models\User` model's `token` method now returns an instance of `Laravel\Passport\AccessToken` class instead of `Laravel\Passport\Token`.
+
 ## Upgrading To 12.0 From 11.x
 
 ### Migration Changes

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Laravel\Passport;
+
+use Illuminate\Support\Traits\ForwardsCalls;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @property  string  oauth_access_token_id
+ * @property  string  oauth_client_id
+ * @property  string  oauth_user_id
+ * @property  string[]  oauth_scopes
+ */
+class AccessToken
+{
+    use ResolvesInheritedScopes, ForwardsCalls;
+
+    /**
+     * All the attributes set on the access token instance.
+     *
+     * @var array<string, mixed>
+     */
+    protected array $attributes = [];
+
+    /**
+     * The token instance.
+     */
+    protected ?Token $token;
+
+    /**
+     * Create a new access token instance.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        foreach ($attributes as $key => $value) {
+            $this->attributes[$key] = $value;
+        }
+    }
+
+    /**
+     * Create a new access token instance from the incoming PSR-7 request.
+     */
+    public static function fromPsrRequest(ServerRequestInterface $request): static
+    {
+        return new static($request->getAttributes());
+    }
+
+    /**
+     * Determine if the token has a given scope.
+     */
+    public function can(string $scope): bool
+    {
+        if (in_array('*', $this->oauth_scopes)) {
+            return true;
+        }
+
+        $scopes = Passport::$withInheritedScopes
+            ? $this->resolveInheritedScopes($scope)
+            : [$scope];
+
+        foreach ($scopes as $scope) {
+            if (array_key_exists($scope, array_flip($this->oauth_scopes))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the token is missing a given scope.
+     */
+    public function cant(string $scope): bool
+    {
+        return ! $this->can($scope);
+    }
+
+    /**
+     * Determine if the token is a transient JWT token.
+     */
+    public function transient(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Revoke the token instance.
+     */
+    public function revoke(): bool
+    {
+        return Passport::token()->whereKey($this->oauth_access_token_id)->forceFill(['revoked' => true])->save();
+    }
+
+    /**
+     * Get the token instance.
+     */
+    protected function getToken(): ?Token
+    {
+        return $this->token ??= Passport::token()->find($this->oauth_access_token_id);
+    }
+
+    /**
+     * Pass dynamic methods onto the token instance.
+     */
+    public function __call(string $method, array $parameters): mixed
+    {
+        return $this->forwardCallTo($this->getToken(), $method, $parameters);
+    }
+
+    /**
+     * Dynamically retrieve the value of an attribute.
+     */
+    public function __get(string $key)
+    {
+        if (array_key_exists($key, $this->attributes)) {
+            return $this->attributes[$key];
+        }
+
+        return $this->getToken()?->{$key};
+    }
+
+    /**
+     * Dynamically check if an attribute is set.
+     */
+    public function __isset(string $key): bool
+    {
+        return isset($this->attributes[$key]) || isset($this->getToken()?->{$key});
+    }
+}

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -16,16 +16,16 @@ class AccessToken
     use ResolvesInheritedScopes, ForwardsCalls;
 
     /**
+     * The token instance.
+     */
+    protected ?Token $token;
+
+    /**
      * All the attributes set on the access token instance.
      *
      * @var array<string, mixed>
      */
     protected array $attributes = [];
-
-    /**
-     * The token instance.
-     */
-    protected ?Token $token;
 
     /**
      * Create a new access token instance.
@@ -102,11 +102,11 @@ class AccessToken
     }
 
     /**
-     * Pass dynamic methods onto the token instance.
+     * Dynamically determine if an attribute is set.
      */
-    public function __call(string $method, array $parameters): mixed
+    public function __isset(string $key): bool
     {
-        return $this->forwardCallTo($this->getToken(), $method, $parameters);
+        return isset($this->attributes[$key]) || isset($this->getToken()?->{$key});
     }
 
     /**
@@ -122,10 +122,10 @@ class AccessToken
     }
 
     /**
-     * Dynamically check if an attribute is set.
+     * Pass dynamic methods onto the token instance.
      */
-    public function __isset(string $key): bool
+    public function __call(string $method, array $parameters): mixed
     {
-        return isset($this->attributes[$key]) || isset($this->getToken()?->{$key});
+        return $this->forwardCallTo($this->getToken(), $method, $parameters);
     }
 }

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -14,6 +14,7 @@ use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Http\Request;
 use Illuminate\Support\Traits\Macroable;
+use Laravel\Passport\AccessToken;
 use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
@@ -203,9 +204,7 @@ class TokenGuard implements Guard
         // Next, we will assign a token instance to this user which the developers may use
         // to determine if the token has a given scope, etc. This will be useful during
         // authorization such as within the developer's Laravel model policy classes.
-        $token = $this->tokens->find(
-            $psr->getAttribute('oauth_access_token_id')
-        );
+        $token = AccessToken::fromPsrRequest($psr);
 
         return $token ? $user->withAccessToken($token) : null;
     }

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -9,7 +9,7 @@ trait HasApiTokens
     /**
      * The current access token for the authentication user.
      *
-     * @var \Laravel\Passport\Token|\Laravel\Passport\TransientToken|null
+     * @var \Laravel\Passport\AccessToken|\Laravel\Passport\TransientToken|null
      */
     protected $accessToken;
 
@@ -36,7 +36,7 @@ trait HasApiTokens
     /**
      * Get the current access token being used by the user.
      *
-     * @return \Laravel\Passport\Token|\Laravel\Passport\TransientToken|null
+     * @return \Laravel\Passport\AccessToken|\Laravel\Passport\TransientToken|null
      */
     public function token()
     {
@@ -71,7 +71,7 @@ trait HasApiTokens
     /**
      * Set the current access token for the user.
      *
-     * @param  \Laravel\Passport\Token|\Laravel\Passport\TransientToken|null  $accessToken
+     * @param  \Laravel\Passport\AccessToken|\Laravel\Passport\TransientToken|null  $accessToken
      * @return $this
      */
     public function withAccessToken($accessToken)

--- a/src/Http/Middleware/CheckClientCredentials.php
+++ b/src/Http/Middleware/CheckClientCredentials.php
@@ -10,7 +10,7 @@ class CheckClientCredentials extends CheckCredentials
     /**
      * Validate token credentials.
      *
-     * @param  \Laravel\Passport\Token  $token
+     * @param  \Laravel\Passport\AccessToken  $token
      * @return void
      *
      * @throws \Laravel\Passport\Exceptions\AuthenticationException
@@ -25,7 +25,7 @@ class CheckClientCredentials extends CheckCredentials
     /**
      * Validate token credentials.
      *
-     * @param  \Laravel\Passport\Token  $token
+     * @param  \Laravel\Passport\AccessToken  $token
      * @param  array  $scopes
      * @return void
      *
@@ -33,7 +33,7 @@ class CheckClientCredentials extends CheckCredentials
      */
     protected function validateScopes($token, $scopes)
     {
-        if (in_array('*', $token->scopes)) {
+        if (in_array('*', $token->oauth_scopes)) {
             return;
         }
 

--- a/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
+++ b/src/Http/Middleware/CheckClientCredentialsForAnyScope.php
@@ -10,7 +10,7 @@ class CheckClientCredentialsForAnyScope extends CheckCredentials
     /**
      * Validate token credentials.
      *
-     * @param  \Laravel\Passport\Token  $token
+     * @param  \Laravel\Passport\AccessToken  $token
      * @return void
      *
      * @throws \Laravel\Passport\Exceptions\AuthenticationException
@@ -25,7 +25,7 @@ class CheckClientCredentialsForAnyScope extends CheckCredentials
     /**
      * Validate token credentials.
      *
-     * @param  \Laravel\Passport\Token  $token
+     * @param  \Laravel\Passport\AccessToken  $token
      * @param  array  $scopes
      * @return void
      *
@@ -33,7 +33,7 @@ class CheckClientCredentialsForAnyScope extends CheckCredentials
      */
     protected function validateScopes($token, $scopes)
     {
-        if (in_array('*', $token->scopes)) {
+        if (in_array('*', $token->oauth_scopes)) {
             return;
         }
 

--- a/src/Http/Middleware/CheckCredentials.php
+++ b/src/Http/Middleware/CheckCredentials.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Closure;
+use Laravel\Passport\AccessToken;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
@@ -95,7 +96,7 @@ abstract class CheckCredentials
      */
     protected function validate($psr, $scopes)
     {
-        $token = $this->repository->find($psr->getAttribute('oauth_access_token_id'));
+        $token = AccessToken::fromPsrRequest($psr);
 
         $this->validateCredentials($token);
 
@@ -105,7 +106,7 @@ abstract class CheckCredentials
     /**
      * Validate token credentials.
      *
-     * @param  \Laravel\Passport\Token  $token
+     * @param  \Laravel\Passport\AccessToken  $token
      * @return void
      *
      * @throws \Laravel\Passport\Exceptions\AuthenticationException
@@ -115,7 +116,7 @@ abstract class CheckCredentials
     /**
      * Validate token scopes.
      *
-     * @param  \Laravel\Passport\Token  $token
+     * @param  \Laravel\Passport\AccessToken  $token
      * @param  array  $scopes
      * @return void
      *

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -368,9 +368,10 @@ class Passport
      */
     public static function actingAs($user, $scopes = [], $guard = 'api')
     {
-        $token = app(self::tokenModel());
-
-        $token->scopes = $scopes;
+        $token = new AccessToken([
+            'oauth_user_id' => $user->getKey(),
+            'oauth_scopes' => $scopes,
+        ]);
 
         $user->withAccessToken($token);
 
@@ -395,27 +396,14 @@ class Passport
      */
     public static function actingAsClient($client, $scopes = [], $guard = 'api')
     {
-        $token = app(self::tokenModel());
-
-        $token->client_id = $client->getKey();
-        $token->setRelation('client', $client);
-
-        $token->scopes = $scopes;
-
         $mock = Mockery::mock(ResourceServer::class);
         $mock->shouldReceive('validateAuthenticatedRequest')
-            ->andReturnUsing(function (ServerRequestInterface $request) use ($token) {
-                return $request->withAttribute('oauth_client_id', $token->client->id)
-                    ->withAttribute('oauth_access_token_id', $token->id)
-                    ->withAttribute('oauth_scopes', $token->scopes);
+            ->andReturnUsing(function (ServerRequestInterface $request) use ($client, $scopes) {
+                return $request->withAttribute('oauth_client_id', $client->getKey())
+                    ->withAttribute('oauth_scopes', $scopes);
             });
 
         app()->instance(ResourceServer::class, $mock);
-
-        $mock = Mockery::mock(TokenRepository::class);
-        $mock->shouldReceive('find')->andReturn($token);
-
-        app()->instance(TokenRepository::class, $mock);
 
         app('auth')->guard($guard)->setClient($client);
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -6,8 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class Token extends Model
 {
-    use ResolvesInheritedScopes;
-
     /**
      * The database table used by the model.
      *
@@ -82,42 +80,6 @@ class Token extends Model
     }
 
     /**
-     * Determine if the token has a given scope.
-     *
-     * @param  string  $scope
-     * @return bool
-     */
-    public function can($scope)
-    {
-        if (in_array('*', $this->scopes)) {
-            return true;
-        }
-
-        $scopes = Passport::$withInheritedScopes
-            ? $this->resolveInheritedScopes($scope)
-            : [$scope];
-
-        foreach ($scopes as $scope) {
-            if (array_key_exists($scope, array_flip($this->scopes))) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Determine if the token is missing a given scope.
-     *
-     * @param  string  $scope
-     * @return bool
-     */
-    public function cant($scope)
-    {
-        return ! $this->can($scope);
-    }
-
-    /**
      * Revoke the token instance.
      *
      * @return bool
@@ -125,16 +87,6 @@ class Token extends Model
     public function revoke()
     {
         return $this->forceFill(['revoked' => true])->save();
-    }
-
-    /**
-     * Determine if the token is a transient JWT token.
-     *
-     * @return bool
-     */
-    public function transient()
-    {
-        return false;
     }
 
     /**

--- a/src/TransientToken.php
+++ b/src/TransientToken.php
@@ -6,32 +6,24 @@ class TransientToken
 {
     /**
      * Determine if the token has a given scope.
-     *
-     * @param  string  $scope
-     * @return bool
      */
-    public function can($scope)
+    public function can(string $scope): bool
     {
         return true;
     }
 
     /**
      * Determine if the token is missing a given scope.
-     *
-     * @param  string  $scope
-     * @return bool
      */
-    public function cant($scope)
+    public function cant(string $scope): bool
     {
         return false;
     }
 
     /**
      * Determine if the token is a transient JWT token.
-     *
-     * @return bool
      */
-    public function transient()
+    public function transient(): bool
     {
         return true;
     }

--- a/tests/Unit/AccessTokenTest.php
+++ b/tests/Unit/AccessTokenTest.php
@@ -2,12 +2,12 @@
 
 namespace Laravel\Passport\Tests\Unit;
 
+use Laravel\Passport\AccessToken;
 use Laravel\Passport\Passport;
-use Laravel\Passport\Token;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 
-class TokenTest extends TestCase
+class AccessTokenTest extends TestCase
 {
     protected function tearDown(): void
     {
@@ -16,9 +16,34 @@ class TokenTest extends TestCase
         Passport::$withInheritedScopes = false;
     }
 
+    public function test_token_attributes_are_accessible()
+    {
+        $token = new AccessToken([
+            'oauth_user_id' => 1,
+            'oauth_client_id' => 2,
+            'oauth_access_token_id' => 'token',
+            'oauth_scopes' => ['*'],
+            'foo' => 'bar',
+        ]);
+
+        $this->assertFalse($token->transient());
+
+        $this->assertSame(1, $token->oauth_user_id);
+        $this->assertSame(2, $token->oauth_client_id);
+        $this->assertSame('token', $token->oauth_access_token_id);
+        $this->assertSame(['*'], $token->oauth_scopes);
+        $this->assertSame('bar', $token->foo);
+
+        $this->assertTrue(isset($token->oauth_user_id));
+        $this->assertTrue(isset($token->oauth_client_id));
+        $this->assertTrue(isset($token->oauth_access_token_id));
+        $this->assertTrue(isset($token->oauth_scopes));
+        $this->assertTrue(isset($token->foo));
+    }
+
     public function test_token_can_determine_if_it_has_scopes()
     {
-        $token = new Token(['scopes' => ['user']]);
+        $token = new AccessToken(['oauth_scopes' => ['user']]);
 
         $this->assertTrue($token->can('user'));
         $this->assertFalse($token->can('something'));
@@ -27,7 +52,7 @@ class TokenTest extends TestCase
 
         $this->assertTrue($token->cant('user:read'));
 
-        $token = new Token(['scopes' => ['*']]);
+        $token = new AccessToken(['oauth_scopes' => ['*']]);
         $this->assertTrue($token->can('user'));
         $this->assertTrue($token->can('something'));
     }
@@ -36,8 +61,8 @@ class TokenTest extends TestCase
     {
         Passport::$withInheritedScopes = true;
 
-        $token = new Token([
-            'scopes' => [
+        $token = new AccessToken([
+            'oauth_scopes' => [
                 'user',
                 'group',
                 'admin:webhooks:read',
@@ -54,7 +79,7 @@ class TokenTest extends TestCase
 
         $this->assertFalse($token->can('something'));
 
-        $token = new Token(['scopes' => ['*']]);
+        $token = new AccessToken(['oauth_scopes' => ['*']]);
         $this->assertTrue($token->can('user'));
         $this->assertTrue($token->can('something'));
         $this->assertTrue($token->can('admin:webhooks:write'));
@@ -62,7 +87,7 @@ class TokenTest extends TestCase
 
     public function test_token_resolves_inherited_scopes()
     {
-        $token = new Token;
+        $token = new AccessToken;
 
         $reflector = new ReflectionObject($token);
         $method = $reflector->getMethod('resolveInheritedScopes');

--- a/tests/Unit/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/Unit/CheckClientCredentialsForAnyScopeTest.php
@@ -3,10 +3,8 @@
 namespace Laravel\Passport\Tests\Unit;
 
 use Illuminate\Http\Request;
-use Laravel\Passport\Client;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
-use Laravel\Passport\Token;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
@@ -25,20 +23,14 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
-        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
-        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
-
-        $client = m::mock(Client::class);
-        $client->shouldReceive('firstParty')->andReturnFalse();
-
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['*']);
+        $psr->shouldReceive('getAttributes')->andReturn([
+            'oauth_user_id' => 1,
+            'oauth_client_id' => 1,
+            'oauth_access_token_id' => 'token',
+            'oauth_scopes' => ['*'],
+        ]);
 
         $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
 
         $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
 
@@ -56,22 +48,14 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
-        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
-        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'bar', 'baz']);
-
-        $client = m::mock(Client::class);
-        $client->shouldReceive('firstParty')->andReturnFalse();
-
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['foo', 'bar', 'baz']);
-        $token->shouldReceive('can')->with('notfoo')->andReturnFalse();
-        $token->shouldReceive('can')->with('bar')->andReturnTrue();
+        $psr->shouldReceive('getAttributes')->andReturn([
+            'oauth_user_id' => 1,
+            'oauth_client_id' => 1,
+            'oauth_access_token_id' => 'token',
+            'oauth_scopes' => ['foo', 'bar', 'baz'],
+        ]);
 
         $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
 
         $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
 
@@ -111,22 +95,14 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
 
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
-        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
-        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'bar']);
-
-        $client = m::mock(Client::class);
-        $client->shouldReceive('firstParty')->andReturnFalse();
-
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['foo', 'bar']);
-        $token->shouldReceive('can')->with('baz')->andReturnFalse();
-        $token->shouldReceive('can')->with('notbar')->andReturnFalse();
+        $psr->shouldReceive('getAttributes')->andReturn([
+            'oauth_user_id' => 1,
+            'oauth_client_id' => 1,
+            'oauth_access_token_id' => 'token',
+            'oauth_scopes' => ['foo', 'bar'],
+        ]);
 
         $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
 
         $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
 

--- a/tests/Unit/CheckClientCredentialsTest.php
+++ b/tests/Unit/CheckClientCredentialsTest.php
@@ -3,10 +3,8 @@
 namespace Laravel\Passport\Tests\Unit;
 
 use Illuminate\Http\Request;
-use Laravel\Passport\Client;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
-use Laravel\Passport\Token;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
@@ -25,20 +23,14 @@ class CheckClientCredentialsTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
-        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
-        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['*']);
-
-        $client = m::mock(Client::class);
-        $client->shouldReceive('firstParty')->andReturnFalse();
-
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['*']);
+        $psr->shouldReceive('getAttributes')->andReturn([
+            'oauth_user_id' => 1,
+            'oauth_client_id' => 1,
+            'oauth_access_token_id' => 'token',
+            'oauth_scopes' => ['*'],
+        ]);
 
         $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
 
         $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
@@ -56,21 +48,14 @@ class CheckClientCredentialsTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
-        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
-        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['see-profile']);
-
-        $client = m::mock(Client::class);
-        $client->shouldReceive('firstParty')->andReturnFalse();
-
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['see-profile']);
-        $token->shouldReceive('cant')->with('see-profile')->andReturnFalse();
+        $psr->shouldReceive('getAttributes')->andReturn([
+            'oauth_user_id' => 1,
+            'oauth_client_id' => 1,
+            'oauth_access_token_id' => 'token',
+            'oauth_scopes' => ['see-profile'],
+        ]);
 
         $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
 
         $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 
@@ -110,22 +95,14 @@ class CheckClientCredentialsTest extends TestCase
 
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
-        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
-        $psr->shouldReceive('getAttribute')->with('oauth_scopes')->andReturn(['foo', 'notbar']);
-
-        $client = m::mock(Client::class);
-        $client->shouldReceive('firstParty')->andReturnFalse();
-
-        $token = m::mock(Token::class);
-        $token->shouldReceive('getAttribute')->with('client')->andReturn($client);
-        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['foo', 'notbar']);
-        $token->shouldReceive('cant')->with('foo')->andReturnFalse();
-        $token->shouldReceive('cant')->with('bar')->andReturnTrue();
+        $psr->shouldReceive('getAttributes')->andReturn([
+            'oauth_user_id' => 1,
+            'oauth_client_id' => 1,
+            'oauth_access_token_id' => 'token',
+            'oauth_scopes' => ['foo', 'notbar'],
+        ]);
 
         $tokenRepository = m::mock(TokenRepository::class);
-        $tokenRepository->shouldReceive('find')->with('token')->andReturn($token);
 
         $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
 

--- a/tests/Unit/TokenGuardTest.php
+++ b/tests/Unit/TokenGuardTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Http\Request;
+use Laravel\Passport\AccessToken;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Guards\TokenGuard;
 use Laravel\Passport\HasApiTokens;
@@ -47,16 +48,21 @@ class TokenGuardTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
+        $psr->shouldReceive('getAttributes')->andReturn([
+            'oauth_user_id' => 1,
+            'oauth_client_id' => 1,
+            'oauth_access_token_id' => 'token',
+            'oauth_scopes' => [],
+        ]);
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
-        $tokens->shouldReceive('find')->once()->with('token')->andReturn($token = m::mock());
         $clients->shouldReceive('revoked')->with(1)->andReturn(false);
         $clients->shouldReceive('findActive')->with(1)->andReturn(new TokenGuardTestClient);
 
         $user = $guard->user();
 
         $this->assertInstanceOf(TokenGuardTestUser::class, $user);
-        $this->assertEquals($token, $user->token());
+        $this->assertEquals(AccessToken::fromPsrRequest($psr), $user->token());
     }
 
     public function test_user_is_resolved_only_once()
@@ -76,9 +82,14 @@ class TokenGuardTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
+        $psr->shouldReceive('getAttributes')->andReturn([
+            'oauth_user_id' => 1,
+            'oauth_client_id' => 1,
+            'oauth_access_token_id' => 'token',
+            'oauth_scopes' => [],
+        ]);
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
-        $tokens->shouldReceive('find')->once()->with('token')->andReturn($token = m::mock());
         $clients->shouldReceive('revoked')->with(1)->andReturn(false);
         $clients->shouldReceive('findActive')->with(1)->andReturn(new TokenGuardTestClient);
 
@@ -89,7 +100,7 @@ class TokenGuardTest extends TestCase
         $user2 = $guard->user();
 
         $this->assertInstanceOf(TokenGuardTestUser::class, $user);
-        $this->assertEquals($token, $user->token());
+        $this->assertEquals(AccessToken::fromPsrRequest($psr), $user->token());
         $this->assertSame($user, $user2);
     }
 


### PR DESCRIPTION
Fixes #382 

As discussed [here](https://github.com/laravel/passport/pull/1751#issuecomment-2141482284), this PR fixes a long-standing issue #382.

The `TokenGuard` authenticates the user via bearer token and assigns this token to the authenticated user. This will be useful when the developer wants to check if the token has a given scope using the `tokenCan` method on the authenticated `App\Models\User` instance:

```php
$request->user()->tokenCan('place-orders')
```

The problem is that the `TokenGuard` guard (and also `CheckClientCredentials` middleware) unnecessarily query the DB to find the token's record and retrieve its scopes, but we have already decoded the token and we can simply use the `oauth_scopes` property instead.

This PR fixes the issue by separating the logic into new `Passport\AccessToken` class from the `Passport\Token` model, so we don't need to query the DB to find the token. This can be considered as performance optimization and also a security fix!

### Upgrade Guide
There shouldn't be any breaking change here, the `user()->tokenCan()` is the only documented functionality and works like before. The `user()->token()` returns `TransientToken` if the user is authenticated via the cookie just like before, but now returns `Passport\AccessToken` instance instead of `Passport\Token` instance when the user is authenticated via bearer token, but to avoid any breaking change, this class dynamically forwards method calls to `Passport\Token`.