### PR TITLE
[13.x] Cleanup

### DIFF
--- a/src/AuthCode.php
+++ b/src/AuthCode.php
@@ -54,6 +54,8 @@ class AuthCode extends Model
     /**
      * Get the client that owns the authentication code.
      *
+     * @deprecated Will be removed in a future Laravel version.
+     *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function client()

--- a/src/Bridge/PersonalAccessGrant.php
+++ b/src/Bridge/PersonalAccessGrant.php
@@ -19,7 +19,7 @@ class PersonalAccessGrant extends AbstractGrant
     ): ResponseTypeInterface {
         // Validate request
         $client = $this->validateClient($request);
-        $scopes = $this->validateScopes($this->getRequestParameter('scope', $request));
+        $scopes = $this->validateScopes($this->getRequestParameter('scope', $request, $this->defaultScope));
         $userIdentifier = $this->getRequestParameter('user_id', $request);
 
         // Finalize the requested scopes

--- a/src/Client.php
+++ b/src/Client.php
@@ -91,6 +91,8 @@ class Client extends Model
     /**
      * Get all of the authentication codes for the client.
      *
+     * @deprecated Will be removed in a future Laravel version.
+     *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function authCodes()

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -44,11 +44,8 @@ class InstallCommand extends Command
         if ($this->confirm('Would you like to run all pending database migrations?', true)) {
             $this->call('migrate');
 
-            if ($this->confirm('Would you like to create the "personal access" and "password grant" clients?', true)) {
-                $provider = in_array('users', array_keys(config('auth.providers'))) ? 'users' : null;
-
+            if ($this->confirm('Would you like to create the "personal access" grant client?', true)) {
                 $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client']);
-                $this->call('passport:client', ['--password' => true, '--name' => config('app.name').' Password Grant Client', '--provider' => $provider]);
             }
         }
     }

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -111,8 +111,6 @@ class TokenGuard implements Guard
         } elseif ($this->request->cookie(Passport::cookie())) {
             return $this->user = $this->authenticateViaCookie($this->request);
         }
-
-        return null;
     }
 
     /**
@@ -145,7 +143,7 @@ class TokenGuard implements Guard
 
         if ($this->request->bearerToken()) {
             if (! $psr = $this->getPsrRequestViaBearerToken($this->request)) {
-                return null;
+                return;
             }
 
             return $this->client = $this->clients->findActive(
@@ -156,8 +154,6 @@ class TokenGuard implements Guard
                 return $this->client = $this->clients->findActive($token['aud']);
             }
         }
-
-        return null;
     }
 
     /**
@@ -169,7 +165,7 @@ class TokenGuard implements Guard
     protected function authenticateViaBearerToken($request)
     {
         if (! $psr = $this->getPsrRequestViaBearerToken($request)) {
-            return null;
+            return;
         }
 
         $client = $this->clients->findActive(
@@ -179,7 +175,7 @@ class TokenGuard implements Guard
         if (! $client ||
             ($client->provider &&
              $client->provider !== $this->provider->getProviderName())) {
-            return null;
+            return;
         }
 
         $this->setClient($client);
@@ -192,7 +188,7 @@ class TokenGuard implements Guard
         );
 
         if (! $user) {
-            return null;
+            return;
         }
 
         // Next, we will assign a token instance to this user which the developers may use
@@ -230,8 +226,6 @@ class TokenGuard implements Guard
                 ExceptionHandler::class
             )->report($e);
         }
-
-        return null;
     }
 
     /**
@@ -243,7 +237,7 @@ class TokenGuard implements Guard
     protected function authenticateViaCookie($request)
     {
         if (! $token = $this->getTokenViaCookie($request)) {
-            return null;
+            return;
         }
 
         // If this user exists, we will return this user and attach a "transient" token to
@@ -252,8 +246,6 @@ class TokenGuard implements Guard
         if ($user = $this->provider->retrieveById($token['sub'])) {
             return $user->withAccessToken(new TransientToken);
         }
-
-        return null;
     }
 
     /**
@@ -270,7 +262,7 @@ class TokenGuard implements Guard
         try {
             $token = $this->decodeJwtTokenCookie($request);
         } catch (Exception $e) {
-            return null;
+            return;
         }
 
         // We will compare the CSRF token in the decoded API token against the CSRF header
@@ -278,7 +270,7 @@ class TokenGuard implements Guard
         // a valid source and we won't authenticate the request for further handling.
         if (! Passport::$ignoreCsrfToken && (! $this->validCsrf($token, $request) ||
             time() >= $token['expiry'])) {
-            return null;
+            return;
         }
 
         return $token;

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -206,7 +206,7 @@ class TokenGuard implements Guard
     /**
      * Authenticate and get the incoming PSR-7 request via the Bearer token.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param  \Illuminate\Http\Request  $request
      * @return \Psr\Http\Message\ServerRequestInterface|null
      */
     protected function getPsrRequestViaBearerToken($request)

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -51,7 +51,7 @@ trait HasApiTokens
      */
     public function tokenCan($scope)
     {
-        return $this->accessToken ? $this->accessToken->can($scope) : false;
+        return $this->accessToken && $this->accessToken->can($scope);
     }
 
     /**

--- a/src/Http/Middleware/CheckCredentials.php
+++ b/src/Http/Middleware/CheckCredentials.php
@@ -5,7 +5,6 @@ namespace Laravel\Passport\Http\Middleware;
 use Closure;
 use Laravel\Passport\AccessToken;
 use Laravel\Passport\Exceptions\AuthenticationException;
-use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -21,23 +20,14 @@ abstract class CheckCredentials
     protected $server;
 
     /**
-     * Token Repository.
-     *
-     * @var \Laravel\Passport\TokenRepository
-     */
-    protected $repository;
-
-    /**
      * Create a new middleware instance.
      *
      * @param  \League\OAuth2\Server\ResourceServer  $server
-     * @param  \Laravel\Passport\TokenRepository  $repository
      * @return void
      */
-    public function __construct(ResourceServer $server, TokenRepository $repository)
+    public function __construct(ResourceServer $server)
     {
         $this->server = $server;
-        $this->repository = $repository;
     }
 
     /**

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -352,7 +352,6 @@ class PassportServiceProvider extends ServiceProvider
         return new TokenGuard(
             $this->app->make(ResourceServer::class),
             new PassportUserProvider(Auth::createUserProvider($config['provider']), $config['provider']),
-            $this->app->make(TokenRepository::class),
             $this->app->make(ClientRepository::class),
             $this->app->make('encrypter'),
             $this->app->make('request')

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -72,16 +72,6 @@ class RefreshToken extends Model
     }
 
     /**
-     * Determine if the token is a transient JWT token.
-     *
-     * @return bool
-     */
-    public function transient()
-    {
-        return false;
-    }
-
-    /**
      * Get the current connection name for the model.
      *
      * @return string|null

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -54,6 +54,8 @@ class TokenRepository
     /**
      * Get a valid token instance for the given user and client.
      *
+     * @deprecated use findValidToken
+     *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Laravel\Passport\Client  $client
      * @return \Laravel\Passport\Token|null

--- a/tests/Unit/CheckClientCredentialsForAnyScopeTest.php
+++ b/tests/Unit/CheckClientCredentialsForAnyScopeTest.php
@@ -5,7 +5,6 @@ namespace Laravel\Passport\Tests\Unit;
 use Illuminate\Http\Request;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentialsForAnyScope;
-use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Mockery as m;
@@ -30,9 +29,7 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
             'oauth_scopes' => ['*'],
         ]);
 
-        $tokenRepository = m::mock(TokenRepository::class);
-
-        $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -55,9 +52,7 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
             'oauth_scopes' => ['foo', 'bar', 'baz'],
         ]);
 
-        $tokenRepository = m::mock(TokenRepository::class);
-
-        $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -73,13 +68,12 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
     {
         $this->expectException(AuthenticationException::class);
 
-        $tokenRepository = m::mock(TokenRepository::class);
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
             new OAuthServerException('message', 500, 'error type')
         );
 
-        $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -102,9 +96,7 @@ class CheckClientCredentialsForAnyScopeTest extends TestCase
             'oauth_scopes' => ['foo', 'bar'],
         ]);
 
-        $tokenRepository = m::mock(TokenRepository::class);
-
-        $middleware = new CheckClientCredentialsForAnyScope($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentialsForAnyScope($resourceServer);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');

--- a/tests/Unit/CheckClientCredentialsTest.php
+++ b/tests/Unit/CheckClientCredentialsTest.php
@@ -5,7 +5,6 @@ namespace Laravel\Passport\Tests\Unit;
 use Illuminate\Http\Request;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials;
-use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Mockery as m;
@@ -30,9 +29,7 @@ class CheckClientCredentialsTest extends TestCase
             'oauth_scopes' => ['*'],
         ]);
 
-        $tokenRepository = m::mock(TokenRepository::class);
-
-        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentials($resourceServer);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -55,9 +52,7 @@ class CheckClientCredentialsTest extends TestCase
             'oauth_scopes' => ['see-profile'],
         ]);
 
-        $tokenRepository = m::mock(TokenRepository::class);
-
-        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentials($resourceServer);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -73,13 +68,12 @@ class CheckClientCredentialsTest extends TestCase
     {
         $this->expectException(AuthenticationException::class);
 
-        $tokenRepository = m::mock(TokenRepository::class);
         $resourceServer = m::mock(ResourceServer::class);
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
             new OAuthServerException('message', 500, 'error type')
         );
 
-        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentials($resourceServer);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -102,9 +96,7 @@ class CheckClientCredentialsTest extends TestCase
             'oauth_scopes' => ['foo', 'notbar'],
         ]);
 
-        $tokenRepository = m::mock(TokenRepository::class);
-
-        $middleware = new CheckClientCredentials($resourceServer, $tokenRepository);
+        $middleware = new CheckClientCredentials($resourceServer);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');

--- a/tests/Unit/TokenGuardTest.php
+++ b/tests/Unit/TokenGuardTest.php
@@ -11,12 +11,12 @@ use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Http\Request;
 use Laravel\Passport\AccessToken;
+use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Guards\TokenGuard;
 use Laravel\Passport\HasApiTokens;
 use Laravel\Passport\Passport;
 use Laravel\Passport\PassportUserProvider;
-use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Mockery as m;
@@ -35,14 +35,13 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = m::mock(Encrypter::class);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
@@ -69,14 +68,13 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = m::mock(Encrypter::class);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
@@ -113,14 +111,13 @@ class TokenGuardTest extends TestCase
 
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = m::mock(Encrypter::class);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
             new OAuthServerException('message', 500, 'error type')
@@ -136,7 +133,6 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = m::mock(Encrypter::class);
 
@@ -147,7 +143,7 @@ class TokenGuardTest extends TestCase
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
@@ -162,7 +158,6 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
@@ -181,7 +176,7 @@ class TokenGuardTest extends TestCase
             ], str_repeat('a', 16), 'HS256'), false)
         );
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
@@ -195,7 +190,6 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
@@ -214,7 +208,7 @@ class TokenGuardTest extends TestCase
             ], str_repeat('a', 16), 'HS256'), false)
         );
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
@@ -228,7 +222,6 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
@@ -243,7 +236,7 @@ class TokenGuardTest extends TestCase
             ], str_repeat('a', 16), 'HS256'))
         );
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $userProvider->shouldReceive('retrieveById')->never();
 
@@ -254,7 +247,6 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
@@ -269,7 +261,7 @@ class TokenGuardTest extends TestCase
             ], str_repeat('a', 16), 'HS256'))
         );
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $userProvider->shouldReceive('retrieveById')->never();
 
@@ -284,7 +276,6 @@ class TokenGuardTest extends TestCase
 
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
@@ -303,7 +294,7 @@ class TokenGuardTest extends TestCase
             ], Passport::tokenEncryptionKey($encrypter), 'HS256'), false)
         );
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
@@ -325,7 +316,6 @@ class TokenGuardTest extends TestCase
 
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
@@ -344,7 +334,7 @@ class TokenGuardTest extends TestCase
             ], Passport::tokenEncryptionKey($encrypter), 'HS256')
         );
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
@@ -362,7 +352,6 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
@@ -377,7 +366,7 @@ class TokenGuardTest extends TestCase
             ], str_repeat('a', 16), 'HS256'))
         );
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $userProvider->shouldReceive('retrieveById')->never();
 
@@ -388,7 +377,6 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
@@ -403,7 +391,7 @@ class TokenGuardTest extends TestCase
             ], str_repeat('a', 16), 'HS256'))
         );
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $userProvider->shouldReceive('retrieveById')->never();
 
@@ -414,7 +402,6 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
@@ -433,7 +420,7 @@ class TokenGuardTest extends TestCase
             ], str_repeat('a', 16), 'HS256'), false)
         );
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn($expectedUser = new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
@@ -447,14 +434,13 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = m::mock(Encrypter::class);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
@@ -469,14 +455,13 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = m::mock(Encrypter::class);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
@@ -501,14 +486,13 @@ class TokenGuardTest extends TestCase
 
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = m::mock(Encrypter::class);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andThrow(
             new OAuthServerException('message', 500, 'error type')
@@ -524,14 +508,13 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = m::mock(Encrypter::class);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
@@ -544,7 +527,6 @@ class TokenGuardTest extends TestCase
     {
         $resourceServer = m::mock(ResourceServer::class);
         $userProvider = m::mock(PassportUserProvider::class);
-        $tokens = m::mock(TokenRepository::class);
         $clients = m::mock(ClientRepository::class);
         $encrypter = new Encrypter(str_repeat('a', 16));
 
@@ -559,7 +541,7 @@ class TokenGuardTest extends TestCase
             ], str_repeat('a', 16), 'HS256'), false)
         );
 
-        $guard = new TokenGuard($resourceServer, $userProvider, $tokens, $clients, $encrypter, $request);
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
 
         $clients->shouldReceive('findActive')->with(1)->andReturn($expectedClient = new TokenGuardTestClient);
 
@@ -574,7 +556,7 @@ class TokenGuardTestUser
     use HasApiTokens;
 }
 
-class TokenGuardTestClient
+class TokenGuardTestClient extends Client
 {
     public $provider;
 }


### PR DESCRIPTION
Cleanup.

* Do not create password grant client (deprecated grant) on install command anymore.
* Remove unused `\Laravel\Passport\TokenRepository` from `\Laravel\Passport\Guards\TokenGuard` and `\Laravel\Passport\Http\Middleware\CheckCredentials` classes.
* Remove `\Laravel\Passport\RefreshToken::transient()` method, probably copy/pasted from `Token` model class mistakenly long time ago!
* Fix doc types on `\Laravel\Passport\Guards\TokenGuard` class.
* Deprecate some unused methods to be removed later:
  * `\Laravel\Passport\AuthCode::client()` method
  * `\Laravel\Passport\Client::authCodes()` method
  * `\Laravel\Passport\TokenRepository::getValidToken()` method
* Use `$defaultScope` on `PersonalAccessGrant`.