### PR TITLE
[13.x] Refactor migrations

### DIFF
--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -12,9 +12,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('oauth_auth_codes', function (Blueprint $table) {
-            $table->string('id', 100)->primary();
-            $table->unsignedBigInteger('user_id')->index();
-            $table->unsignedBigInteger('client_id');
+            $table->char('id', 80)->primary();
+            $table->foreignId('user_id');
+            $table->foreignId('client_id');
             $table->text('scopes')->nullable();
             $table->boolean('revoked');
             $table->dateTime('expires_at')->nullable();
@@ -27,5 +27,15 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('oauth_auth_codes');
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return $this->connection ?? config('passport.connection');
     }
 };

--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('oauth_auth_codes', function (Blueprint $table) {
             $table->char('id', 80)->primary();
-            $table->foreignId('user_id');
+            $table->foreignId('user_id')->index();
             $table->foreignId('client_id');
             $table->text('scopes')->nullable();
             $table->boolean('revoked');

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -12,11 +12,11 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('oauth_access_tokens', function (Blueprint $table) {
-            $table->string('id', 100)->primary();
-            $table->unsignedBigInteger('user_id')->nullable()->index();
-            $table->unsignedBigInteger('client_id');
+            $table->char('id', 80)->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->foreignId('client_id');
             $table->string('name')->nullable();
-            $table->text('scopes')->nullable();
+            $table->text('scopes');
             $table->boolean('revoked');
             $table->timestamps();
             $table->dateTime('expires_at')->nullable();
@@ -29,5 +29,15 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('oauth_access_tokens');
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return $this->connection ?? config('passport.connection');
     }
 };

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->foreignId('user_id')->nullable()->index();
             $table->foreignId('client_id');
             $table->string('name')->nullable();
-            $table->text('scopes');
+            $table->text('scopes')->nullable();
             $table->boolean('revoked');
             $table->timestamps();
             $table->dateTime('expires_at')->nullable();

--- a/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
@@ -12,8 +12,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('oauth_refresh_tokens', function (Blueprint $table) {
-            $table->string('id', 100)->primary();
-            $table->string('access_token_id', 100)->index();
+            $table->char('id', 80)->primary();
+            $table->char('access_token_id', 80)->index();
             $table->boolean('revoked');
             $table->dateTime('expires_at')->nullable();
         });
@@ -25,5 +25,15 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('oauth_refresh_tokens');
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return $this->connection ?? config('passport.connection');
     }
 };

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->string('name');
             $table->string('secret', 100)->nullable();
             $table->string('provider')->nullable();
-            $table->text('redirect')->nullable();
+            $table->text('redirect');
             $table->boolean('personal_access_client');
             $table->boolean('password_client');
             $table->boolean('revoked');

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -12,12 +12,12 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('oauth_clients', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->id();
+            $table->foreignId('user_id')->nullable()->index();
             $table->string('name');
             $table->string('secret', 100)->nullable();
             $table->string('provider')->nullable();
-            $table->text('redirect');
+            $table->text('redirect')->nullable();
             $table->boolean('personal_access_client');
             $table->boolean('password_client');
             $table->boolean('revoked');
@@ -31,5 +31,15 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('oauth_clients');
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return $this->connection ?? config('passport.connection');
     }
 };

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -66,9 +66,9 @@ class InstallCommand extends Command
         Passport::setClientUuids(true);
 
         $this->replaceInFile(config_path('passport.php'), '\'client_uuids\' => false', '\'client_uuids\' => true');
-        $this->replaceInFile(database_path('migrations/****_**_**_******_create_oauth_auth_codes_table.php'), '$table->unsignedBigInteger(\'client_id\');', '$table->uuid(\'client_id\');');
-        $this->replaceInFile(database_path('migrations/****_**_**_******_create_oauth_access_tokens_table.php'), '$table->unsignedBigInteger(\'client_id\');', '$table->uuid(\'client_id\');');
-        $this->replaceInFile(database_path('migrations/****_**_**_******_create_oauth_clients_table.php'), '$table->bigIncrements(\'id\');', '$table->uuid(\'id\')->primary();');
+        $this->replaceInFile(database_path('migrations/****_**_**_******_create_oauth_auth_codes_table.php'), '$table->foreignId(\'client_id\');', '$table->foreignUuid(\'client_id\');');
+        $this->replaceInFile(database_path('migrations/****_**_**_******_create_oauth_access_tokens_table.php'), '$table->foreignId(\'client_id\');', '$table->foreignUuid(\'client_id\');');
+        $this->replaceInFile(database_path('migrations/****_**_**_******_create_oauth_clients_table.php'), '$table->id();', '$table->uuid(\'id\')->primary();');
     }
 
     /**


### PR DESCRIPTION
There is no breaking change on this PR, just better migrations for new apps. No need to change/modify columns for existing apps.

* Use `passport.connection` on migrations (Related to #1738)
* Use `foreignId` instead of `unsignedBigInteger`, makes the purpose of the column more clear.
* IDs are always 80 char long, more optimized storage.