### PR TITLE
[13.x] Use UUID to identify clients by default

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,14 +26,14 @@ The `league/oauth2-server` Composer package which is utilized internally by Pass
 
 PR: https://github.com/laravel/passport/pull/1764
 
-Passport now uses UUIDs to identify clients by default. You may keep using incremental integer IDs by setting `Passport::$clientUuids` to `false` on the `boot` method of your application's `App\Providers\AppServiceProvider` class:
+By default, Passport now uses UUIDs to identify clients. You may keep using incremental integer IDs by setting `Passport::$clientUuids` to `false` within the `boot` method of your application's `App\Providers\AppServiceProvider` class:
 
     public function boot(): void
     {
         Passport::$clientUuids = false;
     }
 
-Therefore, the `'passport.client_uuids'` config property, `Passport::clientUuids()` and `Passport::setClientUuids()` methods have been removed.
+As a consequence of this change, the `'passport.client_uuids'` configuration property has been removed, as well as the `Passport::clientUuids()` and `Passport::setClientUuids()` methods.
 
 ### Client Secrets Hashed by Default
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,19 @@ PR: https://github.com/laravel/passport/pull/1734
 
 The `league/oauth2-server` Composer package which is utilized internally by Passport has been updated to 9.0, which adds additional types to method signatures. To ensure your application is compatible, you should review this package's complete [changelog](https://github.com/thephpleague/oauth2-server/blob/master/CHANGELOG.md#900---released-2024-05-13). 
 
+### Identify Clients by UUIDs
+
+PR: https://github.com/laravel/passport/pull/1764
+
+Passport now uses UUIDs to identify clients by default. You may keep using incremental integer IDs by setting `Passport::$clientUuids` to `false` on the `boot` method of your application's `App\Providers\AppServiceProvider` class:
+
+    public function boot(): void
+    {
+        Passport::$clientUuids = false;
+    }
+
+Therefore, the `'passport.client_uuids'` config property, `Passport::clientUuids()` and `Passport::setClientUuids()` methods have been removed.
+
 ### Client Secrets Hashed by Default
 
 PR: https://github.com/laravel/passport/pull/1745

--- a/config/passport.php
+++ b/config/passport.php
@@ -45,19 +45,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Client UUIDs
-    |--------------------------------------------------------------------------
-    |
-    | By default, Passport uses auto-incrementing primary keys when assigning
-    | IDs to clients. However, if Passport is installed using the provided
-    | --uuids switch, this will be set to "true" and UUIDs will be used.
-    |
-    */
-
-    'client_uuids' => false,
-
-    /*
-    |--------------------------------------------------------------------------
     | Personal Access Client
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('oauth_auth_codes', function (Blueprint $table) {
             $table->char('id', 80)->primary();
             $table->foreignId('user_id')->index();
-            $table->foreignId('client_id');
+            $table->foreignUuid('client_id');
             $table->text('scopes')->nullable();
             $table->boolean('revoked');
             $table->dateTime('expires_at')->nullable();

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('oauth_access_tokens', function (Blueprint $table) {
             $table->char('id', 80)->primary();
             $table->foreignId('user_id')->nullable()->index();
-            $table->foreignId('client_id');
+            $table->foreignUuid('client_id');
             $table->string('name')->nullable();
             $table->text('scopes')->nullable();
             $table->boolean('revoked');

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -12,10 +12,10 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('oauth_clients', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
             $table->string('name');
-            $table->string('secret', 100)->nullable();
+            $table->string('secret')->nullable();
             $table->string('provider')->nullable();
             $table->text('redirect');
             $table->boolean('personal_access_client');

--- a/src/Client.php
+++ b/src/Client.php
@@ -68,7 +68,7 @@ class Client extends Model
     {
         parent::__construct($attributes);
 
-        $this->usesUniqueIds = Passport::clientUuids();
+        $this->usesUniqueIds = Passport::$clientUuids;
     }
 
     /**
@@ -209,7 +209,7 @@ class Client extends Model
      */
     public function uniqueIds()
     {
-        return Passport::clientUuids() ? [$this->getKeyName()] : [];
+        return $this->usesUniqueIds ? [$this->getKeyName()] : [];
     }
 
     /**
@@ -219,7 +219,7 @@ class Client extends Model
      */
     public function newUniqueId()
     {
-        return Passport::clientUuids() ? (string) Str::orderedUuid() : null;
+        return $this->usesUniqueIds ? (string) Str::orderedUuid() : null;
     }
 
     /**
@@ -229,7 +229,7 @@ class Client extends Model
      */
     public function getKeyType()
     {
-        return Passport::clientUuids() ? 'string' : $this->keyType;
+        return $this->usesUniqueIds ? 'string' : $this->keyType;
     }
 
     /**
@@ -239,7 +239,7 @@ class Client extends Model
      */
     public function getIncrementing()
     {
-        return Passport::clientUuids() ? false : $this->incrementing;
+        return $this->usesUniqueIds ? false : $this->incrementing;
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -3,7 +3,6 @@
 namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
-use Laravel\Passport\Passport;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'passport:install')]
@@ -15,7 +14,6 @@ class InstallCommand extends Command
      * @var string
      */
     protected $signature = 'passport:install
-                            {--uuids : Use UUIDs for all client IDs}
                             {--force : Overwrite keys they already exist}
                             {--length=4096 : The length of the private key}';
 
@@ -35,11 +33,8 @@ class InstallCommand extends Command
     {
         $this->call('passport:keys', ['--force' => $this->option('force'), '--length' => $this->option('length')]);
 
+        $this->call('vendor:publish', ['--tag' => 'passport-config']);
         $this->call('vendor:publish', ['--tag' => 'passport-migrations']);
-
-        if ($this->option('uuids')) {
-            $this->configureUuids();
-        }
 
         if ($this->confirm('Would you like to run all pending database migrations?', true)) {
             $this->call('migrate');
@@ -47,42 +42,6 @@ class InstallCommand extends Command
             if ($this->confirm('Would you like to create the "personal access" grant client?', true)) {
                 $this->call('passport:client', ['--personal' => true, '--name' => config('app.name').' Personal Access Client']);
             }
-        }
-    }
-
-    /**
-     * Configure Passport for client UUIDs.
-     *
-     * @return void
-     */
-    protected function configureUuids()
-    {
-        $this->call('vendor:publish', ['--tag' => 'passport-config']);
-
-        config(['passport.client_uuids' => true]);
-        Passport::setClientUuids(true);
-
-        $this->replaceInFile(config_path('passport.php'), '\'client_uuids\' => false', '\'client_uuids\' => true');
-        $this->replaceInFile(database_path('migrations/****_**_**_******_create_oauth_auth_codes_table.php'), '$table->foreignId(\'client_id\');', '$table->foreignUuid(\'client_id\');');
-        $this->replaceInFile(database_path('migrations/****_**_**_******_create_oauth_access_tokens_table.php'), '$table->foreignId(\'client_id\');', '$table->foreignUuid(\'client_id\');');
-        $this->replaceInFile(database_path('migrations/****_**_**_******_create_oauth_clients_table.php'), '$table->id();', '$table->uuid(\'id\')->primary();');
-    }
-
-    /**
-     * Replace a given string in a given file.
-     *
-     * @param  string  $path
-     * @param  string  $search
-     * @param  string  $replace
-     * @return void
-     */
-    protected function replaceInFile($path, $search, $replace)
-    {
-        foreach (glob($path) as $file) {
-            file_put_contents(
-                $file,
-                str_replace($search, $replace, file_get_contents($file))
-            );
         }
     }
 }

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -119,7 +119,7 @@ class Passport
      *
      * @var bool
      */
-    public static $clientUuids = false;
+    public static $clientUuids = true;
 
     /**
      * The token model class name.
@@ -509,27 +509,6 @@ class Passport
     public static function client()
     {
         return new static::$clientModel;
-    }
-
-    /**
-     * Determine if clients are identified using UUIDs.
-     *
-     * @return bool
-     */
-    public static function clientUuids()
-    {
-        return static::$clientUuids;
-    }
-
-    /**
-     * Specify if clients are identified using UUIDs.
-     *
-     * @param  bool  $value
-     * @return void
-     */
-    public static function setClientUuids($value)
-    {
-        static::$clientUuids = $value;
     }
 
     /**

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -126,8 +126,6 @@ class PassportServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/passport.php', 'passport');
 
-        Passport::setClientUuids($this->app->make(Config::class)->get('passport.client_uuids', false));
-
         $this->app->when(AuthorizationController::class)
                 ->needs(StatefulGuard::class)
                 ->give(fn () => Auth::guard(config('passport.guard', null)));


### PR DESCRIPTION
Clients are now identified by UUID by default. According to [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#page-15:~:text=a%20client%0A%20%20%20identifier%20%2D%2D-,a%20unique%20string,-representing%20the%20registration) the client identifier must be a unique string. It's also more secure than incremental integer IDs.

### Changes
- `Passport::clientUuids()` method has been removed.
- `Passport::setClientUuids()` method has been removed.
- `'passport.client_uuids'` config property has been removed.

### Upgrade Guide
You may set `Passport::$clientUuids = false` on `boot` method of your application's `App\Providers\AppServiceProvider` class to identify clients by incremental integer IDs.