### PR TITLE
[13.x] Disable PAT requests

### DIFF
--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -40,7 +40,7 @@ class ClientFactory extends Factory
     }
 
     /**
-     * Use as Password Client.
+     * Use as as Password client.
      *
      * @return $this
      */
@@ -53,7 +53,7 @@ class ClientFactory extends Factory
     }
 
     /**
-     * Use as Personal Access Token Client.
+     * Use as a Personal Access Token client.
      *
      * @return $this
      */
@@ -66,7 +66,7 @@ class ClientFactory extends Factory
     }
 
     /**
-     * Use as Client Credentials.
+     * Use as a Client Credentials client.
      *
      * @return $this
      */

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -40,7 +40,7 @@ class ClientFactory extends Factory
     }
 
     /**
-     * Use as as Password client.
+     * Use as a Password client.
      *
      * @return $this
      */

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -53,6 +53,19 @@ class ClientFactory extends Factory
     }
 
     /**
+     * Use as Personal Access Token Client.
+     *
+     * @return $this
+     */
+    public function asPersonalAccessTokenClient()
+    {
+        return $this->state([
+            'personal_access_client' => true,
+            'password_client' => false,
+        ]);
+    }
+
+    /**
      * Use as Client Credentials.
      *
      * @return $this

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
-use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Nyholm\Psr7\Response as Psr7Response;
@@ -20,24 +19,14 @@ class AccessTokenController
     protected $server;
 
     /**
-     * The token repository instance.
-     *
-     * @var \Laravel\Passport\TokenRepository
-     */
-    protected $tokens;
-
-    /**
      * Create a new controller instance.
      *
      * @param  \League\OAuth2\Server\AuthorizationServer  $server
-     * @param  \Laravel\Passport\TokenRepository  $tokens
      * @return void
      */
-    public function __construct(AuthorizationServer $server,
-                                TokenRepository $tokens)
+    public function __construct(AuthorizationServer $server)
     {
         $this->server = $server;
-        $this->tokens = $tokens;
     }
 
     /**

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -4,6 +4,7 @@ namespace Laravel\Passport\Http\Controllers;
 
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Nyholm\Psr7\Response as Psr7Response;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -44,10 +45,17 @@ class AccessTokenController
      *
      * @param  \Psr\Http\Message\ServerRequestInterface  $request
      * @return \Illuminate\Http\Response
+     *
+     * @throws \Laravel\Passport\Exceptions\OAuthServerException
      */
     public function issueToken(ServerRequestInterface $request)
     {
         return $this->withErrorHandling(function () use ($request) {
+            if (array_key_exists('grant_type', $attributes = (array) $request->getParsedBody())
+                && $attributes['grant_type'] === 'personal_access') {
+                throw OAuthServerException::unsupportedGrantType();
+            }
+
             return $this->convertResponse(
                 $this->server->respondToAccessTokenRequest($request, new Psr7Response)
             );

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -45,8 +45,6 @@ class AccessTokenController
      *
      * @param  \Psr\Http\Message\ServerRequestInterface  $request
      * @return \Illuminate\Http\Response
-     *
-     * @throws \Laravel\Passport\Exceptions\OAuthServerException
      */
     public function issueToken(ServerRequestInterface $request)
     {

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -269,6 +269,45 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertArrayHasKey('id_token', $decodedResponse);
         $this->assertSame('foo_bar_open_id_token', $decodedResponse['id_token']);
     }
+
+    public function testPersonalAccessTokenRequestIsDisabled()
+    {
+        $user = UserFactory::new()->create([
+            'email' => 'foo@gmail.com',
+            'password' => $this->app->make(Hasher::class)->make('foobar123'),
+        ]);
+
+        /** @var Client $client */
+        $client = ClientFactory::new()->asPersonalAccessTokenClient()->create();
+
+        config([
+            'passport.personal_access_client.id' => $client->getKey(),
+            'passport.personal_access_client.secret' => $client->plainSecret,
+        ]);
+
+        $response = $this->post(
+            '/oauth/token',
+            [
+                'grant_type' => 'personal_access',
+                'client_id' => $client->getKey(),
+                'client_secret' => $client->plainSecret,
+                'user_id' => $user->getKey(),
+                'scope' => '',
+            ]
+        );
+
+        $response->assertStatus(400);
+
+        $decodedResponse = $response->decodeResponseJson()->json();
+
+        $this->assertArrayNotHasKey('token_type', $decodedResponse);
+        $this->assertArrayNotHasKey('expires_in', $decodedResponse);
+        $this->assertArrayNotHasKey('access_token', $decodedResponse);
+
+        $this->assertArrayHasKey('error', $decodedResponse);
+        $this->assertSame('unsupported_grant_type', $decodedResponse['error']);
+        $this->assertArrayHasKey('error_description', $decodedResponse);
+    }
 }
 
 class IdTokenResponse extends \League\OAuth2\Server\ResponseTypes\BearerTokenResponse

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -307,6 +307,10 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertArrayHasKey('error', $decodedResponse);
         $this->assertSame('unsupported_grant_type', $decodedResponse['error']);
         $this->assertArrayHasKey('error_description', $decodedResponse);
+
+        $token = $user->createToken('test');
+
+        $this->assertInstanceOf(\Laravel\Passport\PersonalAccessTokenResult::class, $token);
     }
 }
 

--- a/tests/Unit/AccessTokenControllerTest.php
+++ b/tests/Unit/AccessTokenControllerTest.php
@@ -26,7 +26,6 @@ class AccessTokenControllerTest extends TestCase
         $request->shouldReceive('getParsedBody')->once()->andReturn([]);
 
         $response = m::type(ResponseInterface::class);
-        $tokens = m::mock(TokenRepository::class);
 
         $psrResponse = new Response();
         $psrResponse->getBody()->write(json_encode(['access_token' => 'access-token']));
@@ -36,7 +35,7 @@ class AccessTokenControllerTest extends TestCase
             ->with($request, $response)
             ->andReturn($psrResponse);
 
-        $controller = new AccessTokenController($server, $tokens);
+        $controller = new AccessTokenController($server);
 
         $this->assertSame('{"access_token":"access-token"}', $controller->issueToken($request)->getContent());
     }
@@ -46,14 +45,12 @@ class AccessTokenControllerTest extends TestCase
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getParsedBody')->once()->andReturn([]);
 
-        $tokens = m::mock(TokenRepository::class);
-
         $server = m::mock(AuthorizationServer::class);
         $server->shouldReceive('respondToAccessTokenRequest')->with(
             $request, m::type(ResponseInterface::class)
         )->andThrow(LeagueException::invalidCredentials());
 
-        $controller = new AccessTokenController($server, $tokens);
+        $controller = new AccessTokenController($server);
 
         $this->expectException(OAuthServerException::class);
 

--- a/tests/Unit/AccessTokenControllerTest.php
+++ b/tests/Unit/AccessTokenControllerTest.php
@@ -23,6 +23,8 @@ class AccessTokenControllerTest extends TestCase
     public function test_a_token_can_be_issued()
     {
         $request = m::mock(ServerRequestInterface::class);
+        $request->shouldReceive('getParsedBody')->once()->andReturn([]);
+
         $response = m::type(ResponseInterface::class);
         $tokens = m::mock(TokenRepository::class);
 
@@ -41,18 +43,21 @@ class AccessTokenControllerTest extends TestCase
 
     public function test_exceptions_are_handled()
     {
+        $request = m::mock(ServerRequestInterface::class);
+        $request->shouldReceive('getParsedBody')->once()->andReturn([]);
+
         $tokens = m::mock(TokenRepository::class);
 
         $server = m::mock(AuthorizationServer::class);
         $server->shouldReceive('respondToAccessTokenRequest')->with(
-            m::type(ServerRequestInterface::class), m::type(ResponseInterface::class)
+            $request, m::type(ResponseInterface::class)
         )->andThrow(LeagueException::invalidCredentials());
 
         $controller = new AccessTokenController($server, $tokens);
 
         $this->expectException(OAuthServerException::class);
 
-        $controller->issueToken(m::mock(ServerRequestInterface::class));
+        $controller->issueToken($request);
     }
 }
 

--- a/tests/Unit/AccessTokenControllerTest.php
+++ b/tests/Unit/AccessTokenControllerTest.php
@@ -4,7 +4,6 @@ namespace Laravel\Passport\Tests\Unit;
 
 use Laravel\Passport\Exceptions\OAuthServerException;
 use Laravel\Passport\Http\Controllers\AccessTokenController;
-use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException as LeagueException;
 use Mockery as m;


### PR DESCRIPTION
In addition to OAuth2 grants, we are enabling "Personal Access Token" grant on Passport. This implicitly causes `POST /oauth/token` to respond to access token requests with `'grant_type' => 'personal_access'`, which is totally unwanted, insecure and not documented.

This change doesn't effect issuing PAT via `$user->createToken()` method.