### PR TITLE
[13.x] Configure the user provider for PAT

### DIFF
--- a/src/Bridge/PersonalAccessGrant.php
+++ b/src/Bridge/PersonalAccessGrant.php
@@ -31,6 +31,10 @@ class PersonalAccessGrant extends AbstractGrant
         $scopes = $this->validateScopes($this->getRequestParameter('scope', $request, $this->defaultScope));
         $userIdentifier = $this->getRequestParameter('user_id', $request);
 
+        if (! $userIdentifier) {
+            throw OAuthServerException::invalidRequest('user_id');
+        }
+
         // Finalize the requested scopes
         $scopes = $this->scopeRepository->finalizeScopes(
             $scopes,

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -64,8 +64,28 @@ trait HasApiTokens
     public function createToken($name, array $scopes = [])
     {
         return Container::getInstance()->make(PersonalAccessTokenFactory::class)->make(
-            $this->getAuthIdentifier(), $name, $scopes
+            $this->getAuthIdentifier(), $name, $scopes, $this->getProvider()
         );
+    }
+
+    /**
+     * Get the user provider name.
+     *
+     * @return string|null
+     */
+    public function getProvider(): ?string
+    {
+        $providers = collect(config('auth.guards'))->where('driver', 'passport')->pluck('provider')->all();
+
+        foreach (config('auth.providers') as $provider => $config) {
+            if (in_array($provider, $providers)
+                && (($config['driver'] === 'eloquent' && is_a($this, $config['model']))
+                    || ($config['driver'] === 'database' && $config['table'] === $this->getTable()))) {
+                return $provider;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -19,6 +19,13 @@ class PersonalAccessTokenFactory
     protected $server;
 
     /**
+     * The client repository instance.
+     *
+     * @var \Laravel\Passport\ClientRepository
+     */
+    protected $clients;
+
+    /**
      * The token repository instance.
      *
      * @var \Laravel\Passport\TokenRepository
@@ -36,15 +43,20 @@ class PersonalAccessTokenFactory
      * Create a new personal access token factory instance.
      *
      * @param  \League\OAuth2\Server\AuthorizationServer  $server
+     * @param  \Laravel\Passport\ClientRepository  $clients
      * @param  \Laravel\Passport\TokenRepository  $tokens
      * @param  \Lcobucci\JWT\Parser  $jwt
      * @return void
      */
-    public function __construct(AuthorizationServer $server, TokenRepository $tokens, JwtParser $jwt)
+    public function __construct(AuthorizationServer $server,
+                                ClientRepository $clients,
+                                TokenRepository $tokens,
+                                JwtParser $jwt)
     {
         $this->jwt = $jwt;
         $this->tokens = $tokens;
         $this->server = $server;
+        $this->clients = $clients;
     }
 
     /**
@@ -88,7 +100,9 @@ class PersonalAccessTokenFactory
             ? config("passport.personal_access_client.$provider", config('passport.personal_access_client'))
             : config('passport.personal_access_client');
 
-        if (! $config) {
+        $client = isset($config['id']) ? $this->clients->findActive($config['id']) : null;
+
+        if (! $client || ($client->provider && $client->provider !== $provider)) {
             throw new RuntimeException(
                 'Personal access client not found. Please create one and set the `PASSPORT_PERSONAL_ACCESS_CLIENT_ID` and `PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET` environment variables.'
             );

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -53,12 +53,13 @@ class PersonalAccessTokenFactory
      * @param  mixed  $userId
      * @param  string  $name
      * @param  string[]  $scopes
+     * @param  string|null  $provider
      * @return \Laravel\Passport\PersonalAccessTokenResult
      */
-    public function make($userId, string $name, array $scopes = [])
+    public function make($userId, string $name, array $scopes = [], ?string $provider = null)
     {
         $response = $this->dispatchRequestToAuthorizationServer(
-            $this->createRequest($userId, $scopes)
+            $this->createRequest($userId, $scopes, $provider)
         );
 
         $token = tap($this->findAccessToken($response), function ($token) use ($userId, $name) {
@@ -78,11 +79,14 @@ class PersonalAccessTokenFactory
      *
      * @param  mixed  $userId
      * @param  string[]  $scopes
+     * @param  string|null  $provider
      * @return \Psr\Http\Message\ServerRequestInterface
      */
-    protected function createRequest($userId, array $scopes)
+    protected function createRequest($userId, array $scopes, ?string $provider)
     {
-        $config = config('passport.personal_access_client');
+        $config = $provider
+            ? config("passport.personal_access_client.$provider", config('passport.personal_access_client'))
+            : config('passport.personal_access_client');
 
         if (! $config) {
             throw new RuntimeException(

--- a/tests/Feature/HasApiTokensTest.php
+++ b/tests/Feature/HasApiTokensTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Laravel\Passport\HasApiTokens;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
+use Workbench\Database\Factories\UserFactory;
+
+class HasApiTokensTest extends PassportTestCase
+{
+    use WithLaravelMigrations;
+
+    public function testGetProvider()
+    {
+        config([
+            'auth.providers.admins' => ['driver' => 'eloquent', 'model' => AdminHasApiTokensStub::class],
+            'auth.guards.api-admins' => ['driver' => 'passport', 'provider' => 'admins'],
+            'auth.providers.customers' => ['driver' => 'database', 'table' => 'customer_has_api_tokens_stubs'],
+            'auth.guards.api-customers' => ['driver' => 'passport', 'provider' => 'customers'],
+        ]);
+
+        $this->assertSame('users', UserFactory::new()->create()->getProvider());
+        $this->assertSame('admins', (new AdminHasApiTokensStub)->getProvider());
+        $this->assertSame('customers', (new CustomerHasApiTokensStub)->getProvider());
+    }
+}
+
+class AdminHasApiTokensStub extends Authenticatable
+{
+    use HasApiTokens;
+}
+
+class CustomerHasApiTokensStub extends Authenticatable
+{
+    use HasApiTokens;
+}

--- a/tests/Feature/PersonalAccessTokenFactoryTest.php
+++ b/tests/Feature/PersonalAccessTokenFactoryTest.php
@@ -3,8 +3,10 @@
 namespace Laravel\Passport\Tests\Feature;
 
 use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 use Laravel\Passport\Client;
 use Laravel\Passport\Database\Factories\ClientFactory;
+use Laravel\Passport\HasApiTokens;
 use Laravel\Passport\Passport;
 use Laravel\Passport\PersonalAccessTokenResult;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
@@ -40,5 +42,63 @@ class PersonalAccessTokenFactoryTest extends PassportTestCase
         $this->assertSame($client->getKey(), $result->token->client_id);
         $this->assertSame($user->getAuthIdentifier(), $result->token->user_id);
         $this->assertSame(['bar'], $result->token->scopes);
+    }
+
+    public function testIssueTokenWithDifferentProviders()
+    {
+        $client = ClientFactory::new()->asPersonalAccessTokenClient()->create();
+        $adminClient = ClientFactory::new()->asPersonalAccessTokenClient()->create(['provider' => 'admins']);
+        $customerClient = ClientFactory::new()->asPersonalAccessTokenClient()->create(['provider' => 'customers']);
+
+        config([
+            'auth.providers.admins' => ['driver' => 'eloquent', 'model' => AdminProviderStub::class],
+            'auth.guards.api-admins' => ['driver' => 'passport', 'provider' => 'admins'],
+            'auth.providers.customers' => ['driver' => 'database', 'table' => 'customer_provider_stubs'],
+            'auth.guards.api-customers' => ['driver' => 'passport', 'provider' => 'customers'],
+            'passport.personal_access_client' => ['id' => $client->getKey(), 'secret' => $client->plainSecret],
+            'passport.personal_access_client.admins' => ['id' => $adminClient->getKey(), 'secret' => $adminClient->plainSecret],
+            'passport.personal_access_client.customers' => ['id' => $customerClient->getKey(), 'secret' => $customerClient->plainSecret],
+        ]);
+
+        $user = UserFactory::new()->create();
+        $userToken = $user->createToken('test user');
+
+        $admin = new AdminProviderStub;
+        $adminToken = $admin->createToken('test admin');
+
+        $customer = new CustomerProviderStub;
+        $customerToken = $customer->createToken('test customer');
+
+        $this->assertInstanceOf(PersonalAccessTokenResult::class, $userToken);
+        $this->assertSame($client->getKey(), $userToken->token->client_id);
+        $this->assertSame($user->getAuthIdentifier(), $userToken->token->user_id);
+
+        $this->assertInstanceOf(PersonalAccessTokenResult::class, $adminToken);
+        $this->assertSame($adminClient->getKey(), $adminToken->token->client_id);
+        $this->assertSame($admin->getAuthIdentifier(), $adminToken->token->user_id);
+
+        $this->assertInstanceOf(PersonalAccessTokenResult::class, $customerToken);
+        $this->assertSame($customerClient->getKey(), $customerToken->token->client_id);
+        $this->assertSame($customer->getAuthIdentifier(), $customerToken->token->user_id);
+    }
+}
+
+class AdminProviderStub extends Authenticatable
+{
+    use HasApiTokens;
+
+    public function getAuthIdentifier()
+    {
+        return 'foo';
+    }
+}
+
+class CustomerProviderStub extends Authenticatable
+{
+    use HasApiTokens;
+
+    public function getAuthIdentifier()
+    {
+        return 3;
     }
 }

--- a/tests/Unit/HasApiTokensTest.php
+++ b/tests/Unit/HasApiTokensTest.php
@@ -5,7 +5,6 @@ namespace Laravel\Passport\Tests\Unit;
 use Illuminate\Container\Container;
 use Laravel\Passport\AccessToken;
 use Laravel\Passport\HasApiTokens;
-use Laravel\Passport\PersonalAccessTokenFactory;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/HasApiTokensTest.php
+++ b/tests/Unit/HasApiTokensTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Tests\Unit;
 
 use Illuminate\Container\Container;
+use Laravel\Passport\AccessToken;
 use Laravel\Passport\HasApiTokens;
 use Laravel\Passport\PersonalAccessTokenFactory;
 use Mockery as m;
@@ -19,25 +20,12 @@ class HasApiTokensTest extends TestCase
     public function test_token_can_indicates_if_token_has_given_scope()
     {
         $user = new HasApiTokensTestStub;
-        $token = m::mock();
+        $token = m::mock(AccessToken::class);
         $token->shouldReceive('can')->with('scope')->andReturn(true);
         $token->shouldReceive('can')->with('another-scope')->andReturn(false);
 
         $this->assertTrue($user->withAccessToken($token)->tokenCan('scope'));
         $this->assertFalse($user->withAccessToken($token)->tokenCan('another-scope'));
-    }
-
-    public function test_token_can_be_created()
-    {
-        $this->expectNotToPerformAssertions();
-
-        $container = new Container;
-        Container::setInstance($container);
-        $container->instance(PersonalAccessTokenFactory::class, $factory = m::mock());
-        $factory->shouldReceive('make')->once()->with(1, 'name', ['scopes']);
-        $user = new HasApiTokensTestStub;
-
-        $user->createToken('name', ['scopes']);
     }
 }
 


### PR DESCRIPTION
We have documented how to add a guard with 'passport' as driver and set its 'provider'. So it's common practice to have several guards and providers. This PR makes PAT factory respect the guard provider when issuing personal access tokens.

### Changes
* Add feature tests.
* Require `user_id` on `PersonalAccessGrant`.
* Add `getProvider()` method to `HasApiTokens` to get the user provider name.
* Make `PersonalAccessTokenFactory` to check for `config('passport.personal_access_client.{provider}')` before getting default PAT credentials from `config('passport.personal_access_client')`. For example, having `customers` auth provider:

    ```php
    // config/passport.php

    'personal_access_client' => [
        'id' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_ID'),
        'secret' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET'),

        'customers' => [
            'id' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_CUSTOMER_ID'),
            'secret' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_CUSTOMER_SECRET'),
        ]
    ],
    ```