### PR TITLE
[13.x] Always validate auth token 

### DIFF
--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class AccessTokenController
 {
-    use HandlesOAuthErrors;
+    use ConvertsPsrResponses, HandlesOAuthErrors;
 
     /**
      * The authorization server.

--- a/src/Http/Controllers/ApproveAuthorizationController.php
+++ b/src/Http/Controllers/ApproveAuthorizationController.php
@@ -36,8 +36,6 @@ class ApproveAuthorizationController
      */
     public function approve(Request $request)
     {
-        $this->assertValidAuthToken($request);
-
         $authRequest = $this->getAuthRequestFromSession($request);
 
         $authRequest->setAuthorizationApproved(true);

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class AuthorizationController
 {
-    use HandlesOAuthErrors;
+    use ConvertsPsrResponses, HandlesOAuthErrors;
 
     /**
      * The authorization server.

--- a/src/Http/Controllers/DenyAuthorizationController.php
+++ b/src/Http/Controllers/DenyAuthorizationController.php
@@ -36,8 +36,6 @@ class DenyAuthorizationController
      */
     public function deny(Request $request)
     {
-        $this->assertValidAuthToken($request);
-
         $authRequest = $this->getAuthRequestFromSession($request);
 
         $authRequest->setAuthorizationApproved(false);

--- a/tests/Unit/ApproveAuthorizationControllerTest.php
+++ b/tests/Unit/ApproveAuthorizationControllerTest.php
@@ -26,11 +26,11 @@ class ApproveAuthorizationControllerTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
-        $request->shouldReceive('has')->with('auth_token')->andReturn(true);
+        $request->shouldReceive('isNotFilled')->with('auth_token')->andReturn(false);
         $request->shouldReceive('get')->with('auth_token')->andReturn('foo');
 
-        $session->shouldReceive('get')->once()->with('authToken')->andReturn('foo');
-        $session->shouldReceive('get')
+        $session->shouldReceive('pull')->once()->with('authToken')->andReturn('foo');
+        $session->shouldReceive('pull')
             ->once()
             ->with('authRequest')
             ->andReturn($authRequest = m::mock(AuthorizationRequest::class));

--- a/tests/Unit/DenyAuthorizationControllerTest.php
+++ b/tests/Unit/DenyAuthorizationControllerTest.php
@@ -28,11 +28,11 @@ class DenyAuthorizationControllerTest extends TestCase
 
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $request->shouldReceive('user')->andReturn(new DenyAuthorizationControllerFakeUser);
-        $request->shouldReceive('has')->with('auth_token')->andReturn(true);
+        $request->shouldReceive('isNotFilled')->with('auth_token')->andReturn(false);
         $request->shouldReceive('get')->with('auth_token')->andReturn('foo');
 
-        $session->shouldReceive('get')->once()->with('authToken')->andReturn('foo');
-        $session->shouldReceive('get')
+        $session->shouldReceive('pull')->once()->with('authToken')->andReturn('foo');
+        $session->shouldReceive('pull')
             ->once()
             ->with('authRequest')
             ->andReturn($authRequest = m::mock(
@@ -65,11 +65,11 @@ class DenyAuthorizationControllerTest extends TestCase
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $request->shouldReceive('user')->never();
         $request->shouldReceive('input')->never();
-        $request->shouldReceive('has')->with('auth_token')->andReturn(true);
+        $request->shouldReceive('isNotFilled')->with('auth_token')->andReturn(false);
         $request->shouldReceive('get')->with('auth_token')->andReturn('foo');
 
-        $session->shouldReceive('get')->once()->with('authToken')->andReturn('foo');
-        $session->shouldReceive('get')->once()->with('authRequest')->andReturnNull();
+        $session->shouldReceive('pull')->once()->with('authToken')->andReturn('foo');
+        $session->shouldReceive('pull')->once()->with('authRequest')->andReturnNull();
 
         $server->shouldReceive('completeAuthorizationRequest')->never();
 


### PR DESCRIPTION
The `auth_token` was validated only if present on the request, this PR does:
* Make sure the `auth_token` is present and filled.
* Merges `assertValidAuthToken()` method into `getAuthRequestFromSession()` method, we always validating the auth request from session before retrieving.
* Pull the values from session (get and forget at the same time) to not be misused on the future requests.