### PR TITLE
[12.x] Fix purge command

### DIFF
--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -38,10 +38,9 @@ class PurgeCommand extends Command
             ? Carbon::now()->subHours($this->option('hours'))
             : false;
 
-        $constraint = function (Builder $query) use ($revoked, $expired) {
-            $query->when($revoked, fn () => $query->orWhere('revoked', true))
-                ->when($expired, fn () => $query->orWhere('expires_at', '<', $expired));
-        };
+        $constraint = fn (Builder $query) => $query
+            ->when($revoked, fn () => $query->orWhere('revoked', true))
+            ->when($expired, fn () => $query->orWhere('expires_at', '<', $expired));
 
         Passport::token()->where($constraint)->delete();
         Passport::authCode()->where($constraint)->delete();

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -39,33 +39,18 @@ class PurgeCommand extends Command
             : false;
 
         Passport::token()->where(function (Builder $query) use ($revoked, $expired) {
-            $query->when($revoked, function ($query) {
-                $query->orWhere('revoked', true);
-            });
-
-            $query->when($expired, function ($query, $expired) {
-                $query->orWhere('expires_at', '<', $expired);
-            });
+            $query->when($revoked, fn (Builder $query) => $query->orWhere('revoked', true));
+            $query->when($expired, fn (Builder $query) => $query->orWhere('expires_at', '<', $expired));
         })->delete();
 
         Passport::authCode()->where(function (Builder $query) use ($revoked, $expired) {
-            $query->when($revoked, function ($query) {
-                $query->orWhere('revoked', true);
-            });
-
-            $query->when($expired, function ($query, $expired) {
-                $query->orWhere('expires_at', '<', $expired);
-            });
+            $query->when($revoked, fn (Builder $query) => $query->orWhere('revoked', true));
+            $query->when($expired, fn (Builder $query) => $query->orWhere('expires_at', '<', $expired));
         })->delete();
 
         Passport::refreshToken()->where(function (Builder $query) use ($revoked, $expired) {
-            $query->when($revoked, function ($query) {
-                $query->orWhere('revoked', true);
-            });
-
-            $query->when($expired, function ($query, $expired) {
-                $query->orWhere('expires_at', '<', $expired);
-            });
+            $query->when($revoked, fn (Builder $query) => $query->orWhere('revoked', true));
+            $query->when($expired, fn (Builder $query) => $query->orWhere('expires_at', '<', $expired));
         })->delete();
 
         $this->components->info(sprintf('Purged %s.', implode(' and ', array_filter([

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -38,20 +38,14 @@ class PurgeCommand extends Command
             ? Carbon::now()->subHours($this->option('hours'))
             : false;
 
-        Passport::token()->where(function (Builder $query) use ($revoked, $expired) {
+        $constraint = function (Builder $query) use ($revoked, $expired) {
             $query->when($revoked, fn () => $query->orWhere('revoked', true))
                 ->when($expired, fn () => $query->orWhere('expires_at', '<', $expired));
-        })->delete();
+        };
 
-        Passport::authCode()->where(function (Builder $query) use ($revoked, $expired) {
-            $query->when($revoked, fn () => $query->orWhere('revoked', true))
-                ->when($expired, fn () => $query->orWhere('expires_at', '<', $expired));
-        })->delete();
-
-        Passport::refreshToken()->where(function (Builder $query) use ($revoked, $expired) {
-            $query->when($revoked, fn () => $query->orWhere('revoked', true))
-                ->when($expired, fn () => $query->orWhere('expires_at', '<', $expired));
-        })->delete();
+        Passport::token()->where($constraint)->delete();
+        Passport::authCode()->where($constraint)->delete();
+        Passport::refreshToken()->where($constraint)->delete();
 
         $this->components->info(sprintf('Purged %s.', implode(' and ', array_filter([
             $revoked ? 'revoked items' : null,

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -39,18 +39,18 @@ class PurgeCommand extends Command
             : false;
 
         Passport::token()->where(function (Builder $query) use ($revoked, $expired) {
-            $query->when($revoked, fn (Builder $query) => $query->orWhere('revoked', true));
-            $query->when($expired, fn (Builder $query) => $query->orWhere('expires_at', '<', $expired));
+            $query->when($revoked, fn () => $query->orWhere('revoked', true))
+                ->when($expired, fn () => $query->orWhere('expires_at', '<', $expired));
         })->delete();
 
         Passport::authCode()->where(function (Builder $query) use ($revoked, $expired) {
-            $query->when($revoked, fn (Builder $query) => $query->orWhere('revoked', true));
-            $query->when($expired, fn (Builder $query) => $query->orWhere('expires_at', '<', $expired));
+            $query->when($revoked, fn () => $query->orWhere('revoked', true))
+                ->when($expired, fn () => $query->orWhere('expires_at', '<', $expired));
         })->delete();
 
         Passport::refreshToken()->where(function (Builder $query) use ($revoked, $expired) {
-            $query->when($revoked, fn (Builder $query) => $query->orWhere('revoked', true));
-            $query->when($expired, fn (Builder $query) => $query->orWhere('expires_at', '<', $expired));
+            $query->when($revoked, fn () => $query->orWhere('revoked', true))
+                ->when($expired, fn () => $query->orWhere('expires_at', '<', $expired));
         })->delete();
 
         $this->components->info(sprintf('Purged %s.', implode(' and ', array_filter([

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -70,7 +70,7 @@ class PurgeCommand extends Command
 
         $this->components->info(sprintf('Purged %s.', implode(' and ', array_filter([
             $revoked ? 'revoked items' : null,
-            $expired ? "items expired {$expired->diffForHumans()}" : null,
+            $expired ? "items expired for more than {$expired->longAbsoluteDiffForHumans()}" : null,
         ]))));
     }
 }

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 use Laravel\Passport\Passport;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -18,7 +19,7 @@ class PurgeCommand extends Command
     protected $signature = 'passport:purge
                             {--revoked : Only purge revoked tokens and authentication codes}
                             {--expired : Only purge expired tokens and authentication codes}
-                            {--hours= : The number of hours to retain expired tokens}';
+                            {--hours=168 : The number of hours to retain expired tokens}';
 
     /**
      * The console command description.
@@ -32,33 +33,44 @@ class PurgeCommand extends Command
      */
     public function handle()
     {
-        $expired = $this->option('hours')
+        $revoked = $this->option('revoked') || ! $this->option('expired');
+        $expired = $this->option('expired') || ! $this->option('revoked')
             ? Carbon::now()->subHours($this->option('hours'))
-            : Carbon::now()->subDays(7);
+            : false;
 
-        if (($this->option('revoked') && $this->option('expired')) ||
-            (! $this->option('revoked') && ! $this->option('expired'))) {
-            Passport::token()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
-            Passport::authCode()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
-            Passport::refreshToken()->where('revoked', 1)->orWhereDate('expires_at', '<', $expired)->delete();
+        Passport::token()->where(function (Builder $query) use ($revoked, $expired) {
+            $query->when($revoked, function ($query) {
+                $query->orWhere('revoked', true);
+            });
 
-            $this->option('hours')
-                ? $this->components->info('Purged revoked items and items expired for more than '.$this->option('hours').' hours.')
-                : $this->components->info('Purged revoked items and items expired for more than seven days.');
-        } elseif ($this->option('revoked')) {
-            Passport::token()->where('revoked', 1)->delete();
-            Passport::authCode()->where('revoked', 1)->delete();
-            Passport::refreshToken()->where('revoked', 1)->delete();
+            $query->when($expired, function ($query, $expired) {
+                $query->orWhere('expires_at', '<', $expired);
+            });
+        })->delete();
 
-            $this->components->info('Purged revoked items.');
-        } elseif ($this->option('expired')) {
-            Passport::token()->whereDate('expires_at', '<', $expired)->delete();
-            Passport::authCode()->whereDate('expires_at', '<', $expired)->delete();
-            Passport::refreshToken()->whereDate('expires_at', '<', $expired)->delete();
+        Passport::authCode()->where(function (Builder $query) use ($revoked, $expired) {
+            $query->when($revoked, function ($query) {
+                $query->orWhere('revoked', true);
+            });
 
-            $this->option('hours')
-                ? $this->components->info('Purged items expired for more than '.$this->option('hours').' hours.')
-                : $this->components->info('Purged items expired for more than seven days.');
-        }
+            $query->when($expired, function ($query, $expired) {
+                $query->orWhere('expires_at', '<', $expired);
+            });
+        })->delete();
+
+        Passport::refreshToken()->where(function (Builder $query) use ($revoked, $expired) {
+            $query->when($revoked, function ($query) {
+                $query->orWhere('revoked', true);
+            });
+
+            $query->when($expired, function ($query, $expired) {
+                $query->orWhere('expires_at', '<', $expired);
+            });
+        })->delete();
+
+        $this->components->info(sprintf('Purged %s.', implode(' and ', array_filter([
+            $revoked ? 'revoked items' : null,
+            $expired ? "items expired {$expired->diffForHumans()}" : null,
+        ]))));
     }
 }

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -34,6 +34,7 @@ class PurgeCommand extends Command
     public function handle()
     {
         $revoked = $this->option('revoked') || ! $this->option('expired');
+
         $expired = $this->option('expired') || ! $this->option('revoked')
             ? Carbon::now()->subHours($this->option('hours'))
             : false;

--- a/tests/Feature/Console/PurgeCommand.php
+++ b/tests/Feature/Console/PurgeCommand.php
@@ -23,7 +23,7 @@ class PurgeCommand extends TestCase
         $this->assertSame([
             'delete from "oauth_access_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
             'delete from "oauth_auth_codes" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
-            'delete from "oauth_refresh_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')'
+            'delete from "oauth_refresh_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
         ], array_column($query, 'query'));
     }
 
@@ -37,7 +37,7 @@ class PurgeCommand extends TestCase
         $this->assertSame([
             'delete from "oauth_access_tokens" where ("revoked" = 1)',
             'delete from "oauth_auth_codes" where ("revoked" = 1)',
-            'delete from "oauth_refresh_tokens" where ("revoked" = 1)'
+            'delete from "oauth_refresh_tokens" where ("revoked" = 1)',
         ], array_column($query, 'query'));
     }
 
@@ -53,7 +53,7 @@ class PurgeCommand extends TestCase
         $this->assertSame([
             'delete from "oauth_access_tokens" where ("expires_at" < \'2000-01-01 00:00:00\')',
             'delete from "oauth_auth_codes" where ("expires_at" < \'2000-01-01 00:00:00\')',
-            'delete from "oauth_refresh_tokens" where ("expires_at" < \'2000-01-01 00:00:00\')'
+            'delete from "oauth_refresh_tokens" where ("expires_at" < \'2000-01-01 00:00:00\')',
         ], array_column($query, 'query'));
     }
 
@@ -69,7 +69,7 @@ class PurgeCommand extends TestCase
         $this->assertSame([
             'delete from "oauth_access_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
             'delete from "oauth_auth_codes" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
-            'delete from "oauth_refresh_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')'
+            'delete from "oauth_refresh_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
         ], array_column($query, 'query'));
     }
 
@@ -86,7 +86,7 @@ class PurgeCommand extends TestCase
         $this->assertSame([
             'delete from "oauth_access_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
             'delete from "oauth_auth_codes" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
-            'delete from "oauth_refresh_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')'
+            'delete from "oauth_refresh_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
         ], array_column($query, 'query'));
     }
 }

--- a/tests/Feature/Console/PurgeCommand.php
+++ b/tests/Feature/Console/PurgeCommand.php
@@ -73,7 +73,6 @@ class PurgeCommand extends TestCase
         ], array_column($query, 'query'));
     }
 
-
     public function test_it_can_purge_tokens_by_hours()
     {
         $this->travelTo(Carbon::create(2000, 1, 1, 2));

--- a/tests/Feature/Console/PurgeCommand.php
+++ b/tests/Feature/Console/PurgeCommand.php
@@ -17,7 +17,7 @@ class PurgeCommand extends TestCase
 
         $query = DB::pretend(function () {
             $this->artisan('passport:purge')
-                ->expectsOutputToContain('Purged revoked items and items expired 1 week ago.');
+                ->expectsOutputToContain('Purged revoked items and items expired for more than 1 week.');
         });
 
         $this->assertSame([
@@ -47,7 +47,7 @@ class PurgeCommand extends TestCase
 
         $query = DB::pretend(function () {
             $this->artisan('passport:purge', ['--expired' => true])
-                ->expectsOutputToContain('Purged items expired 1 week ago.');
+                ->expectsOutputToContain('Purged items expired for more than 1 week.');
         });
 
         $this->assertSame([
@@ -63,7 +63,7 @@ class PurgeCommand extends TestCase
 
         $query = DB::pretend(function () {
             $this->artisan('passport:purge', ['--revoked' => true, '--expired' => true])
-                ->expectsOutputToContain('Purged revoked items and items expired 1 week ago.');
+                ->expectsOutputToContain('Purged revoked items and items expired for more than 1 week.');
         });
 
         $this->assertSame([
@@ -80,7 +80,7 @@ class PurgeCommand extends TestCase
 
         $query = DB::pretend(function () {
             $this->artisan('passport:purge', ['--hours' => 2])
-                ->expectsOutputToContain('Purged revoked items and items expired 2 hours ago.');
+                ->expectsOutputToContain('Purged revoked items and items expired for more than 2 hours.');
         });
 
         $this->assertSame([

--- a/tests/Feature/Console/PurgeCommand.php
+++ b/tests/Feature/Console/PurgeCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Console;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class PurgeCommand extends TestCase
+{
+    use WithWorkbench;
+
+    public function test_it_can_purge_tokens()
+    {
+        $this->travelTo(Carbon::create(2000, 1, 8));
+
+        $query = DB::pretend(function () {
+            $this->artisan('passport:purge')
+                ->expectsOutputToContain('Purged revoked items and items expired 1 week ago.');
+        });
+
+        $this->assertSame([
+            'delete from "oauth_access_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
+            'delete from "oauth_auth_codes" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
+            'delete from "oauth_refresh_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')'
+        ], array_column($query, 'query'));
+    }
+
+    public function test_it_can_purge_revoked_tokens()
+    {
+        $query = DB::pretend(function () {
+            $this->artisan('passport:purge', ['--revoked' => true])
+                ->expectsOutputToContain('Purged revoked items.');
+        });
+
+        $this->assertSame([
+            'delete from "oauth_access_tokens" where ("revoked" = 1)',
+            'delete from "oauth_auth_codes" where ("revoked" = 1)',
+            'delete from "oauth_refresh_tokens" where ("revoked" = 1)'
+        ], array_column($query, 'query'));
+    }
+
+    public function test_it_can_purge_expired_tokens()
+    {
+        $this->travelTo(Carbon::create(2000, 1, 8));
+
+        $query = DB::pretend(function () {
+            $this->artisan('passport:purge', ['--expired' => true])
+                ->expectsOutputToContain('Purged items expired 1 week ago.');
+        });
+
+        $this->assertSame([
+            'delete from "oauth_access_tokens" where ("expires_at" < \'2000-01-01 00:00:00\')',
+            'delete from "oauth_auth_codes" where ("expires_at" < \'2000-01-01 00:00:00\')',
+            'delete from "oauth_refresh_tokens" where ("expires_at" < \'2000-01-01 00:00:00\')'
+        ], array_column($query, 'query'));
+    }
+
+    public function test_it_can_purge_revoked_and_expired_tokens()
+    {
+        $this->travelTo(Carbon::create(2000, 1, 8));
+
+        $query = DB::pretend(function () {
+            $this->artisan('passport:purge', ['--revoked' => true, '--expired' => true])
+                ->expectsOutputToContain('Purged revoked items and items expired 1 week ago.');
+        });
+
+        $this->assertSame([
+            'delete from "oauth_access_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
+            'delete from "oauth_auth_codes" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
+            'delete from "oauth_refresh_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')'
+        ], array_column($query, 'query'));
+    }
+
+
+    public function test_it_can_purge_tokens_by_hours()
+    {
+        $this->travelTo(Carbon::create(2000, 1, 1, 2));
+
+        $query = DB::pretend(function () {
+            $this->artisan('passport:purge', ['--hours' => 2])
+                ->expectsOutputToContain('Purged revoked items and items expired 2 hours ago.');
+        });
+
+        $this->assertSame([
+            'delete from "oauth_access_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
+            'delete from "oauth_auth_codes" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')',
+            'delete from "oauth_refresh_tokens" where ("revoked" = 1 or "expires_at" < \'2000-01-01 00:00:00\')'
+        ], array_column($query, 'query'));
+    }
+}


### PR DESCRIPTION
Fixes #1770

The `passport:purge` command was not working properly with `--hours` option. This PR fixes this and adds some tests for the command. 