### PR TITLE
[13.x] Fix user-token relations

### DIFF
--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -65,10 +65,10 @@ class PersonalAccessTokenFactory
      * @param  mixed  $userId
      * @param  string  $name
      * @param  string[]  $scopes
-     * @param  string|null  $provider
+     * @param  string  $provider
      * @return \Laravel\Passport\PersonalAccessTokenResult
      */
-    public function make($userId, string $name, array $scopes = [], ?string $provider = null)
+    public function make($userId, string $name, array $scopes, string $provider)
     {
         $response = $this->dispatchRequestToAuthorizationServer(
             $this->createRequest($userId, $scopes, $provider)
@@ -91,14 +91,12 @@ class PersonalAccessTokenFactory
      *
      * @param  mixed  $userId
      * @param  string[]  $scopes
-     * @param  string|null  $provider
+     * @param  string  $provider
      * @return \Psr\Http\Message\ServerRequestInterface
      */
-    protected function createRequest($userId, array $scopes, ?string $provider)
+    protected function createRequest($userId, array $scopes, string $provider)
     {
-        $config = $provider
-            ? config("passport.personal_access_client.$provider", config('passport.personal_access_client'))
-            : config('passport.personal_access_client');
+        $config = config("passport.personal_access_client.$provider", config('passport.personal_access_client'));
 
         $client = isset($config['id']) ? $this->clients->findActive($config['id']) : null;
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -68,11 +68,13 @@ class Token extends Model
     /**
      * Get the user that the token belongs to.
      *
+     * @deprecated Will be removed in a future Laravel version.
+     *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function user()
     {
-        $provider = config('auth.guards.api.provider');
+        $provider = $this->client->provider ?: config('auth.guards.api.provider');
 
         $model = config('auth.providers.'.$provider.'.model');
 

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -145,7 +145,7 @@ class AccessTokenControllerTest extends PassportTestCase
         $token = $this->app->make(PersonalAccessTokenFactory::class)->findAccessToken($decodedResponse);
         $this->assertInstanceOf(Token::class, $token);
         $this->assertFalse($token->revoked);
-        $this->assertTrue($token->user->is($user));
+        $this->assertSame($user->getAuthIdentifier(), $token->user_id);
         $this->assertTrue($token->client->is($client));
         $this->assertNull($token->name);
         $this->assertLessThanOrEqual(5, CarbonImmutable::now()->addSeconds($expiresInSeconds)->diffInSeconds($token->expires_at));

--- a/tests/Feature/HasApiTokensTest.php
+++ b/tests/Feature/HasApiTokensTest.php
@@ -16,7 +16,7 @@ class HasApiTokensTest extends PassportTestCase
         config([
             'auth.providers.admins' => ['driver' => 'eloquent', 'model' => AdminHasApiTokensStub::class],
             'auth.guards.api-admins' => ['driver' => 'passport', 'provider' => 'admins'],
-            'auth.providers.customers' => ['driver' => 'database', 'table' => 'customer_has_api_tokens_stubs'],
+            'auth.providers.customers' => ['driver' => 'eloquent', 'model' => CustomerHasApiTokensStub::class],
             'auth.guards.api-customers' => ['driver' => 'passport', 'provider' => 'customers'],
         ]);
 


### PR DESCRIPTION
1.  `$user->getProviders()` has been added recently on PR #1768, this method actually must not return `null` in a healthy environment / configuration. Also, it is not possible to use Passport with a `database` provider. This PR fixes these 2 situations on this method.
2. The relation between the authenticable model (`User` model by default) and `Token` model depends on the client's `provider`. This PR makes sure we are retrieving the tokens associated with the right authenticable model and adds integration tests for this.
   - Note: On Sanctum [`user->tokens()` relation is morphable](https://github.com/laravel/sanctum/blob/3f57a4cd069ad9442ab2082ffafa4f4186e41ce8/src/HasApiTokens.php#L22-L25), so we know which model is the owner of the key, on Passport we should check the client's `provider` to know which model is the owner of the key.