### PR TITLE
[12.x] Add access token revoked event

### DIFF
--- a/src/Bridge/AccessTokenRepository.php
+++ b/src/Bridge/AccessTokenRepository.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport\Bridge;
 use DateTime;
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Passport\Events\AccessTokenCreated;
+use Laravel\Passport\Events\AccessTokenRevoked;
 use Laravel\Passport\Passport;
 use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
@@ -78,7 +79,9 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      */
     public function revokeAccessToken($tokenId)
     {
-        $this->tokenRepository->revokeAccessToken($tokenId);
+        if ($this->tokenRepository->revokeAccessToken($tokenId)) {
+            $this->events->dispatch(new AccessTokenRevoked($tokenId));
+        }
     }
 
     /**

--- a/src/Events/AccessTokenRevoked.php
+++ b/src/Events/AccessTokenRevoked.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Passport\Events;
+
+class AccessTokenRevoked
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $tokenId
+     * @return void
+     */
+    public function __construct(
+        public string $tokenId,
+    ) {
+    }
+}

--- a/tests/Unit/BridgeAccessTokenRepositoryTest.php
+++ b/tests/Unit/BridgeAccessTokenRepositoryTest.php
@@ -49,6 +49,34 @@ class BridgeAccessTokenRepositoryTest extends TestCase
         $repository->persistNewAccessToken($accessToken);
     }
 
+    public function test_access_tokens_can_be_revoked()
+    {
+        $tokenRepository = m::mock(TokenRepository::class);
+        $events = m::mock(Dispatcher::class);
+
+        $tokenRepository->shouldReceive('revokeAccessToken')->with('token-id')->once()->andReturn(1);
+        $events->shouldReceive('dispatch')->once();
+
+        $repository = new AccessTokenRepository($tokenRepository, $events);
+        $repository->revokeAccessToken('token-id');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function test_access_token_revoke_event_is_not_dispatched_when_nothing_happened()
+    {
+        $tokenRepository = m::mock(TokenRepository::class);
+        $events = m::mock(Dispatcher::class);
+
+        $tokenRepository->shouldReceive('revokeAccessToken')->with('token-id')->once()->andReturn(0);
+        $events->shouldNotReceive('dispatch');
+
+        $repository = new AccessTokenRepository($tokenRepository, $events);
+        $repository->revokeAccessToken('token-id');
+
+        $this->expectNotToPerformAssertions();
+    }
+
     public function test_can_get_new_access_token()
     {
         $tokenRepository = m::mock(TokenRepository::class);


### PR DESCRIPTION
This PR adds an event when Passport revokes an access token. This is implemented in the same way as the access token creation event.