### PR TITLE
[13.x] Fix skipping consent prompt

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -163,9 +164,9 @@ class Client extends Model
     /**
      * Determine if the client should skip the authorization prompt.
      *
-     * @return bool
+     * @param  \Laravel\Passport\Scope[]  $scopes
      */
-    public function skipsAuthorization()
+    public function skipsAuthorization(Authenticatable $user, array $scopes): bool
     {
         return false;
     }

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -140,8 +140,8 @@ class AuthorizationController
     protected function hasGrantedScopes($user, $client, $scopes)
     {
         return collect($scopes)->pluck('id')->diff(
-            $user->tokens()->where([
-                ['client_id', '=', $client->getKey()],
+            $client->tokens()->where([
+                ['user_id', '=', $user->getAuthIdentifier()],
                 ['revoked', '=', false],
                 ['expires_at', '>', Date::now()],
             ])->pluck('scopes')->flatten()

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -94,7 +94,7 @@ class AuthorizationController
         $client = $clients->find($authRequest->getClient()->getIdentifier());
 
         if ($request->get('prompt') !== 'consent' &&
-            ($client->skipsAuthorization($user, $scopes) || $this->hasConsent($user, $client, $scopes))) {
+            ($client->skipsAuthorization($user, $scopes) || $this->hasGrantedScopes($user, $client, $scopes))) {
             return $this->approveRequest($authRequest, $user);
         }
 
@@ -130,14 +130,14 @@ class AuthorizationController
     }
 
     /**
-     * Determine if the given user has already consented the scopes for the client.
+     * Determine if the given user has already granted the client access to the scopes.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Laravel\Passport\Client  $client
      * @param  array  $scopes
      * @return bool
      */
-    protected function hasConsent($user, $client, $scopes)
+    protected function hasGrantedScopes($user, $client, $scopes)
     {
         return collect($scopes)->pluck('id')
             ->diff($user->tokens()

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -64,7 +64,6 @@ class AuthorizationController
      * @param  \Psr\Http\Message\ServerRequestInterface  $psrRequest
      * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Passport\ClientRepository  $clients
-     * @param  \Laravel\Passport\TokenRepository  $tokens
      * @return \Illuminate\Http\Response|\Laravel\Passport\Contracts\AuthorizationViewResponse
      */
     public function authorize(ServerRequestInterface $psrRequest, Request $request, ClientRepository $clients)

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -139,14 +139,13 @@ class AuthorizationController
      */
     protected function hasGrantedScopes($user, $client, $scopes)
     {
-        return collect($scopes)->pluck('id')
-            ->diff($user->tokens()
-                ->where('client_id', $client->getKey())
-                ->where('revoked', false)
-                ->where('expires_at', '>', Date::now())
-                ->pluck('scopes')
-                ->flatten()
-            )->isEmpty();
+        return collect($scopes)->pluck('id')->diff(
+            $user->tokens()->where([
+                ['client_id', '=', $client->getKey()],
+                ['revoked', '=', false],
+                ['expires_at', '>', Date::now()],
+            ])->pluck('scopes')->flatten()
+        )->isEmpty();
     }
 
     /**

--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -4,13 +4,13 @@ namespace Laravel\Passport\Http\Controllers;
 
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Laravel\Passport\Bridge\User;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Contracts\AuthorizationViewResponse;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Passport;
-use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Nyholm\Psr7\Response as Psr7Response;
@@ -67,10 +67,7 @@ class AuthorizationController
      * @param  \Laravel\Passport\TokenRepository  $tokens
      * @return \Illuminate\Http\Response|\Laravel\Passport\Contracts\AuthorizationViewResponse
      */
-    public function authorize(ServerRequestInterface $psrRequest,
-                              Request $request,
-                              ClientRepository $clients,
-                              TokenRepository $tokens)
+    public function authorize(ServerRequestInterface $psrRequest, Request $request, ClientRepository $clients)
     {
         $authRequest = $this->withErrorHandling(function () use ($psrRequest) {
             return $this->server->validateAuthorizationRequest($psrRequest);
@@ -78,8 +75,8 @@ class AuthorizationController
 
         if ($this->guard->guest()) {
             return $request->get('prompt') === 'none'
-                    ? $this->denyRequest($authRequest)
-                    : $this->promptForLogin($request);
+                ? $this->denyRequest($authRequest)
+                : $this->promptForLogin($request);
         }
 
         if ($request->get('prompt') === 'login' &&
@@ -98,7 +95,7 @@ class AuthorizationController
         $client = $clients->find($authRequest->getClient()->getIdentifier());
 
         if ($request->get('prompt') !== 'consent' &&
-            ($client->skipsAuthorization() || $this->hasValidToken($tokens, $user, $client, $scopes))) {
+            ($client->skipsAuthorization($user, $scopes) || $this->hasConsent($user, $client, $scopes))) {
             return $this->approveRequest($authRequest, $user);
         }
 
@@ -134,19 +131,23 @@ class AuthorizationController
     }
 
     /**
-     * Determine if a valid token exists for the given user, client, and scopes.
+     * Determine if the given user has already consented the scopes for the client.
      *
-     * @param  \Laravel\Passport\TokenRepository  $tokens
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  \Laravel\Passport\Client  $client
      * @param  array  $scopes
      * @return bool
      */
-    protected function hasValidToken($tokens, $user, $client, $scopes)
+    protected function hasConsent($user, $client, $scopes)
     {
-        $token = $tokens->findValidToken($user, $client);
-
-        return $token && $token->scopes === collect($scopes)->pluck('id')->all();
+        return collect($scopes)->pluck('id')
+            ->diff($user->tokens()
+                ->where('client_id', $client->getKey())
+                ->where('revoked', false)
+                ->where('expires_at', '>', Date::now())
+                ->pluck('scopes')
+                ->flatten()
+            )->isEmpty();
     }
 
     /**

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -59,9 +59,9 @@ class AuthorizationControllerTest extends TestCase
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
-        $client->shouldReceive('getKey')->andReturn(1);
+        $client->shouldReceive('tokens->where->pluck->flatten')->andReturn(collect());
 
-        $user->shouldReceive('tokens->where->pluck->flatten')->andReturn(collect());
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
 
         $response->shouldReceive('withParameters')->once()->andReturnUsing(function ($data) use ($client, $user, $request) {
             $this->assertEquals($client, $data['client']);
@@ -139,8 +139,7 @@ class AuthorizationControllerTest extends TestCase
 
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
         $client->shouldReceive('getKey')->andReturn(1);
-
-        $user->shouldReceive('tokens->where->pluck->flatten')->andReturn(collect(['scope-1']));
+        $client->shouldReceive('tokens->where->pluck->flatten')->andReturn(collect(['scope-1']));
 
         $this->assertSame('approved', $controller->authorize(
             m::mock(ServerRequestInterface::class), $request, $clients
@@ -276,8 +275,7 @@ class AuthorizationControllerTest extends TestCase
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
         $client->shouldReceive('getKey')->andReturn(1);
-
-        $user->shouldReceive('tokens->where->pluck->flatten')->andReturn(collect());
+        $client->shouldReceive('tokens->where->pluck->flatten')->andReturn(collect());
 
         $controller->authorize(
             m::mock(ServerRequestInterface::class), $request, $clients

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Passport\Tests\Unit;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Laravel\Passport\Bridge\Scope;
@@ -12,8 +13,6 @@ use Laravel\Passport\Exceptions\OAuthServerException;
 use Laravel\Passport\Http\Controllers\AuthorizationController;
 use Laravel\Passport\Http\Responses\AuthorizationViewResponse;
 use Laravel\Passport\Passport;
-use Laravel\Passport\Token;
-use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException as LeagueException;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
@@ -44,7 +43,7 @@ class AuthorizationControllerTest extends TestCase
         $controller = new AuthorizationController($server, $guard, $response);
 
         $guard->shouldReceive('guest')->andReturn(false);
-        $guard->shouldReceive('user')->andReturn($user = m::mock());
+        $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
         $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest = m::mock(AuthorizationRequestInterface::class));
 
         $request = m::mock(Request::class);
@@ -60,9 +59,9 @@ class AuthorizationControllerTest extends TestCase
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
+        $client->shouldReceive('getKey')->andReturn(1);
 
-        $tokens = m::mock(TokenRepository::class);
-        $tokens->shouldReceive('findValidToken')->with($user, $client)->andReturnNull();
+        $user->shouldReceive('tokens->where->where->where->pluck->flatten')->andReturn(collect());
 
         $response->shouldReceive('withParameters')->once()->andReturnUsing(function ($data) use ($client, $user, $request) {
             $this->assertEquals($client, $data['client']);
@@ -74,7 +73,7 @@ class AuthorizationControllerTest extends TestCase
         });
 
         $this->assertSame('view', $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request, $clients, $tokens
+            m::mock(ServerRequestInterface::class), $request, $clients
         ));
     }
 
@@ -93,12 +92,11 @@ class AuthorizationControllerTest extends TestCase
         $request->shouldReceive('session')->andReturn($session = m::mock());
 
         $clients = m::mock(ClientRepository::class);
-        $tokens = m::mock(TokenRepository::class);
 
         $this->expectException(OAuthServerException::class);
 
         $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request, $clients, $tokens
+            m::mock(ServerRequestInterface::class), $request, $clients
         );
     }
 
@@ -115,7 +113,7 @@ class AuthorizationControllerTest extends TestCase
         $controller = new AuthorizationController($server, $guard, $response);
 
         $guard->shouldReceive('guest')->andReturn(false);
-        $guard->shouldReceive('user')->andReturn($user = m::mock());
+        $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
         $psrResponse = new Response();
         $psrResponse->getBody()->write('approved');
         $server->shouldReceive('validateAuthorizationRequest')
@@ -140,15 +138,12 @@ class AuthorizationControllerTest extends TestCase
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
 
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
+        $client->shouldReceive('getKey')->andReturn(1);
 
-        $tokens = m::mock(TokenRepository::class);
-        $tokens->shouldReceive('findValidToken')
-            ->with($user, $client)
-            ->andReturn($token = m::mock(Token::class));
-        $token->shouldReceive('getAttribute')->with('scopes')->andReturn(['scope-1']);
+        $user->shouldReceive('tokens->where->where->where->pluck->flatten')->andReturn(collect(['scope-1']));
 
         $this->assertSame('approved', $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request, $clients, $tokens
+            m::mock(ServerRequestInterface::class), $request, $clients
         )->getContent());
     }
 
@@ -165,7 +160,7 @@ class AuthorizationControllerTest extends TestCase
         $controller = new AuthorizationController($server, $guard, $response);
 
         $guard->shouldReceive('guest')->andReturn(false);
-        $guard->shouldReceive('user')->andReturn($user = m::mock());
+        $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
         $psrResponse = new Response();
         $psrResponse->getBody()->write('approved');
         $server->shouldReceive('validateAuthorizationRequest')
@@ -191,13 +186,10 @@ class AuthorizationControllerTest extends TestCase
 
         $client->shouldReceive('skipsAuthorization')->andReturn(true);
 
-        $tokens = m::mock(TokenRepository::class);
-        $tokens->shouldReceive('findValidToken')
-            ->with($user, $client)
-            ->andReturnNull();
+        $user->shouldReceive('tokens->where->where->where->pluck->flatten')->andReturn(collect());
 
         $this->assertSame('approved', $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request, $clients, $tokens
+            m::mock(ServerRequestInterface::class), $request, $clients
         )->getContent());
     }
 
@@ -232,9 +224,6 @@ class AuthorizationControllerTest extends TestCase
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
 
-        $tokens = m::mock(TokenRepository::class);
-        $tokens->shouldNotReceive('findValidToken');
-
         $response->shouldReceive('withParameters')->once()->andReturnUsing(function ($data) use ($client, $user, $request) {
             $this->assertEquals($client, $data['client']);
             $this->assertEquals($user, $data['user']);
@@ -245,7 +234,7 @@ class AuthorizationControllerTest extends TestCase
         });
 
         $this->assertSame('view', $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request, $clients, $tokens
+            m::mock(ServerRequestInterface::class), $request, $clients
         ));
     }
 
@@ -264,7 +253,7 @@ class AuthorizationControllerTest extends TestCase
         $controller = new AuthorizationController($server, $guard, $response);
 
         $guard->shouldReceive('guest')->andReturn(false);
-        $guard->shouldReceive('user')->andReturn($user = m::mock());
+        $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
         $server->shouldReceive('validateAuthorizationRequest')
             ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
         $server->shouldReceive('completeAuthorizationRequest')
@@ -288,14 +277,12 @@ class AuthorizationControllerTest extends TestCase
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
+        $client->shouldReceive('getKey')->andReturn(1);
 
-        $tokens = m::mock(TokenRepository::class);
-        $tokens->shouldReceive('findValidToken')
-            ->with($user, $client)
-            ->andReturnNull();
+        $user->shouldReceive('tokens->where->where->where->pluck->flatten')->andReturn(collect());
 
         $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request, $clients, $tokens
+            m::mock(ServerRequestInterface::class), $request, $clients
         );
     }
 
@@ -324,11 +311,10 @@ class AuthorizationControllerTest extends TestCase
         $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
 
         $clients = m::mock(ClientRepository::class);
-        $tokens = m::mock(TokenRepository::class);
 
         try {
             $controller->authorize(
-                m::mock(ServerRequestInterface::class), $request, $clients, $tokens
+                m::mock(ServerRequestInterface::class), $request, $clients
             );
         } catch (\Laravel\Passport\Exceptions\OAuthServerException $e) {
             $this->assertStringStartsWith(
@@ -362,10 +348,9 @@ class AuthorizationControllerTest extends TestCase
         $request->shouldReceive('get')->with('prompt')->andReturn('login');
 
         $clients = m::mock(ClientRepository::class);
-        $tokens = m::mock(TokenRepository::class);
 
         $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request, $clients, $tokens
+            m::mock(ServerRequestInterface::class), $request, $clients
         );
     }
 
@@ -390,10 +375,9 @@ class AuthorizationControllerTest extends TestCase
         $request->shouldReceive('get')->with('prompt')->andReturn(null);
 
         $clients = m::mock(ClientRepository::class);
-        $tokens = m::mock(TokenRepository::class);
 
         $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request, $clients, $tokens
+            m::mock(ServerRequestInterface::class), $request, $clients
         );
     }
 }

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -61,7 +61,7 @@ class AuthorizationControllerTest extends TestCase
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
         $client->shouldReceive('getKey')->andReturn(1);
 
-        $user->shouldReceive('tokens->where->where->where->pluck->flatten')->andReturn(collect());
+        $user->shouldReceive('tokens->where->pluck->flatten')->andReturn(collect());
 
         $response->shouldReceive('withParameters')->once()->andReturnUsing(function ($data) use ($client, $user, $request) {
             $this->assertEquals($client, $data['client']);
@@ -140,7 +140,7 @@ class AuthorizationControllerTest extends TestCase
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
         $client->shouldReceive('getKey')->andReturn(1);
 
-        $user->shouldReceive('tokens->where->where->where->pluck->flatten')->andReturn(collect(['scope-1']));
+        $user->shouldReceive('tokens->where->pluck->flatten')->andReturn(collect(['scope-1']));
 
         $this->assertSame('approved', $controller->authorize(
             m::mock(ServerRequestInterface::class), $request, $clients
@@ -185,8 +185,6 @@ class AuthorizationControllerTest extends TestCase
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
 
         $client->shouldReceive('skipsAuthorization')->andReturn(true);
-
-        $user->shouldReceive('tokens->where->where->where->pluck->flatten')->andReturn(collect());
 
         $this->assertSame('approved', $controller->authorize(
             m::mock(ServerRequestInterface::class), $request, $clients
@@ -279,7 +277,7 @@ class AuthorizationControllerTest extends TestCase
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
         $client->shouldReceive('getKey')->andReturn(1);
 
-        $user->shouldReceive('tokens->where->where->where->pluck->flatten')->andReturn(collect());
+        $user->shouldReceive('tokens->where->pluck->flatten')->andReturn(collect());
 
         $controller->authorize(
             m::mock(ServerRequestInterface::class), $request, $clients


### PR DESCRIPTION
Fixes #899

As [stated on the docs](https://laravel.com/docs/10.x/passport#:~:text=If%20no,the%20requested%20scopes.), we skip the auth prompt if the user previously authorized access to the consuming application for the requested scopes. However, the current implementation checks the scopes of the latest valid token only, not all the previously granted scopes.

This PR does:
* Fix implementation of skipping authorization screen.
* Pass user and scopes to `Client::skipsAuthorization()` method.

