### PR TITLE
[13.x] Improve issuing PATs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -53,13 +53,13 @@ When authenticating users via bearer tokens, the `User` model's `token` method n
 
 ### Personal Access Client Table and Model Removal
 
-PR: https://github.com/laravel/passport/pull/1749
+PR: https://github.com/laravel/passport/pull/1749, https://github.com/laravel/passport/pull/1780
 
 Passport's `oauth_personal_access_clients` table has been redundant and unnecessary for several release cycles. Therefore, this release of Passport no longer interacts with this table or its corresponding model. If you wish, you may create a migration that drops this table:
 
     Schema::drop('oauth_personal_access_clients');
 
-In addition, the `Laravel\Passport\PersonalAccessClient` model, `Passport::$personalAccessClientModel` property, `Passport::usePersonalAccessClientModel()`, `Passport::personalAccessClientModel()`, and `Passport::personalAccessClient()` methods have been removed.
+In addition, the `passport.personal_access_client` config property, `Laravel\Passport\PersonalAccessClient` model, `Passport::$personalAccessClientModel` property, `Passport::usePersonalAccessClientModel()`, `Passport::personalAccessClientModel()`, and `Passport::personalAccessClient()` methods have been removed.
 
 ## Upgrading To 12.0 From 11.x
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -59,7 +59,7 @@ Passport's `oauth_personal_access_clients` table has been redundant and unnecess
 
     Schema::drop('oauth_personal_access_clients');
 
-In addition, the `passport.personal_access_client` config property, `Laravel\Passport\PersonalAccessClient` model, `Passport::$personalAccessClientModel` property, `Passport::usePersonalAccessClientModel()`, `Passport::personalAccessClientModel()`, and `Passport::personalAccessClient()` methods have been removed.
+In addition, the `passport.personal_access_client` configuration value, `Laravel\Passport\PersonalAccessClient` model, `Passport::$personalAccessClientModel` property, `Passport::usePersonalAccessClientModel()`, `Passport::personalAccessClientModel()`, and `Passport::personalAccessClient()` methods have been removed.
 
 ## Upgrading To 12.0 From 11.x
 

--- a/config/passport.php
+++ b/config/passport.php
@@ -43,20 +43,4 @@ return [
 
     'connection' => env('PASSPORT_CONNECTION'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Personal Access Client
-    |--------------------------------------------------------------------------
-    |
-    | If you enable client hashing, you should set the personal access client
-    | ID and unhashed secret within your environment file. The values will
-    | get used while issuing fresh personal access tokens to your users.
-    |
-    */
-
-    'personal_access_client' => [
-        'id' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_ID'),
-        'secret' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET'),
-    ],
-
 ];

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -73,6 +73,16 @@ class ClientRepository implements ClientRepositoryInterface
     }
 
     /**
+     * Get the personal access client for the given provider.
+     */
+    public function getPersonalAccessClientEntity(string $provider): ?ClientEntityInterface
+    {
+        return $this->fromClientModel(
+            $this->clients->personalAccessClient($provider)
+        );
+    }
+
+    /**
      * Create a new client entity from the given client model instance.
      */
     protected function fromClientModel(ClientModel $model): ClientEntityInterface
@@ -83,16 +93,6 @@ class ClientRepository implements ClientRepositoryInterface
             $model->redirect_uris,
             $model->confidential(),
             $model->provider
-        );
-    }
-
-    /**
-     * Get the personal access client for the given provider.
-     */
-    public function getPersonalAccessClientEntity(string $provider): ?ClientEntityInterface
-    {
-        return $this->fromClientModel(
-            $this->clients->personalAccessClient($provider)
         );
     }
 }

--- a/src/Bridge/ClientRepository.php
+++ b/src/Bridge/ClientRepository.php
@@ -36,17 +36,7 @@ class ClientRepository implements ClientRepositoryInterface
     {
         $record = $this->clients->findActive($clientIdentifier);
 
-        if (! $record) {
-            return null;
-        }
-
-        return new Client(
-            $clientIdentifier,
-            $record->name,
-            $record->redirect_uris,
-            $record->confidential(),
-            $record->provider
-        );
+        return $record ? $this->fromClientModel($record) : null;
     }
 
     /**
@@ -80,5 +70,29 @@ class ClientRepository implements ClientRepositoryInterface
     protected function verifySecret(string $clientSecret, string $storedHash): bool
     {
         return $this->hasher->check($clientSecret, $storedHash);
+    }
+
+    /**
+     * Create a new client entity from the given client model instance.
+     */
+    protected function fromClientModel(ClientModel $model): ClientEntityInterface
+    {
+        return new Client(
+            $model->getKey(),
+            $model->name,
+            $model->redirect_uris,
+            $model->confidential(),
+            $model->provider
+        );
+    }
+
+    /**
+     * Get the personal access client for the given provider.
+     */
+    public function getPersonalAccessClientEntity(string $provider): ?ClientEntityInterface
+    {
+        return $this->fromClientModel(
+            $this->clients->personalAccessClient($provider)
+        );
     }
 }

--- a/src/Bridge/PersonalAccessGrant.php
+++ b/src/Bridge/PersonalAccessGrant.php
@@ -5,7 +5,6 @@ namespace Laravel\Passport\Bridge;
 use DateInterval;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\AbstractGrant;
-use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -20,20 +19,17 @@ class PersonalAccessGrant extends AbstractGrant
         DateInterval $accessTokenTTL
     ): ResponseTypeInterface {
         // Validate request
-        $client = $this->validateClient($request);
-
-        if (! $client->isConfidential()) {
-            $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
-
-            throw OAuthServerException::invalidClient($request);
-        }
-
-        $scopes = $this->validateScopes($this->getRequestParameter('scope', $request, $this->defaultScope));
-        $userIdentifier = $this->getRequestParameter('user_id', $request);
-
-        if (! $userIdentifier) {
+        if (! $userIdentifier = $this->getRequestParameter('user_id', $request)) {
             throw OAuthServerException::invalidRequest('user_id');
         }
+
+        if (! $provider = $this->getRequestParameter('provider', $request)) {
+            throw OAuthServerException::invalidRequest('provider');
+        }
+
+        $client = $this->clientRepository->getPersonalAccessClientEntity($provider);
+
+        $scopes = $this->validateScopes($this->getRequestParameter('scope', $request, $this->defaultScope));
 
         // Finalize the requested scopes
         $scopes = $this->scopeRepository->finalizeScopes(

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -68,19 +68,13 @@ class ClientCommand extends Command
 
         $provider = $this->option('provider') ?: $this->choice(
             'Which user provider should this client use to retrieve users?',
-            array_keys(config('auth.providers')),
+            collect(config('auth.guards'))->where('driver', 'passport')->pluck('provider')->all(),
             config('auth.guards.api.provider')
         );
 
-        $client = $clients->createPersonalAccessGrantClient($name, $provider);
+        $clients->createPersonalAccessGrantClient($name, $provider);
 
         $this->components->info('Personal access client created successfully.');
-
-        if (! config('passport.personal_access_client')) {
-            $this->components->info('Next, define the `PASSPORT_PERSONAL_ACCESS_CLIENT_ID` and `PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET` environment variables using the values below.');
-        }
-
-        $this->outputClientDetails($client);
     }
 
     /**
@@ -98,7 +92,7 @@ class ClientCommand extends Command
 
         $provider = $this->option('provider') ?: $this->choice(
             'Which user provider should this client use to retrieve users?',
-            array_keys(config('auth.providers')),
+            collect(config('auth.guards'))->where('driver', 'passport')->pluck('provider')->all(),
             config('auth.guards.api.provider')
         );
 

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -269,49 +269,6 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertArrayHasKey('id_token', $decodedResponse);
         $this->assertSame('foo_bar_open_id_token', $decodedResponse['id_token']);
     }
-
-    public function testPersonalAccessTokenRequestIsDisabled()
-    {
-        $user = UserFactory::new()->create([
-            'email' => 'foo@gmail.com',
-            'password' => $this->app->make(Hasher::class)->make('foobar123'),
-        ]);
-
-        /** @var Client $client */
-        $client = ClientFactory::new()->asPersonalAccessTokenClient()->create();
-
-        config([
-            'passport.personal_access_client.id' => $client->getKey(),
-            'passport.personal_access_client.secret' => $client->plainSecret,
-        ]);
-
-        $response = $this->post(
-            '/oauth/token',
-            [
-                'grant_type' => 'personal_access',
-                'client_id' => $client->getKey(),
-                'client_secret' => $client->plainSecret,
-                'user_id' => $user->getKey(),
-                'scope' => '',
-            ]
-        );
-
-        $response->assertStatus(400);
-
-        $decodedResponse = $response->decodeResponseJson()->json();
-
-        $this->assertArrayNotHasKey('token_type', $decodedResponse);
-        $this->assertArrayNotHasKey('expires_in', $decodedResponse);
-        $this->assertArrayNotHasKey('access_token', $decodedResponse);
-
-        $this->assertArrayHasKey('error', $decodedResponse);
-        $this->assertSame('unsupported_grant_type', $decodedResponse['error']);
-        $this->assertArrayHasKey('error_description', $decodedResponse);
-
-        $token = $user->createToken('test');
-
-        $this->assertInstanceOf(\Laravel\Passport\PersonalAccessTokenResult::class, $token);
-    }
 }
 
 class IdTokenResponse extends \League\OAuth2\Server\ResponseTypes\BearerTokenResponse

--- a/tests/Unit/BridgeClientRepositoryTest.php
+++ b/tests/Unit/BridgeClientRepositoryTest.php
@@ -210,6 +210,7 @@ class BridgeClientRepositoryTest extends TestCase
 class BridgeClientRepositoryTestClientStub extends \Laravel\Passport\Client
 {
     protected $attributes = [
+        'id' => 1,
         'name' => 'Client',
         'redirect_uris' => '["http://localhost"]',
         'secret' => '$2y$10$WgqU4wQpfsARCIQk.nPSOOiNkrMpPVxQiLCFUt8comvQwh1z6WFMG',


### PR DESCRIPTION
This PR improves issuing personal access tokens:
* Reduces number of queries to retrieve the client from the DB from 3 to 1.
* Removes the necessity of redeclaring client credentials on `passport.personal_access_client` config property and environment variables for each user provider.
* Reorganizes personal access grant feature tests.
* Fully backward compatible and no upgrading steps is needed.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
  <td>

1. Create a client using `passport:client --personal` for each user provider.
1. Set client credentials on `passport.personal_access_token` config property [for each user provider](https://github.com/laravel/passport/pull/1768#issuecomment-2210487903).
1. Issue access token using `$user->createToken()`.
   1. Get client credentials for the given user provider from config.
   1. Retrieve the client from DB and validate provider.
   1. Pass `client_id`, `client_secret` and `user_id` to the grant.
   1. Retrieve the client from DB to validate the secret.
   1. Retrieve the client from DB to issue the token.

  </td>
  <td>

1. Create a client using `passport:client --personal` for each user provider.
1. Issue access token using `$user->createToken()`.
   1. Pass `provider` and `user_id` to the grant.
   1. Retrieve the client from DB for the given provider to issue the token.
 
</td>
</tr>
</table>
