### PR TITLE
retrieve primary key identifier in AuthCodeRepository & TokenRepository

### DIFF
--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -40,7 +40,7 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function revokeAuthCode($codeId)
     {
-        Passport::authCode()->where(Passport::authCode()->getKeyName(), $codeId)->update(['revoked' => true]);
+        Passport::authCode()->whereKey($codeId)->update(['revoked' => true]);
     }
 
     /**
@@ -48,6 +48,6 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function isAuthCodeRevoked($codeId)
     {
-        return Passport::authCode()->where(Passport::authCode()->getKeyName(), $codeId)->where('revoked', 1)->exists();
+        return Passport::authCode()->whereKey($codeId)->where('revoked', 1)->exists();
     }
 }

--- a/src/Bridge/AuthCodeRepository.php
+++ b/src/Bridge/AuthCodeRepository.php
@@ -40,7 +40,7 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function revokeAuthCode($codeId)
     {
-        Passport::authCode()->where('id', $codeId)->update(['revoked' => true]);
+        Passport::authCode()->where(Passport::authCode()->getKeyName(), $codeId)->update(['revoked' => true]);
     }
 
     /**
@@ -48,6 +48,6 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function isAuthCodeRevoked($codeId)
     {
-        return Passport::authCode()->where('id', $codeId)->where('revoked', 1)->exists();
+        return Passport::authCode()->where(Passport::authCode()->getKeyName(), $codeId)->where('revoked', 1)->exists();
     }
 }

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -25,7 +25,7 @@ class TokenRepository
      */
     public function find($id)
     {
-        return Passport::token()->where(Passport::token()->getKeyName(), $id)->first();
+        return Passport::token()->whereKey($id)->first();
     }
 
     /**
@@ -37,7 +37,7 @@ class TokenRepository
      */
     public function findForUser($id, $userId)
     {
-        return Passport::token()->where(Passport::token()->getKeyName(), $id)->where('user_id', $userId)->first();
+        return Passport::token()->whereKey($id)->where('user_id', $userId)->first();
     }
 
     /**
@@ -86,7 +86,7 @@ class TokenRepository
      */
     public function revokeAccessToken($id)
     {
-        return Passport::token()->where(Passport::token()->getKeyName(), $id)->update(['revoked' => true]);
+        return Passport::token()->whereKey($id)->update(['revoked' => true]);
     }
 
     /**

--- a/src/TokenRepository.php
+++ b/src/TokenRepository.php
@@ -25,7 +25,7 @@ class TokenRepository
      */
     public function find($id)
     {
-        return Passport::token()->where('id', $id)->first();
+        return Passport::token()->where(Passport::token()->getKeyName(), $id)->first();
     }
 
     /**
@@ -37,7 +37,7 @@ class TokenRepository
      */
     public function findForUser($id, $userId)
     {
-        return Passport::token()->where('id', $id)->where('user_id', $userId)->first();
+        return Passport::token()->where(Passport::token()->getKeyName(), $id)->where('user_id', $userId)->first();
     }
 
     /**
@@ -86,7 +86,7 @@ class TokenRepository
      */
     public function revokeAccessToken($id)
     {
-        return Passport::token()->where('id', $id)->update(['revoked' => true]);
+        return Passport::token()->where(Passport::token()->getKeyName(), $id)->update(['revoked' => true]);
     }
 
     /**


### PR DESCRIPTION
I am using custom table and column names for all Passport created tables. Everything works using the class overrides, except for these particular queries in AuthCodeRepository and TokenRepository. I use mutators to rewrite some model attributes, but that was not working for both. Now this query respects the set primary key on the authCode & token model instead. I am fairly new to Laravel, so there might be a better solution 😄.

This code also exists in 13.x, so I guess this should be merged into 13.x too?