### PR TITLE
[13.x] Validate key files' permissions

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -20,7 +20,7 @@ class Passport
     /**
      * Indicates if Passport should validate the permissions of its encryption keys.
      */
-    public static bool $validateKeyPermissions = false;
+    public static bool $validateKeyPermissions = true;
 
     /**
      * Indicates if the implicit grant type is enabled.

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -254,7 +254,7 @@ class PassportServiceProvider extends ServiceProvider
             $key = 'file://'.Passport::keyPath('oauth-'.$type.'.key');
         }
 
-        return new CryptKey($key, null, Passport::$validateKeyPermissions && ! windows_os());
+        return new CryptKey($key, null, Passport::$validateKeyPermissions);
     }
 
     /**


### PR DESCRIPTION
- [x] thephpleague/oauth2-server#1447

This PR does:
- Validate key files' permissions by default.
- Remove ignorance of permission check on Windows, as `oauth2-server` handles it.