### PR TITLE
[13.x] Enhance error responses

### DIFF
--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -39,6 +39,16 @@ class ClientFactory extends Factory
     }
 
     /**
+     * Use as a public client.
+     */
+    public function asPublic(): static
+    {
+        return $this->state([
+            'secret' => null,
+        ]);
+    }
+
+    /**
      * Use as a Password client.
      */
     public function asPasswordClient(): static
@@ -67,6 +77,7 @@ class ClientFactory extends Factory
     {
         return $this->state([
             'grant_types' => ['implicit'],
+            'secret' => null,
         ]);
     }
 

--- a/src/Exceptions/OAuthServerException.php
+++ b/src/Exceptions/OAuthServerException.php
@@ -3,16 +3,65 @@
 namespace Laravel\Passport\Exceptions;
 
 use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
+use Laravel\Passport\Http\Controllers\ConvertsPsrResponses;
 use League\OAuth2\Server\Exception\OAuthServerException as LeagueException;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
+use Nyholm\Psr7\Response as Psr7Response;
 
 class OAuthServerException extends HttpResponseException
 {
+    use ConvertsPsrResponses;
+
     /**
      * Create a new OAuthServerException.
      */
-    public function __construct(LeagueException $e, Response $response)
+    public function __construct(LeagueException $e, bool $useFragment = false)
     {
-        parent::__construct($response, $e);
+        parent::__construct($this->convertResponse($e->generateHttpResponse(new Psr7Response, $useFragment)), $e);
+    }
+
+    /**
+     * Create a new OAuthServerException for when login is required.
+     */
+    public static function loginRequired(AuthorizationRequestInterface $authRequest): static
+    {
+        $exception = new LeagueException(
+            'The authorization server requires end-user authentication.',
+            9,
+            'login_required',
+            401,
+            'The user is not authenticated',
+            $authRequest->getRedirectUri() ?? Arr::wrap($authRequest->getClient()->getRedirectUri())[0]
+        );
+
+        $exception->setPayload([
+            'state' => $authRequest->getState(),
+            ...$exception->getPayload(),
+        ]);
+
+        return new static($exception, $authRequest->getGrantTypeId() === 'implicit');
+    }
+
+    /**
+     * Create a new OAuthServerException for when consent is required.
+     */
+    public static function consentRequired(AuthorizationRequestInterface $authRequest): static
+    {
+        $exception = new LeagueException(
+            'The authorization server requires end-user consent.',
+            9,
+            'consent_required',
+            401,
+            null,
+            $authRequest->getRedirectUri() ?? Arr::wrap($authRequest->getClient()->getRedirectUri())[0]
+        );
+
+        $exception->setPayload([
+            'state' => $authRequest->getState(),
+            ...$exception->getPayload(),
+        ]);
+
+        return new static($exception, $authRequest->getGrantTypeId() === 'implicit');
     }
 }

--- a/src/Http/Controllers/ApproveAuthorizationController.php
+++ b/src/Http/Controllers/ApproveAuthorizationController.php
@@ -30,6 +30,6 @@ class ApproveAuthorizationController
 
         return $this->withErrorHandling(fn () => $this->convertResponse(
             $this->server->completeAuthorizationRequest($authRequest, new Psr7Response)
-        ));
+        ), $authRequest->getGrantTypeId() === 'implicit');
     }
 }

--- a/src/Http/Controllers/DenyAuthorizationController.php
+++ b/src/Http/Controllers/DenyAuthorizationController.php
@@ -30,6 +30,6 @@ class DenyAuthorizationController
 
         return $this->withErrorHandling(fn () => $this->convertResponse(
             $this->server->completeAuthorizationRequest($authRequest, new Psr7Response)
-        ));
+        ), $authRequest->getGrantTypeId() === 'implicit');
     }
 }

--- a/src/Http/Controllers/HandlesOAuthErrors.php
+++ b/src/Http/Controllers/HandlesOAuthErrors.php
@@ -5,12 +5,9 @@ namespace Laravel\Passport\Http\Controllers;
 use Closure;
 use Laravel\Passport\Exceptions\OAuthServerException;
 use League\OAuth2\Server\Exception\OAuthServerException as LeagueException;
-use Nyholm\Psr7\Response as Psr7Response;
 
 trait HandlesOAuthErrors
 {
-    use ConvertsPsrResponses;
-
     /**
      * Perform the given callback with exception handling.
      *
@@ -21,15 +18,12 @@ trait HandlesOAuthErrors
      *
      * @throws \Laravel\Passport\Exceptions\OAuthServerException
      */
-    protected function withErrorHandling(Closure $callback)
+    protected function withErrorHandling(Closure $callback, bool $useFragment = false)
     {
         try {
             return $callback();
         } catch (LeagueException $e) {
-            throw new OAuthServerException(
-                $e,
-                $this->convertResponse($e->generateHttpResponse(new Psr7Response))
-            );
+            throw new OAuthServerException($e, $useFragment);
         }
     }
 }

--- a/src/Http/Controllers/RetrievesAuthRequestFromSession.php
+++ b/src/Http/Controllers/RetrievesAuthRequestFromSession.php
@@ -4,7 +4,6 @@ namespace Laravel\Passport\Http\Controllers;
 
 use Exception;
 use Illuminate\Http\Request;
-use Laravel\Passport\Bridge\User;
 use Laravel\Passport\Exceptions\InvalidAuthTokenException;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 
@@ -18,18 +17,14 @@ trait RetrievesAuthRequestFromSession
      */
     protected function getAuthRequestFromSession(Request $request): AuthorizationRequest
     {
-        if ($request->isNotFilled('auth_token') || $request->session()->pull('authToken') !== $request->get('auth_token')) {
+        if ($request->isNotFilled('auth_token') ||
+            $request->session()->pull('authToken') !== $request->get('auth_token')) {
             $request->session()->forget(['authToken', 'authRequest']);
 
             throw InvalidAuthTokenException::different();
         }
 
-        return tap($request->session()->pull('authRequest'), function ($authRequest) use ($request) {
-            if (! $authRequest) {
-                throw new Exception('Authorization request was not present in the session.');
-            }
-
-            $authRequest->setUser(new User($request->user()->getAuthIdentifier()));
-        });
+        return $request->session()->pull('authRequest')
+            ?? throw new Exception('Authorization request was not present in the session.');
     }
 }

--- a/tests/Feature/AuthorizationCodeGrantWithPkceTest.php
+++ b/tests/Feature/AuthorizationCodeGrantWithPkceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Laravel\Passport\Database\Factories\ClientFactory;
+use Laravel\Passport\Passport;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
+use Workbench\Database\Factories\UserFactory;
+
+class AuthorizationCodeGrantWithPkceTest extends PassportTestCase
+{
+    use WithLaravelMigrations;
+
+    protected function setUp(): void
+    {
+        PassportTestCase::setUp();
+
+        Passport::tokensCan([
+            'create' => 'Create',
+            'read' => 'Read',
+            'update' => 'Update',
+            'delete' => 'Delete',
+        ]);
+
+        Passport::authorizationView(fn ($params) => $params);
+    }
+
+    public function testIssueAccessToken()
+    {
+        $client = ClientFactory::new()->asPublic()->create();
+
+        $codeVerifier = Str::random(128);
+        $codeChallenge = strtr(rtrim(base64_encode(hash('sha256', $codeVerifier, true)), '='), '+/', '-_');
+
+        $query = http_build_query([
+            'client_id' => $client->getKey(),
+            'redirect_uri' => $redirect = $client->redirect_uris[0],
+            'response_type' => 'code',
+            'scope' => 'create read',
+            'state' => $state = Str::random(40),
+            'code_challenge' => $codeChallenge,
+            'code_challenge_method' => 'S256',
+        ]);
+
+        $user = UserFactory::new()->create();
+        $this->actingAs($user, 'web');
+
+        $response = $this->get('/oauth/authorize?'.$query);
+
+        $response->assertOk();
+        $response->assertSessionHas('authRequest');
+        $response->assertSessionHas('authToken');
+        $json = $response->json();
+        $this->assertEqualsCanonicalizing(['client', 'user', 'scopes', 'request', 'authToken'], array_keys($json));
+        $this->assertSame(collect(Passport::scopesFor(['create', 'read']))->toArray(), $json['scopes']);
+
+        $response = $this->post('/oauth/authorize', ['auth_token' => $json['authToken']]);
+        $response->assertRedirect();
+        $response->assertSessionMissing(['authRequest', 'authToken']);
+
+        $location = $response->headers->get('Location');
+        parse_str(parse_url($location, PHP_URL_QUERY), $params);
+
+        $this->assertStringStartsWith($redirect.'?', $location);
+        $this->assertSame($state, $params['state']);
+        $this->assertArrayHasKey('code', $params);
+
+        $response = $this->post('/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'client_id' => $client->getKey(),
+            'redirect_uri' => $redirect,
+            'code' => $params['code'],
+            'code_verifier' => $codeVerifier,
+        ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        $this->assertArrayHasKey('access_token', $json);
+        $this->assertArrayHasKey('refresh_token', $json);
+        $this->assertSame('Bearer', $json['token_type']);
+        $this->assertSame(31536000, $json['expires_in']);
+
+        Route::get('/foo', fn (Request $request) => $request->user()->token()->toJson())
+            ->middleware('auth:api');
+
+        $json = $this->withToken($json['access_token'], $json['token_type'])->get('/foo')->json();
+
+        $this->assertSame($client->getKey(), $json['oauth_client_id']);
+        $this->assertEquals($user->getAuthIdentifier(), $json['oauth_user_id']);
+        $this->assertSame(['create', 'read'], $json['oauth_scopes']);
+    }
+
+    public function testRequireCodeChallenge()
+    {
+        $client = ClientFactory::new()->asPublic()->create();
+
+        $query = http_build_query([
+            'client_id' => $client->getKey(),
+            'redirect_uri' => $client->redirect_uris[0],
+            'response_type' => 'code',
+        ]);
+
+        $user = UserFactory::new()->create();
+        $this->actingAs($user, 'web');
+        $response = $this->get('/oauth/authorize?'.$query);
+
+        $response->assertStatus(400);
+        $json = $response->json();
+
+        $this->assertSame('invalid_request', $json['error']);
+        $this->assertSame('Code challenge must be provided for public clients', $json['hint']);
+        $this->assertArrayHasKey('error_description', $json);
+    }
+}

--- a/tests/Feature/ImplicitGrantTest.php
+++ b/tests/Feature/ImplicitGrantTest.php
@@ -10,13 +10,15 @@ use Laravel\Passport\Passport;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Workbench\Database\Factories\UserFactory;
 
-class AuthorizationCodeGrantTest extends PassportTestCase
+class ImplicitGrantTest extends PassportTestCase
 {
     use WithLaravelMigrations;
 
     protected function setUp(): void
     {
-        parent::setUp();
+        PassportTestCase::setUp();
+
+        Passport::enableImplicitGrant();
 
         Passport::tokensCan([
             'create' => 'Create',
@@ -30,19 +32,18 @@ class AuthorizationCodeGrantTest extends PassportTestCase
 
     public function testIssueAccessToken()
     {
-        $client = ClientFactory::new()->create();
+        $client = ClientFactory::new()->asImplicitClient()->create();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $redirect = $client->redirect_uris[0],
-            'response_type' => 'code',
+            'response_type' => 'token',
             'scope' => 'create read',
             'state' => $state = Str::random(40),
         ]);
 
         $user = UserFactory::new()->create();
         $this->actingAs($user, 'web');
-
         $response = $this->get('/oauth/authorize?'.$query);
 
         $response->assertOk();
@@ -57,31 +58,19 @@ class AuthorizationCodeGrantTest extends PassportTestCase
         $response->assertSessionMissing(['authRequest', 'authToken']);
 
         $location = $response->headers->get('Location');
-        parse_str(parse_url($location, PHP_URL_QUERY), $params);
+        parse_str(parse_url($location, PHP_URL_FRAGMENT), $params);
 
-        $this->assertStringStartsWith($redirect.'?', $location);
+        $this->assertStringStartsWith($redirect.'#', $location);
         $this->assertSame($state, $params['state']);
-        $this->assertArrayHasKey('code', $params);
-
-        $response = $this->post('/oauth/token', [
-            'grant_type' => 'authorization_code',
-            'client_id' => $client->getKey(),
-            'client_secret' => $client->plainSecret,
-            'redirect_uri' => $redirect,
-            'code' => $params['code'],
-        ]);
-
-        $response->assertOk();
-        $json = $response->json();
-        $this->assertArrayHasKey('access_token', $json);
-        $this->assertArrayHasKey('refresh_token', $json);
-        $this->assertSame('Bearer', $json['token_type']);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertArrayHasKey('access_token', $params);
+        $this->assertArrayNotHasKey('refresh_token', $params);
+        $this->assertSame('Bearer', $params['token_type']);
+        $this->assertSame('31536000', $params['expires_in']);
 
         Route::get('/foo', fn (Request $request) => $request->user()->token()->toJson())
             ->middleware('auth:api');
 
-        $json = $this->withToken($json['access_token'], $json['token_type'])->get('/foo')->json();
+        $json = $this->withToken($params['access_token'], $params['token_type'])->get('/foo')->json();
 
         $this->assertSame($client->getKey(), $json['oauth_client_id']);
         $this->assertEquals($user->getAuthIdentifier(), $json['oauth_user_id']);
@@ -90,13 +79,13 @@ class AuthorizationCodeGrantTest extends PassportTestCase
 
     public function testDenyAuthorization()
     {
-        $client = ClientFactory::new()->create();
+        $client = ClientFactory::new()->asImplicitClient()->create();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $redirect = $client->redirect_uris[0],
-            'response_type' => 'code',
-            'scope' => '',
+            'response_type' => 'token',
+            'scope' => 'create read',
             'state' => $state = Str::random(40),
         ]);
 
@@ -109,24 +98,24 @@ class AuthorizationCodeGrantTest extends PassportTestCase
         $response->assertSessionMissing(['authRequest', 'authToken']);
 
         $location = $response->headers->get('Location');
-        parse_str(parse_url($location, PHP_URL_QUERY), $params);
+        parse_str(parse_url($location, PHP_URL_FRAGMENT), $params);
 
-        $this->assertStringStartsWith($redirect.'?', $location);
-        $this->assertSame($state, $params['state']);
+        // $this->assertStringStartsWith($redirect.'#', $location);
+        // $this->assertSame($state, $params['state']);
         $this->assertSame('access_denied', $params['error']);
         $this->assertArrayHasKey('error_description', $params);
     }
 
     public function testSkipsAuthorizationWhenHasGrantedScopes()
     {
-        $client = ClientFactory::new()->create();
+        $client = ClientFactory::new()->asImplicitClient()->create();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $redirect = $client->redirect_uris[0],
-            'response_type' => 'code',
-            'scope' => 'create read update',
-            'state' => Str::random(40),
+            'response_type' => 'token',
+            'scope' => 'create read',
+            'state' => $state = Str::random(40),
         ]);
 
         $user = UserFactory::new()->create();
@@ -134,45 +123,39 @@ class AuthorizationCodeGrantTest extends PassportTestCase
         $json = $this->get('/oauth/authorize?'.$query)->json();
 
         $response = $this->post('/oauth/authorize', ['auth_token' => $json['authToken']]);
-        parse_str(parse_url($response->headers->get('Location'), PHP_URL_QUERY), $params);
-
-        $this->post('/oauth/token', [
-            'grant_type' => 'authorization_code',
-            'client_id' => $client->getKey(),
-            'client_secret' => $client->plainSecret,
-            'redirect_uri' => $redirect,
-            'code' => $params['code'],
-        ]);
+        $response->assertRedirect();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $redirect,
-            'response_type' => 'code',
-            'scope' => 'create read',
+            'response_type' => 'token',
+            'scope' => 'create',
             'state' => $state = Str::random(40),
         ]);
 
         $response = $this->get('/oauth/authorize?'.$query);
         $response->assertRedirect();
+        $response->assertSessionMissing(['authRequest', 'authToken']);
 
         $location = $response->headers->get('Location');
-        parse_str(parse_url($location, PHP_URL_QUERY), $params);
+        parse_str(parse_url($location, PHP_URL_FRAGMENT), $params);
 
-        $this->assertStringStartsWith($redirect.'?', $location);
+        $this->assertStringStartsWith($redirect.'#', $location);
         $this->assertSame($state, $params['state']);
-        $this->assertArrayHasKey('code', $params);
+        $this->assertArrayHasKey('access_token', $params);
+        $this->assertArrayNotHasKey('refresh_token', $params);
+        $this->assertSame('Bearer', $params['token_type']);
+        $this->assertSame('31536000', $params['expires_in']);
     }
 
     public function testValidateAuthorizationRequest()
     {
-        $client = ClientFactory::new()->create();
+        $client = ClientFactory::new()->asImplicitClient()->create();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => fake()->url(),
-            'response_type' => 'code',
-            'scope' => '',
-            'state' => Str::random(40),
+            'response_type' => 'token',
         ]);
 
         $json = $this->get('/oauth/authorize?'.$query)->json();
@@ -182,23 +165,22 @@ class AuthorizationCodeGrantTest extends PassportTestCase
 
     public function testValidateScopes()
     {
-        $client = ClientFactory::new()->create();
+        $client = ClientFactory::new()->asImplicitClient()->create();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $redirect = $client->redirect_uris[0],
-            'response_type' => 'code',
-            'scope' => 'foo',
-            'state' => $state = Str::random(40),
+            'response_type' => 'token',
+            'scope' => 'foo'
         ]);
 
         $response = $this->get('/oauth/authorize?'.$query);
         $response->assertRedirect();
 
         $location = $response->headers->get('Location');
-        parse_str(parse_url($location, PHP_URL_QUERY), $params);
+        parse_str(parse_url($location, PHP_URL_FRAGMENT), $params);
 
-        $this->assertStringStartsWith($redirect.'?', $location);
+        $this->assertStringStartsWith($redirect.'#', $location);
         // $this->assertSame($state, $params['state']);
         $this->assertSame('invalid_scope', $params['error']);
         $this->assertArrayHasKey('error_description', $params);
@@ -208,12 +190,12 @@ class AuthorizationCodeGrantTest extends PassportTestCase
     {
         Route::get('/foo', fn () => '')->name('login');
 
-        $client = ClientFactory::new()->create();
+        $client = ClientFactory::new()->asImplicitClient()->create();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $client->redirect_uris[0],
-            'response_type' => 'code',
+            'response_type' => 'token',
         ]);
 
         $response = $this->get('/oauth/authorize?'.$query);
@@ -223,12 +205,12 @@ class AuthorizationCodeGrantTest extends PassportTestCase
 
     public function testPromptNone()
     {
-        $client = ClientFactory::new()->create();
+        $client = ClientFactory::new()->asImplicitClient()->create();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $redirect = $client->redirect_uris[0],
-            'response_type' => 'code',
+            'response_type' => 'token',
             'state' => $state = Str::random(40),
             'prompt' => 'none',
         ]);
@@ -238,9 +220,9 @@ class AuthorizationCodeGrantTest extends PassportTestCase
         $response->assertRedirect();
 
         $location = $response->headers->get('Location');
-        parse_str(parse_url($location, PHP_URL_QUERY), $params);
+        parse_str(parse_url($location, PHP_URL_FRAGMENT), $params);
 
-        $this->assertStringStartsWith($redirect.'?', $location);
+        $this->assertStringStartsWith($redirect.'#', $location);
         $this->assertSame($state, $params['state']);
         $this->assertSame('consent_required', $params['error']);
         $this->assertArrayHasKey('error_description', $params);
@@ -248,12 +230,12 @@ class AuthorizationCodeGrantTest extends PassportTestCase
 
     public function testPromptNoneLoginRequired()
     {
-        $client = ClientFactory::new()->create();
+        $client = ClientFactory::new()->asImplicitClient()->create();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $redirect = $client->redirect_uris[0],
-            'response_type' => 'code',
+            'response_type' => 'token',
             'state' => $state = Str::random(40),
             'prompt' => 'none',
         ]);
@@ -262,9 +244,9 @@ class AuthorizationCodeGrantTest extends PassportTestCase
         $response->assertRedirect();
 
         $location = $response->headers->get('Location');
-        parse_str(parse_url($location, PHP_URL_QUERY), $params);
+        parse_str(parse_url($location, PHP_URL_FRAGMENT), $params);
 
-        $this->assertStringStartsWith($redirect.'?', $location);
+        $this->assertStringStartsWith($redirect.'#', $location);
         $this->assertSame($state, $params['state']);
         $this->assertSame('login_required', $params['error']);
         $this->assertArrayHasKey('error_description', $params);
@@ -272,12 +254,12 @@ class AuthorizationCodeGrantTest extends PassportTestCase
 
     public function testPromptConsent()
     {
-        $client = ClientFactory::new()->create();
+        $client = ClientFactory::new()->asImplicitClient()->create();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $redirect = $client->redirect_uris[0],
-            'response_type' => 'code',
+            'response_type' => 'token',
             'scope' => 'create read update',
             'state' => Str::random(40),
         ]);
@@ -287,20 +269,18 @@ class AuthorizationCodeGrantTest extends PassportTestCase
         $json = $this->get('/oauth/authorize?'.$query)->json();
 
         $response = $this->post('/oauth/authorize', ['auth_token' => $json['authToken']]);
-        parse_str(parse_url($response->headers->get('Location'), PHP_URL_QUERY), $params);
+        $response->assertRedirect();
 
-        $this->post('/oauth/token', [
-            'grant_type' => 'authorization_code',
-            'client_id' => $client->getKey(),
-            'client_secret' => $client->plainSecret,
-            'redirect_uri' => $redirect,
-            'code' => $params['code'],
-        ]);
+        $location = $response->headers->get('Location');
+        parse_str(parse_url($location, PHP_URL_FRAGMENT), $params);
+
+        $this->assertStringStartsWith($redirect.'#', $location);
+        $this->assertArrayHasKey('access_token', $params);
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $redirect,
-            'response_type' => 'code',
+            'response_type' => 'token',
             'scope' => 'create read',
             'state' => Str::random(40),
             'prompt' => 'consent',
@@ -320,12 +300,12 @@ class AuthorizationCodeGrantTest extends PassportTestCase
     {
         Route::get('/foo', fn () => '')->name('login');
 
-        $client = ClientFactory::new()->create();
+        $client = ClientFactory::new()->asImplicitClient()->create();
 
         $query = http_build_query([
             'client_id' => $client->getKey(),
             'redirect_uri' => $client->redirect_uris[0],
-            'response_type' => 'code',
+            'response_type' => 'token',
             'scope' => 'create read update',
             'state' => Str::random(40),
             'prompt' => 'login',

--- a/tests/Feature/ImplicitGrantTest.php
+++ b/tests/Feature/ImplicitGrantTest.php
@@ -171,7 +171,8 @@ class ImplicitGrantTest extends PassportTestCase
             'client_id' => $client->getKey(),
             'redirect_uri' => $redirect = $client->redirect_uris[0],
             'response_type' => 'token',
-            'scope' => 'foo'
+            'scope' => 'foo',
+            'state' => $state = Str::random(40),
         ]);
 
         $response = $this->get('/oauth/authorize?'.$query);

--- a/tests/Unit/ApproveAuthorizationControllerTest.php
+++ b/tests/Unit/ApproveAuthorizationControllerTest.php
@@ -35,9 +35,7 @@ class ApproveAuthorizationControllerTest extends TestCase
 
         $request->shouldReceive('user')->andReturn(new ApproveAuthorizationControllerFakeUser);
 
-        $authRequest->shouldReceive('getClient->getIdentifier')->andReturn(1);
-        $authRequest->shouldReceive('getUser->getIdentifier')->andReturn(2);
-        $authRequest->shouldReceive('setUser')->once();
+        $authRequest->shouldReceive('getGrantTypeId')->once()->andReturn('authorization_code');
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
 
         $psrResponse = new Response();

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -42,6 +42,9 @@ class AuthorizationControllerTest extends TestCase
         $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
         $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest = m::mock(AuthorizationRequestInterface::class));
 
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
@@ -51,6 +54,7 @@ class AuthorizationControllerTest extends TestCase
 
         $authRequest->shouldReceive('getClient->getIdentifier')->andReturn(1);
         $authRequest->shouldReceive('getScopes')->andReturn([new Scope('scope-1')]);
+        $authRequest->shouldReceive('setUser')->once();
 
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
@@ -70,9 +74,7 @@ class AuthorizationControllerTest extends TestCase
 
         $controller = new AuthorizationController($server, $guard, $response, $clients);
 
-        $this->assertSame($response, $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request
-        ));
+        $this->assertSame($response, $controller->authorize($psrRequest, $request));
     }
 
     public function test_authorization_exceptions_are_handled()
@@ -84,8 +86,10 @@ class AuthorizationControllerTest extends TestCase
         $guard->shouldReceive('guest')->andReturn(false);
         $server->shouldReceive('validateAuthorizationRequest')->andThrow(LeagueException::invalidCredentials());
 
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+
         $request = m::mock(Request::class);
-        $request->shouldReceive('session')->andReturn($session = m::mock());
 
         $clients = m::mock(ClientRepository::class);
 
@@ -93,9 +97,7 @@ class AuthorizationControllerTest extends TestCase
 
         $controller = new AuthorizationController($server, $guard, $response, $clients);
 
-        $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request
-        );
+        $controller->authorize($psrRequest, $request);
     }
 
     public function test_request_is_approved_if_valid_token_exists()
@@ -118,6 +120,9 @@ class AuthorizationControllerTest extends TestCase
             ->with($authRequest, m::type(ResponseInterface::class))
             ->andReturn($psrResponse);
 
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
@@ -129,6 +134,7 @@ class AuthorizationControllerTest extends TestCase
         $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
         $authRequest->shouldReceive('setUser')->once()->andReturnNull();
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
+        $authRequest->shouldReceive('getGrantTypeId')->once()->andReturn('authorization_code');
 
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
@@ -139,9 +145,7 @@ class AuthorizationControllerTest extends TestCase
 
         $controller = new AuthorizationController($server, $guard, $response, $clients);
 
-        $this->assertSame('approved', $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request
-        )->getContent());
+        $this->assertSame('approved', $controller->authorize($psrRequest, $request)->getContent());
     }
 
     public function test_request_is_approved_if_client_can_skip_authorization()
@@ -164,6 +168,9 @@ class AuthorizationControllerTest extends TestCase
             ->with($authRequest, m::type(ResponseInterface::class))
             ->andReturn($psrResponse);
 
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
@@ -175,6 +182,7 @@ class AuthorizationControllerTest extends TestCase
         $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
         $authRequest->shouldReceive('setUser')->once()->andReturnNull();
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
+        $authRequest->shouldReceive('getGrantTypeId')->once()->andReturn('authorization_code');
 
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
@@ -183,9 +191,7 @@ class AuthorizationControllerTest extends TestCase
 
         $controller = new AuthorizationController($server, $guard, $response, $clients);
 
-        $this->assertSame('approved', $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request
-        )->getContent());
+        $this->assertSame('approved', $controller->authorize($psrRequest, $request)->getContent());
     }
 
     public function test_authorization_view_is_presented_if_request_has_prompt_equals_to_consent()
@@ -199,9 +205,13 @@ class AuthorizationControllerTest extends TestCase
         $guard = m::mock(StatefulGuard::class);
 
         $guard->shouldReceive('guest')->andReturn(false);
-        $guard->shouldReceive('user')->andReturn($user = m::mock());
+        $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $server->shouldReceive('validateAuthorizationRequest')
             ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
+
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
 
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
@@ -212,6 +222,7 @@ class AuthorizationControllerTest extends TestCase
 
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
         $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
+        $authRequest->shouldReceive('setUser')->once()->andReturnNull();
 
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
@@ -228,15 +239,11 @@ class AuthorizationControllerTest extends TestCase
 
         $controller = new AuthorizationController($server, $guard, $response, $clients);
 
-        $this->assertSame($response, $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request
-        ));
+        $this->assertSame($response, $controller->authorize($psrRequest, $request));
     }
 
     public function test_authorization_denied_if_request_has_prompt_equals_to_none()
     {
-        $this->expectException('Laravel\Passport\Exceptions\OAuthServerException');
-
         Passport::tokensCan([
             'scope-1' => 'description',
         ]);
@@ -249,12 +256,9 @@ class AuthorizationControllerTest extends TestCase
         $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
         $server->shouldReceive('validateAuthorizationRequest')
             ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
-        $server->shouldReceive('completeAuthorizationRequest')
-            ->with($authRequest, m::type(ResponseInterface::class))
-            ->once()
-            ->andReturnUsing(function () {
-                throw new \League\OAuth2\Server\Exception\OAuthServerException('', 0, '');
-            });
+
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
 
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
@@ -265,7 +269,9 @@ class AuthorizationControllerTest extends TestCase
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
         $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
         $authRequest->shouldReceive('setUser')->once()->andReturnNull();
-        $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(false);
+        $authRequest->shouldReceive('getRedirectUri')->once()->andReturn('http://localhost');
+        $authRequest->shouldReceive('getState')->once()->andReturn('state');
+        $authRequest->shouldReceive('getGrantTypeId')->once()->andReturn('authorization_code');
 
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
@@ -275,9 +281,19 @@ class AuthorizationControllerTest extends TestCase
 
         $controller = new AuthorizationController($server, $guard, $response, $clients);
 
-        $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request
-        );
+        try {
+            $controller->authorize($psrRequest, $request);
+        } catch (OAuthServerException $e) {
+            $this->assertSame($e->getMessage(), 'The authorization server requires end-user consent.');
+            $this->assertStringStartsWith(
+                'http://localhost?state=state&error=consent_required&error_description=',
+                $e->getResponse()->headers->get('location')
+            );
+
+            return;
+        }
+
+        $this->expectException(OAuthServerException::class);
     }
 
     public function test_authorization_denied_if_unauthenticated_and_request_has_prompt_equals_to_none()
@@ -291,6 +307,9 @@ class AuthorizationControllerTest extends TestCase
             ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
         $server->shouldNotReceive('completeAuthorizationRequest');
 
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+
         $request = m::mock(Request::class);
         $request->shouldNotReceive('user');
         $request->shouldReceive('get')->with('prompt')->andReturn('none');
@@ -299,23 +318,26 @@ class AuthorizationControllerTest extends TestCase
         $authRequest->shouldReceive('setAuthorizationApproved')->with(false);
         $authRequest->shouldReceive('getRedirectUri')->andReturn('http://localhost');
         $authRequest->shouldReceive('getClient->getRedirectUri')->andReturn('http://localhost');
-        $authRequest->shouldReceive('getState')->andReturn('state');
-        $authRequest->shouldReceive('getGrantTypeId')->andReturn('authorization_code');
+        $authRequest->shouldReceive('getState')->once()->andReturn('state');
+        $authRequest->shouldReceive('getGrantTypeId')->once()->andReturn('authorization_code');
 
         $clients = m::mock(ClientRepository::class);
 
         $controller = new AuthorizationController($server, $guard, $response, $clients);
 
         try {
-            $controller->authorize(
-                m::mock(ServerRequestInterface::class), $request
-            );
-        } catch (\Laravel\Passport\Exceptions\OAuthServerException $e) {
+            $controller->authorize($psrRequest, $request);
+        } catch (OAuthServerException $e) {
+            $this->assertSame($e->getMessage(), 'The authorization server requires end-user authentication.');
             $this->assertStringStartsWith(
-                'http://localhost?state=state&error=access_denied&error_description=',
+                'http://localhost?state=state&error=login_required&error_description=',
                 $e->getResponse()->headers->get('location')
             );
+
+            return;
         }
+
+        $this->expectException(OAuthServerException::class);
     }
 
     public function test_logout_and_prompt_login_if_request_has_prompt_equals_to_login()
@@ -330,6 +352,9 @@ class AuthorizationControllerTest extends TestCase
         $server->shouldReceive('validateAuthorizationRequest')->once();
         $guard->shouldReceive('logout')->once();
 
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('invalidate')->once();
@@ -343,9 +368,7 @@ class AuthorizationControllerTest extends TestCase
 
         $controller = new AuthorizationController($server, $guard, $response, $clients);
 
-        $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request
-        );
+        $controller->authorize($psrRequest, $request);
     }
 
     public function test_user_should_be_authenticated()
@@ -359,6 +382,9 @@ class AuthorizationControllerTest extends TestCase
         $guard->shouldReceive('guest')->andReturn(true);
         $server->shouldReceive('validateAuthorizationRequest')->once();
 
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+
         $request = m::mock(Request::class);
         $request->shouldNotReceive('user');
         $request->shouldReceive('session')->andReturn($session = m::mock());
@@ -370,8 +396,6 @@ class AuthorizationControllerTest extends TestCase
 
         $controller = new AuthorizationController($server, $guard, $response, $clients);
 
-        $controller->authorize(
-            m::mock(ServerRequestInterface::class), $request, $clients
-        );
+        $controller->authorize($psrRequest, $request);
     }
 }

--- a/tests/Unit/DenyAuthorizationControllerTest.php
+++ b/tests/Unit/DenyAuthorizationControllerTest.php
@@ -25,7 +25,6 @@ class DenyAuthorizationControllerTest extends TestCase
         $request = m::mock(Request::class);
 
         $request->shouldReceive('session')->andReturn($session = m::mock());
-        $request->shouldReceive('user')->andReturn(new DenyAuthorizationControllerFakeUser);
         $request->shouldReceive('isNotFilled')->with('auth_token')->andReturn(false);
         $request->shouldReceive('get')->with('auth_token')->andReturn('foo');
 
@@ -37,7 +36,7 @@ class DenyAuthorizationControllerTest extends TestCase
                 AuthorizationRequest::class
             ));
 
-        $authRequest->shouldReceive('setUser')->once();
+        $authRequest->shouldReceive('getGrantTypeId')->once()->andReturn('authorization_code');
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(false);
 
         $server->shouldReceive('completeAuthorizationRequest')


### PR DESCRIPTION
This PR enhances error responses:

* More meaningful error responses to adhere OpenID specs for `prompt=none` (#1569):
   * `login_required` ([ref](https://openid.net/specs/openid-connect-core-1_0.html#:~:text=End%2DUser%20interaction.-,login_required,The%20Authorization%20Server%20requires%20End%2DUser%20authentication.,-This%20error%20MAY))
   * `consent_required` ([ref](https://openid.net/specs/openid-connect-core-1_0.html#:~:text=session%20to%20use.-,consent_required,The%20Authorization%20Server%20requires%20End%2DUser%20consent.,-This%20error%20MAY))
* Fix a bug on error responses of "implicit" grant. `oauth2-server` needs passing `useFragment` argument when generating redirect responses. Error parameters must be present on fragment instead of query parameters when redirecting to the client when using implicit grant.
* Add more feature tests for "authorization code" grant.
* Add feature tests for "authorization code" grant with PKCE.
* Add feature tests for "implicit" grant.