### PR TITLE
[13.x] Improve resolving and converting PSR responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "nyholm/psr7": "^1.5",
         "phpseclib/phpseclib": "^3.0",
         "symfony/console": "^7.0",
-        "symfony/psr-http-message-bridge": "^7.0"
+        "symfony/psr-http-message-bridge": "^7.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/Exceptions/OAuthServerException.php
+++ b/src/Exceptions/OAuthServerException.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Arr;
 use Laravel\Passport\Http\Controllers\ConvertsPsrResponses;
 use League\OAuth2\Server\Exception\OAuthServerException as LeagueException;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
-use Nyholm\Psr7\Response as Psr7Response;
+use Psr\Http\Message\ResponseInterface;
 
 class OAuthServerException extends HttpResponseException
 {
@@ -18,7 +18,9 @@ class OAuthServerException extends HttpResponseException
      */
     public function __construct(LeagueException $e, bool $useFragment = false)
     {
-        parent::__construct($this->convertResponse($e->generateHttpResponse(new Psr7Response, $useFragment)), $e);
+        parent::__construct($this->convertResponse(
+            $e->generateHttpResponse(app(ResponseInterface::class), $useFragment)
+        ), $e);
     }
 
     /**

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -21,7 +21,6 @@ use Laravel\Passport\PassportUserProvider;
 use Laravel\Passport\TransientToken;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
-use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 
@@ -161,13 +160,8 @@ class TokenGuard implements Guard
     {
         // First, we will convert the Symfony request to a PSR-7 implementation which will
         // be compatible with the base OAuth2 library. The Symfony bridge can perform a
-        // conversion for us to a new Nyholm implementation of this PSR-7 request.
-        $psr = (new PsrHttpFactory(
-            new Psr17Factory,
-            new Psr17Factory,
-            new Psr17Factory,
-            new Psr17Factory
-        ))->createRequest($this->request);
+        // conversion for us to a new PSR-7 implementation from this Symfony request.
+        $psr = (new PsrHttpFactory())->createRequest($this->request);
 
         try {
             return $this->server->validateAuthenticatedRequest($psr);

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -2,11 +2,11 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
-use Illuminate\Http\Response;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
-use Nyholm\Psr7\Response as Psr7Response;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 class AccessTokenController
 {
@@ -23,16 +23,16 @@ class AccessTokenController
     /**
      * Issue an access token.
      */
-    public function issueToken(ServerRequestInterface $request): Response
+    public function issueToken(ServerRequestInterface $psrRequest, ResponseInterface $psrResponse): Response
     {
-        return $this->withErrorHandling(function () use ($request) {
-            if (array_key_exists('grant_type', $attributes = (array) $request->getParsedBody()) &&
+        return $this->withErrorHandling(function () use ($psrRequest, $psrResponse) {
+            if (array_key_exists('grant_type', $attributes = (array) $psrRequest->getParsedBody()) &&
                 $attributes['grant_type'] === 'personal_access') {
                 throw OAuthServerException::unsupportedGrantType();
             }
 
             return $this->convertResponse(
-                $this->server->respondToAccessTokenRequest($request, new Psr7Response)
+                $this->server->respondToAccessTokenRequest($psrRequest, $psrResponse)
             );
         });
     }

--- a/src/Http/Controllers/ApproveAuthorizationController.php
+++ b/src/Http/Controllers/ApproveAuthorizationController.php
@@ -3,9 +3,9 @@
 namespace Laravel\Passport\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use League\OAuth2\Server\AuthorizationServer;
-use Nyholm\Psr7\Response as Psr7Response;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 class ApproveAuthorizationController
 {
@@ -22,14 +22,14 @@ class ApproveAuthorizationController
     /**
      * Approve the authorization request.
      */
-    public function approve(Request $request): Response
+    public function approve(Request $request, ResponseInterface $psrResponse): Response
     {
         $authRequest = $this->getAuthRequestFromSession($request);
 
         $authRequest->setAuthorizationApproved(true);
 
         return $this->withErrorHandling(fn () => $this->convertResponse(
-            $this->server->completeAuthorizationRequest($authRequest, new Psr7Response)
+            $this->server->completeAuthorizationRequest($authRequest, $psrResponse)
         ), $authRequest->getGrantTypeId() === 'implicit');
     }
 }

--- a/src/Http/Controllers/ConvertsPsrResponses.php
+++ b/src/Http/Controllers/ConvertsPsrResponses.php
@@ -2,8 +2,9 @@
 
 namespace Laravel\Passport\Http\Controllers;
 
-use Illuminate\Http\Response;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Component\HttpFoundation\Response;
 
 trait ConvertsPsrResponses
 {
@@ -12,10 +13,6 @@ trait ConvertsPsrResponses
      */
     public function convertResponse(ResponseInterface $psrResponse): Response
     {
-        return new Response(
-            $psrResponse->getBody(),
-            $psrResponse->getStatusCode(),
-            $psrResponse->getHeaders()
-        );
+        return (new HttpFoundationFactory())->createResponse($psrResponse);
     }
 }

--- a/src/Http/Controllers/DenyAuthorizationController.php
+++ b/src/Http/Controllers/DenyAuthorizationController.php
@@ -3,9 +3,9 @@
 namespace Laravel\Passport\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use League\OAuth2\Server\AuthorizationServer;
-use Nyholm\Psr7\Response as Psr7Response;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 class DenyAuthorizationController
 {
@@ -22,14 +22,14 @@ class DenyAuthorizationController
     /**
      * Deny the authorization request.
      */
-    public function deny(Request $request): Response
+    public function deny(Request $request, ResponseInterface $psrResponse): Response
     {
         $authRequest = $this->getAuthRequestFromSession($request);
 
         $authRequest->setAuthorizationApproved(false);
 
         return $this->withErrorHandling(fn () => $this->convertResponse(
-            $this->server->completeAuthorizationRequest($authRequest, new Psr7Response)
+            $this->server->completeAuthorizationRequest($authRequest, $psrResponse)
         ), $authRequest->getGrantTypeId() === 'implicit');
     }
 }

--- a/src/Http/Middleware/CheckCredentials.php
+++ b/src/Http/Middleware/CheckCredentials.php
@@ -8,7 +8,6 @@ use Laravel\Passport\AccessToken;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
-use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -46,12 +45,7 @@ abstract class CheckCredentials
      */
     public function handle(Request $request, Closure $next, string ...$scopes): Response
     {
-        $psr = (new PsrHttpFactory(
-            new Psr17Factory,
-            new Psr17Factory,
-            new Psr17Factory,
-            new Psr17Factory
-        ))->createRequest($request);
+        $psr = (new PsrHttpFactory())->createRequest($request);
 
         try {
             $psr = $this->server->validateAuthenticatedRequest($psr);

--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -4,9 +4,10 @@ namespace Laravel\Passport;
 
 use Lcobucci\JWT\Parser as JwtParser;
 use League\OAuth2\Server\AuthorizationServer;
-use Nyholm\Psr7\Response;
-use Nyholm\Psr7\ServerRequest;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Component\HttpFoundation\Request;
 
 class PersonalAccessTokenFactory
 {
@@ -48,12 +49,12 @@ class PersonalAccessTokenFactory
      */
     protected function createRequest(string|int $userId, array $scopes, string $provider): ServerRequestInterface
     {
-        return (new ServerRequest('POST', 'not-important'))->withParsedBody([
+        return (new PsrHttpFactory())->createRequest(Request::create('not-important', 'POST', [
             'grant_type' => 'personal_access',
             'provider' => $provider,
             'user_id' => $userId,
             'scope' => implode(' ', $scopes),
-        ]);
+        ]));
     }
 
     /**
@@ -64,7 +65,7 @@ class PersonalAccessTokenFactory
     protected function dispatchRequestToAuthorizationServer(ServerRequestInterface $request): array
     {
         return json_decode($this->server->respondToAccessTokenRequest(
-            $request, new Response
+            $request, app(ResponseInterface::class)
         )->getBody()->__toString(), true);
     }
 

--- a/tests/Unit/AccessTokenControllerTest.php
+++ b/tests/Unit/AccessTokenControllerTest.php
@@ -34,13 +34,15 @@ class AccessTokenControllerTest extends TestCase
 
         $controller = new AccessTokenController($server);
 
-        $this->assertSame('{"access_token":"access-token"}', $controller->issueToken($request)->getContent());
+        $this->assertSame('{"access_token":"access-token"}', $controller->issueToken($request, $psrResponse)->getContent());
     }
 
     public function test_exceptions_are_handled()
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getParsedBody')->once()->andReturn([]);
+
+        app()->instance(ResponseInterface::class, new Response);
 
         $server = m::mock(AuthorizationServer::class);
         $server->shouldReceive('respondToAccessTokenRequest')->with(
@@ -51,7 +53,7 @@ class AccessTokenControllerTest extends TestCase
 
         $this->expectException(OAuthServerException::class);
 
-        $controller->issueToken($request);
+        $controller->issueToken($request, m::mock(ResponseInterface::class));
     }
 }
 

--- a/tests/Unit/ApproveAuthorizationControllerTest.php
+++ b/tests/Unit/ApproveAuthorizationControllerTest.php
@@ -45,7 +45,7 @@ class ApproveAuthorizationControllerTest extends TestCase
             ->with($authRequest, m::type(ResponseInterface::class))
             ->andReturn($psrResponse);
 
-        $this->assertSame('response', $controller->approve($request)->getContent());
+        $this->assertSame('response', $controller->approve($request, $psrResponse)->getContent());
     }
 }
 

--- a/tests/Unit/DenyAuthorizationControllerTest.php
+++ b/tests/Unit/DenyAuthorizationControllerTest.php
@@ -8,6 +8,7 @@ use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
+use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
@@ -39,13 +40,16 @@ class DenyAuthorizationControllerTest extends TestCase
         $authRequest->shouldReceive('getGrantTypeId')->once()->andReturn('authorization_code');
         $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(false);
 
+        $psrResponse = m::mock(ResponseInterface::class);
+        app()->instance(ResponseInterface::class, new Response);
+
         $server->shouldReceive('completeAuthorizationRequest')
             ->with($authRequest, m::type(ResponseInterface::class))
             ->andReturnUsing(function () {
                 throw new \League\OAuth2\Server\Exception\OAuthServerException('', 0, '');
             });
 
-        $controller->deny($request);
+        $controller->deny($request, $psrResponse);
     }
 
     public function test_auth_request_should_exist()
@@ -68,9 +72,11 @@ class DenyAuthorizationControllerTest extends TestCase
         $session->shouldReceive('pull')->once()->with('authToken')->andReturn('foo');
         $session->shouldReceive('pull')->once()->with('authRequest')->andReturnNull();
 
+        $psrResponse = m::mock(ResponseInterface::class);
+
         $server->shouldReceive('completeAuthorizationRequest')->never();
 
-        $controller->deny($request);
+        $controller->deny($request, $psrResponse);
     }
 }
 


### PR DESCRIPTION
This PR does:
* Update the `symfony/psr-http-message-bridge` to 7.1 that supports for auto-detecting PSR-17 factories symfony/symfony#51197
* Inject the `Psr\Http\Message\ResponseInterface` to let Laravel's container [resolve](https://github.com/laravel/framework/blob/65b6a407c94d399563590ff34854255ef2723566/src/Illuminate/Routing/RoutingServiceProvider.php#L156-L170) it wherever needed.
* Use Symfony bridge to convert the PSR response.