### PR TITLE
Include the passport guard when throwing exception

### DIFF
--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -3,13 +3,14 @@
 namespace Laravel\Passport\Exceptions;
 
 use Illuminate\Auth\AuthenticationException as Exception;
+use Illuminate\Support\Facades\Config;
 
 class AuthenticationException extends Exception
 {
     public function __construct($message = 'Unauthenticated.', array $guards = null, $redirectTo = null)
     {
         if (is_null($guards)) {
-            $guards = [config('passport.guard')];
+            $guards = [Config::get('passport.guard')];
         }
 
         parent::__construct($message, $guards, $redirectTo);

--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -6,4 +6,12 @@ use Illuminate\Auth\AuthenticationException as Exception;
 
 class AuthenticationException extends Exception
 {
+    public function __construct($message = 'Unauthenticated.', array $guards = null, $redirectTo = null)
+    {
+        if (is_null($guards)) {
+            $guards = [config('passport.guard')];
+        }
+
+        parent::__construct($message, $guards, $redirectTo);
+    }
 }


### PR DESCRIPTION
This passes the guard used for passport when throwing an authentication exception.

When this exception is thrown, the default behavior is to redirect to the login page. This login page is usually associated with the default `web` guard. If a custom guard is used for Passport, you may want to redirect to a different URL. Including the guard itself in the exception allows the exception handler to detect it and change the redirect.