### PR TITLE
[12.x] Supports PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,17 +16,20 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2, 8.3]
-        laravel: [9, 10, 11]
+        php: [8.1, 8.2, 8.3, 8.4]
+        laravel: [10, 11]
+        include:
+          - php: 8.2
+            laravel: 9
+          - php: 8.1
+            laravel: 9
+          - php: '8.0'
+            laravel: 9
         exclude:
-          - php: '8.0'
-            laravel: 10
-          - php: '8.0'
-            laravel: 11
           - php: 8.1
             laravel: 11
-          - php: 8.3
-            laravel: 9
+          - php: 8.4
+            laravel: 10
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -45,8 +48,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-           composer require "illuminate/contracts=^${{ matrix.laravel }}" --no-update
-           composer update --prefer-dist --no-interaction --no-progress
+           composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts=^${{ matrix.laravel }}"
+
+      - name: Execute tests
+        run: vendor/bin/phpunit --display-deprecations --fail-on-deprecation
+        if: matrix.laravel >= 10
 
       - name: Execute tests
         run: vendor/bin/phpunit
+        if: matrix.laravel < 10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,9 +51,4 @@ jobs:
            composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts=^${{ matrix.laravel }}"
 
       - name: Execute tests
-        run: vendor/bin/phpunit --display-deprecations --fail-on-deprecation
-        if: matrix.laravel >= 10
-
-      - name: Execute tests
-        run: vendor/bin/phpunit
-        if: matrix.laravel < 10
+        run: vendor/bin/phpunit ${{ matrix.laravel >= 10 && '--display-deprecations --fail-on-deprecation' || '' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,4 +51,4 @@ jobs:
            composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts=^${{ matrix.laravel }}"
 
       - name: Execute tests
-        run: vendor/bin/phpunit ${{ matrix.laravel >= 10 && '--display-deprecations --fail-on-deprecation' || '' }}
+        run: vendor/bin/phpunit ${{ matrix.laravel >= 10 && '--display-deprecations' || '' }}

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,6 @@
 php:
   preset: laravel
+  enabled:
+    - nullable_type_declarations
 js: true
 css: true

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -291,7 +291,7 @@ class Passport
      * @param  \DateTimeInterface|\DateInterval|null  $date
      * @return \DateInterval|static
      */
-    public static function tokensExpireIn(DateTimeInterface|DateInterval $date = null)
+    public static function tokensExpireIn(DateTimeInterface|DateInterval|null $date = null)
     {
         if (is_null($date)) {
             return static::$tokensExpireIn ?? new DateInterval('P1Y');
@@ -310,7 +310,7 @@ class Passport
      * @param  \DateTimeInterface|\DateInterval|null  $date
      * @return \DateInterval|static
      */
-    public static function refreshTokensExpireIn(DateTimeInterface|DateInterval $date = null)
+    public static function refreshTokensExpireIn(DateTimeInterface|DateInterval|null $date = null)
     {
         if (is_null($date)) {
             return static::$refreshTokensExpireIn ?? new DateInterval('P1Y');
@@ -329,7 +329,7 @@ class Passport
      * @param  \DateTimeInterface|\DateInterval|null  $date
      * @return \DateInterval|static
      */
-    public static function personalAccessTokensExpireIn(DateTimeInterface|DateInterval $date = null)
+    public static function personalAccessTokensExpireIn(DateTimeInterface|DateInterval|null $date = null)
     {
         if (is_null($date)) {
             return static::$personalAccessTokensExpireIn ?? new DateInterval('P1Y');

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -292,7 +292,7 @@ class IdTokenResponse extends \League\OAuth2\Server\ResponseTypes\BearerTokenRes
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function getExtraParams(\League\OAuth2\Server\Entities\AccessTokenEntityInterface $accessToken)
     {


### PR DESCRIPTION
- [x] `voku/portable-ascii`: https://github.com/voku/portable-ascii/issues/101
- [x] `league/oauth2-server`: https://github.com/thephpleague/oauth2-server/pull/1466
- [x] `lcobucci/jwt`: https://github.com/lcobucci/jwt/issues/1087
- [x] `firebase/php-jwt`: https://github.com/firebase/php-jwt/pull/572 (unreleased)

------- 

`league/event` is still on an outdated version and has no compatible version with `league/oauth2-server` 8. To remove all deprecations we need to upgrade `league/oauth2-server` to version 9 (covered in #1797