### PR TITLE
[12.x] Update property annotation for $userId to match constructor type

### DIFF
--- a/src/Events/AccessTokenCreated.php
+++ b/src/Events/AccessTokenCreated.php
@@ -14,7 +14,7 @@ class AccessTokenCreated
     /**
      * The ID of the user associated with the token.
      *
-     * @var string
+     * @var string|int|null
      */
     public $userId;
 


### PR DESCRIPTION
The `$userId` property can be of type `string|int|null` based on the constructor’s allowed types. This PR updates the property annotation accordingly for better type consistency and static analysis support.