### PR TITLE
Feature: Add a trait for easy testing applications that use the Passport package

### DIFF
--- a/src/Testing/WithPersonalClient.php
+++ b/src/Testing/WithPersonalClient.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Traits;
+
+use Laravel\Passport\Client;
+use Laravel\Passport\PersonalAccessClient;
+
+trait WithPersonalClient
+{
+    public function setUp(): void
+    {
+
+        $client = Client::factory()->create([
+            'id' => env("PASSPORT_PERSONAL_ACCESS_CLIENT_ID"),
+            'secret' => env("PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET"),
+            'personal_access_client' => true
+        ]);
+
+        PersonalAccessClient::create([
+            'client_id' => $client->id,
+        ]);
+    }
+}


### PR DESCRIPTION
In testing, when we use the Sanctum package, everything is easy. We can to use the Sanctum::actingAs() method for testing But in the Passport, We must config our client save it in the database, and then write our test. This trait (WithPersoanlClient) will ease our work and like the RefreshDatabase trait can be used in our test. A Personal client is created for the user and without any config user can write a test and use Passport::actingAs().

The developer must define two properties in the .env file:

```
PASSPORT_PERSONAL_ACCESS_CLIENT_ID=[client_id]

PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET=[client-secret]

```

These values will be created for the user when installing the Passport in personal client mode.