### PR TITLE
[12.x] Reference the old docs for 12.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Laravel Passport is an OAuth2 server and API authentication package that is simp
 
 ## Official Documentation
 
-Documentation for Passport can be found on the [Laravel website](https://laravel.com/docs/passport).
+Documentation for Passport can be found on the [Laravel website](https://laravel.com/docs/11.x/passport).
 
 ## Contributing
 


### PR DESCRIPTION
Fix the link for docs. Please let me know if you prefer copy/pasting the whole docs to the README instead.