### PR TITLE
[13.x] Fix access to uninitialised typed static property

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -82,7 +82,7 @@ class Passport
     /**
      * The storage location of the encryption keys.
      */
-    public static string $keyPath;
+    public static string|null $keyPath = null;
 
     /**
      * The access token entity class name.


### PR DESCRIPTION
This adds a default value of `null` for `Passport::$keyPath`, otherwise you get the following error if you haven't used the `Passport::loadKeysFrom()` method (e.g. if you just want to use the default of `storage_path()`).

```
Typed static property Laravel\Passport\Passport::$keyPath must not be accessed before initialization
```

This error happens on this line: https://github.com/laravel/passport/blob/7a4c0a16f83805919e53e0ca7536f571785c42f0/src/Passport.php#L407