### PR TITLE
[13.x] Fix access to undefined route

### DIFF
--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -167,9 +167,11 @@ class PassportServiceProvider extends ServiceProvider
                     );
                 }
 
-                $server->enableGrantType(
-                    $this->makeDeviceCodeGrant(), Passport::tokensExpireIn()
-                );
+                if (Route::has('passport.device')) {
+                    $server->enableGrantType(
+                        $this->makeDeviceCodeGrant(), Passport::tokensExpireIn()
+                    );
+                }
             })
         );
     }


### PR DESCRIPTION
This PR fixes issue #1810 where an exception occurs if no route named `passport.device` is registered with the router. Now Passport will check if the route exists, and if it doesn't it simply won't register the grant for device codes