### PR TITLE
Use isset to check for initialisation

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -404,7 +404,7 @@ class Passport
     {
         $file = ltrim($file, '/\\');
 
-        return static::$keyPath
+        return isset(static::$keyPath)
             ? rtrim(static::$keyPath, '/\\').DIRECTORY_SEPARATOR.$file
             : storage_path($file);
     }


### PR DESCRIPTION
While upgrading to 13 I hit the below error:

```
Error: Typed static property Laravel\Passport\Passport::$keyPath must not be accessed before initialization in /Users/pat/Code/web/vendor/laravel/passport/src/Passport.php:407
```