### PR TITLE
[13.x] Fix middleware type error

### DIFF
--- a/src/Http/Middleware/CheckToken.php
+++ b/src/Http/Middleware/CheckToken.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Http\Middleware;
 
-use Laravel\Passport\AccessToken;
+use Laravel\Passport\Contracts\ScopeAuthorizable;
 use Laravel\Passport\Exceptions\MissingScopeException;
 
 class CheckToken extends ValidateToken
@@ -12,7 +12,7 @@ class CheckToken extends ValidateToken
      *
      * @throws \Laravel\Passport\Exceptions\MissingScopeException
      */
-    protected function validate(AccessToken $token, string ...$params): void
+    protected function validate(ScopeAuthorizable $token, string ...$params): void
     {
         foreach ($params as $scope) {
             if ($token->cant($scope)) {

--- a/src/Http/Middleware/CheckTokenForAnyScope.php
+++ b/src/Http/Middleware/CheckTokenForAnyScope.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Passport\Http\Middleware;
 
-use Laravel\Passport\AccessToken;
+use Laravel\Passport\Contracts\ScopeAuthorizable;
 use Laravel\Passport\Exceptions\MissingScopeException;
 
 class CheckTokenForAnyScope extends ValidateToken
@@ -12,7 +12,7 @@ class CheckTokenForAnyScope extends ValidateToken
      *
      * @throws \Laravel\Passport\Exceptions\MissingScopeException
      */
-    protected function validate(AccessToken $token, string ...$params): void
+    protected function validate(ScopeAuthorizable $token, string ...$params): void
     {
         foreach ($params as $scope) {
             if ($token->can($scope)) {

--- a/src/Http/Middleware/EnsureClientIsResourceOwner.php
+++ b/src/Http/Middleware/EnsureClientIsResourceOwner.php
@@ -3,6 +3,7 @@
 namespace Laravel\Passport\Http\Middleware;
 
 use Laravel\Passport\AccessToken;
+use Laravel\Passport\Contracts\ScopeAuthorizable;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Exceptions\MissingScopeException;
 
@@ -13,9 +14,13 @@ class EnsureClientIsResourceOwner extends ValidateToken
      *
      * @throws \Laravel\Passport\Exceptions\AuthenticationException|\Laravel\Passport\Exceptions\MissingScopeException
      */
-    protected function validate(AccessToken $token, string ...$params): void
+    protected function validate(ScopeAuthorizable $token, string ...$params): void
     {
-        if (! is_null($token->oauth_user_id) && $token->oauth_user_id !== $token->oauth_client_id) {
+        if (
+            $token instanceof AccessToken
+            && ! is_null($token->oauth_user_id)
+            && $token->oauth_user_id !== $token->oauth_client_id
+        ) {
             throw new AuthenticationException;
         }
 

--- a/src/Http/Middleware/ValidateToken.php
+++ b/src/Http/Middleware/ValidateToken.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Laravel\Passport\AccessToken;
+use Laravel\Passport\Contracts\ScopeAuthorizable;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
@@ -54,7 +55,7 @@ abstract class ValidateToken
      *
      * @throws \Laravel\Passport\Exceptions\AuthenticationException
      */
-    protected function validateToken(Request $request): AccessToken
+    protected function validateToken(Request $request): ScopeAuthorizable
     {
         // If the user is authenticated and already has an access token set via
         // the token guard, there's no need to validate the request's bearer
@@ -80,5 +81,5 @@ abstract class ValidateToken
     /**
      * Validate the given access token.
      */
-    abstract protected function validate(AccessToken $token, string ...$params): void;
+    abstract protected function validate(ScopeAuthorizable $token, string ...$params): void;
 }

--- a/tests/Unit/CheckTokenForAnyScopeTest.php
+++ b/tests/Unit/CheckTokenForAnyScopeTest.php
@@ -5,8 +5,10 @@ namespace Laravel\Passport\Tests\Unit;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Laravel\Passport\AccessToken;
+use Laravel\Passport\Contracts\OAuthenticatable;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Http\Middleware\CheckTokenForAnyScope;
+use Laravel\Passport\TransientToken;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -33,6 +35,27 @@ class CheckTokenForAnyScopeTest extends TestCase
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
+
+        $response = $middleware->handle($request, function () {
+            return new Response('response');
+        }, 'notfoo');
+
+        $this->assertSame('response', $response->getContent());
+    }
+
+    public function test_request_is_passed_along_if_token_is_transient()
+    {
+        $user = m::mock(OAuthenticatable::class);
+        $user->shouldReceive('currentAccessToken')->andReturn(new TransientToken());
+
+        $resourceServer = m::mock(ResourceServer::class);
+        $resourceServer->shouldNotReceive('validateAuthenticatedRequest');
+
+        $middleware = new CheckTokenForAnyScope($resourceServer);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+        $request->setUserResolver(fn () => $user);
 
         $response = $middleware->handle($request, function () {
             return new Response('response');

--- a/tests/Unit/CheckTokenTest.php
+++ b/tests/Unit/CheckTokenTest.php
@@ -5,8 +5,10 @@ namespace Laravel\Passport\Tests\Unit;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Laravel\Passport\AccessToken;
+use Laravel\Passport\Contracts\OAuthenticatable;
 use Laravel\Passport\Exceptions\AuthenticationException;
 use Laravel\Passport\Http\Middleware\CheckToken;
+use Laravel\Passport\TransientToken;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -33,6 +35,27 @@ class CheckTokenTest extends TestCase
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
+
+        $response = $middleware->handle($request, function () {
+            return new Response('response');
+        });
+
+        $this->assertSame('response', $response->getContent());
+    }
+
+    public function test_request_is_passed_along_if_token_is_transient()
+    {
+        $user = m::mock(OAuthenticatable::class);
+        $user->shouldReceive('currentAccessToken')->andReturn(new TransientToken());
+
+        $resourceServer = m::mock(ResourceServer::class);
+        $resourceServer->shouldNotReceive('validateAuthenticatedRequest');
+
+        $middleware = new CheckToken($resourceServer);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+        $request->setUserResolver(fn () => $user);
 
         $response = $middleware->handle($request, function () {
             return new Response('response');


### PR DESCRIPTION
Passport's changed middleware incorrectly assumes `OAuthenticatable::currentAccessToken()` returns an instance of `AccessToken`, when it actually returns any implementation of `ScopeAuthorizable` (which includes `TransientToken`). This PR fixes the `TypeError` that arises when the user has a token set that is not of type `AccessToken`.

Note that this is a potential breaking change for anyone that is extending the middleware on 13.0.0 (which is probably not many people since its not been out for long). However, I don't see any other way to fix this `TypeError` and not fixing this means you'd have to use your own middleware if you wanted to use `TransientToken` or a custom token implementation