### PR TITLE
Changed getTokenFromRequest method to handle null value and prevent type error

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -257,15 +257,17 @@ class TokenGuard implements Guard
      */
     protected function validCsrf(array $token): bool
     {
-        return isset($token['csrf']) && hash_equals(
-            $token['csrf'], $this->getTokenFromRequest()
-        );
+        $requestToken = $this->getTokenFromRequest();
+
+        return isset($token['csrf']) &&
+               is_string($requestToken) &&
+               hash_equals($token['csrf'], $requestToken);
     }
 
     /**
      * Get the CSRF token from the request.
      */
-    protected function getTokenFromRequest(): string
+    protected function getTokenFromRequest(): ?string
     {
         $token = $this->request->header('X-CSRF-TOKEN');
 
@@ -277,7 +279,7 @@ class TokenGuard implements Guard
             }
         }
 
-        return $token ?? '';
+        return $token;
     }
 
     /**

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -275,7 +275,7 @@ class TokenGuard implements Guard
             try {
                 $token = CookieValuePrefix::remove($this->encrypter->decrypt($header, static::serialized()));
             } catch (DecryptException) {
-                $token = '';
+                $token = null;
             }
         }
 

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -8,6 +8,7 @@ use Firebase\JWT\Key;
 use Illuminate\Auth\GuardHelpers;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\EncryptCookies;
@@ -269,10 +270,14 @@ class TokenGuard implements Guard
         $token = $this->request->header('X-CSRF-TOKEN');
 
         if (! $token && $header = $this->request->header('X-XSRF-TOKEN')) {
-            $token = CookieValuePrefix::remove($this->encrypter->decrypt($header, static::serialized()));
+            try {
+                $token = CookieValuePrefix::remove($this->encrypter->decrypt($header, static::serialized()));
+            } catch (DecryptException) {
+                $token = '';
+            }
         }
 
-        return $token;
+        return $token ?? '';
     }
 
     /**


### PR DESCRIPTION
This code change solves `Laravel\Passport\Guards\TokenGuard::getTokenFromRequest(): Return value must be of type string, null returned` error which can happen when `X-CSRF-TOKEN` is missing from the request.

It also aligns `getTokenFromRequest` method with it's counterpart in `VerifyCsrfToken` class (which has no return value and handles null value in `tokensMatch` method)
