### PR TITLE
[13.x] Fix object returned by mocked `validateAuthenticatedRequest()` method in `Passport::actingAsClient()` method

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -378,6 +378,7 @@ class Passport
             fn (ServerRequestInterface $request) => $request
                 ->withAttribute('oauth_client_id', $client->getKey())
                 ->withAttribute('oauth_scopes', $scopes)
+                ->withAttribute('oauth_user_id', null)
         );
 
         app()->instance(ResourceServer::class, $mock);


### PR DESCRIPTION
If you use `Passport::actingAsClient()` and call an api call that uses the `EnsureClientIsResourceOwner` middleware, then the following exception is currently thrown:
```
The following exception occurred during the last request:

ErrorException: Undefined property: Laravel\Passport\AccessToken::$oauth_access_token_id in /var/www/html/vendor/laravel/passport/src/AccessToken.php:95
Stack trace:
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(256): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError()
#1 /var/www/html/vendor/laravel/passport/src/AccessToken.php(95): Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::forwardsTo():255}()
#2 /var/www/html/vendor/laravel/passport/src/AccessToken.php(145): Laravel\Passport\AccessToken->getToken()
#3 /var/www/html/vendor/laravel/passport/src/AccessToken.php(95): Laravel\Passport\AccessToken->__get()
#4 /var/www/html/vendor/laravel/passport/src/AccessToken.php(145): Laravel\Passport\AccessToken->getToken()
#5 /var/www/html/vendor/laravel/passport/src/Http/Middleware/EnsureClientIsResourceOwner.php(21): Laravel\Passport\AccessToken->__get()
#6 /var/www/html/vendor/laravel/passport/src/Http/Middleware/ValidateToken.php(48): Laravel\Passport\Http\Middleware\EnsureClientIsResourceOwner->validate()
#7 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(208): Laravel\Passport\Http\Middleware\ValidateToken->handle()
#8 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Middleware/SubstituteBindings.php(50): Illuminate\Pipeline\Pipeline->{closure:{closure:Illuminate\Pipeline\Pipeline::carry():183}:184}()
#9 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(208): Illuminate\Routing\Middleware\SubstituteBindings->handle()
```
This is caused by the fact that the object returned by the mocked `validateAuthenticatedRequest` method does not set the `oauth_user_id` attribute. This PR fixes that.