### PR TITLE
[13.x] Fix skipping authorization consent when no scopes are requested

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -114,14 +114,25 @@ class AuthorizationController
      */
     protected function hasGrantedScopes(Authenticatable $user, Client $client, array $scopes): bool
     {
-        $tokensScopes = $client->tokens()->where([
+        $activeTokens = $client->tokens()->where([
             ['user_id', '=', $user->getAuthIdentifier()],
             ['revoked', '=', false],
             ['expires_at', '>', Date::now()],
-        ])->pluck('scopes')->flatten();
+        ]);
 
-        return $tokensScopes->isNotEmpty() &&
-            collect($scopes)->pluck('id')->diff($tokensScopes)->isEmpty();
+        // If no specific scope is requested, we'll simply check whether the given
+        // user has any active tokens that grant access to the specified client
+        // In this case, comparing the granted scopes is no longer necessary.
+        if (empty($scopes)) {
+            return $activeTokens->exists();
+        }
+
+        // Otherwise, we list all previously granted scopes from the active tokens
+        // of the given user that authorize access to the specified client, and
+        // check whether the newly requested scopes are included in that set.
+        return collect($scopes)->pluck('id')->diff(
+            $activeTokens->pluck('scopes')->flatten()
+        )->isEmpty();
     }
 
     /**

--- a/tests/Feature/AuthorizationCodeGrantTest.php
+++ b/tests/Feature/AuthorizationCodeGrantTest.php
@@ -163,6 +163,52 @@ class AuthorizationCodeGrantTest extends PassportTestCase
         $this->assertArrayHasKey('code', $params);
     }
 
+    public function testSkipsAuthorizationWhenHasActiveTokensAndEmptyScope()
+    {
+        $client = ClientFactory::new()->create();
+
+        $query = http_build_query([
+            'client_id' => $client->getKey(),
+            'redirect_uri' => $redirect = $client->redirect_uris[0],
+            'response_type' => 'code',
+            'scope' => '',
+            'state' => Str::random(40),
+        ]);
+
+        $user = UserFactory::new()->create();
+        $this->actingAs($user, 'web');
+        $json = $this->get('/oauth/authorize?'.$query)->json();
+
+        $response = $this->post('/oauth/authorize', ['auth_token' => $json['authToken']]);
+        parse_str(parse_url($response->headers->get('Location'), PHP_URL_QUERY), $params);
+
+        $this->post('/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'client_id' => $client->getKey(),
+            'client_secret' => $client->plainSecret,
+            'redirect_uri' => $redirect,
+            'code' => $params['code'],
+        ])->assertOk();
+
+        $query = http_build_query([
+            'client_id' => $client->getKey(),
+            'redirect_uri' => $redirect,
+            'response_type' => 'code',
+            'scope' => '',
+            'state' => $state = Str::random(40),
+        ]);
+
+        $response = $this->get('/oauth/authorize?'.$query);
+        $response->assertRedirect();
+
+        $location = $response->headers->get('Location');
+        parse_str(parse_url($location, PHP_URL_QUERY), $params);
+
+        $this->assertStringStartsWith($redirect.'?', $location);
+        $this->assertSame($state, $params['state']);
+        $this->assertArrayHasKey('code', $params);
+    }
+
     public function testValidateAuthorizationRequest()
     {
         $client = ClientFactory::new()->create();

--- a/tests/Feature/AuthorizationCodeGrantTest.php
+++ b/tests/Feature/AuthorizationCodeGrantTest.php
@@ -209,6 +209,51 @@ class AuthorizationCodeGrantTest extends PassportTestCase
         $this->assertArrayHasKey('code', $params);
     }
 
+    public function testPromptConsentForNewScope()
+    {
+        $client = ClientFactory::new()->create();
+
+        $query = http_build_query([
+            'client_id' => $client->getKey(),
+            'redirect_uri' => $redirect = $client->redirect_uris[0],
+            'response_type' => 'code',
+            'scope' => 'create read',
+            'state' => Str::random(40),
+        ]);
+
+        $user = UserFactory::new()->create();
+        $this->actingAs($user, 'web');
+        $json = $this->get('/oauth/authorize?'.$query)->json();
+
+        $response = $this->post('/oauth/authorize', ['auth_token' => $json['authToken']]);
+        parse_str(parse_url($response->headers->get('Location'), PHP_URL_QUERY), $params);
+
+        $this->post('/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'client_id' => $client->getKey(),
+            'client_secret' => $client->plainSecret,
+            'redirect_uri' => $redirect,
+            'code' => $params['code'],
+        ])->assertOk();
+
+        $query = http_build_query([
+            'client_id' => $client->getKey(),
+            'redirect_uri' => $redirect,
+            'response_type' => 'code',
+            'scope' => 'create update',
+            'state' => $state = Str::random(40),
+        ]);
+
+        $response = $this->get('/oauth/authorize?'.$query);
+
+        $response->assertOk();
+        $response->assertSessionHas('authRequest');
+        $response->assertSessionHas('authToken');
+        $json = $response->json();
+        $this->assertEqualsCanonicalizing(['client', 'user', 'scopes', 'request', 'authToken'], array_keys($json));
+        $this->assertSame(collect(Passport::scopesFor(['create', 'update']))->toArray(), $json['scopes']);
+    }
+
     public function testValidateAuthorizationRequest()
     {
         $client = ClientFactory::new()->create();


### PR DESCRIPTION
Fixes #1824 

This PR fixes a bug where requesting an authorization code with no scopes would always prompt the user for consent, even if they had already granted access to the specified client.
