### PR TITLE
[13.x] Fix "Undefined property $oauth_access_token_id error"

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -349,8 +349,8 @@ class Passport
     public static function actingAs(Authenticatable $user, array $scopes = [], ?string $guard = 'api'): Authenticatable
     {
         $token = new AccessToken([
-            'oauth_user_id' => $user->getAuthIdentifier(),
             'oauth_access_token_id' => null,
+            'oauth_user_id' => $user->getAuthIdentifier(),
             'oauth_scopes' => $scopes,
         ]);
 

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -350,8 +350,8 @@ class Passport
     {
         $token = new AccessToken([
             'oauth_user_id' => $user->getAuthIdentifier(),
-            'oauth_scopes' => $scopes,
             'oauth_access_token_id' => null,
+            'oauth_scopes' => $scopes,
         ]);
 
         $user->withAccessToken($token);

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -351,6 +351,7 @@ class Passport
         $token = new AccessToken([
             'oauth_user_id' => $user->getAuthIdentifier(),
             'oauth_scopes' => $scopes,
+            'oauth_access_token_id' => null,
         ]);
 
         $user->withAccessToken($token);


### PR DESCRIPTION
Resolves #1827 

This PR fixes `Undefined property $oauth_access_token_id error` when using `Passport::actingAs(....)` on tests

```
testing.ERROR: Undefined property: Laravel\Passport\AccessToken::$oauth_access_token_id {"userId":22,"exception":"[object] (ErrorException(code: 0): Undefined property: Laravel\\Passport\\AccessToken::$oauth_access_token_id at /var/www/vendor/laravel/passport/src/AccessToken.php:95)
[stacktrace]
#0 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(256): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 /var/www/vendor/laravel/passport/src/AccessToken.php(95): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->{closure:Illuminate\\Foundation\\Bootstrap\\HandleExceptions::forwardsTo():255}()
#2 /var/www/vendor/laravel/passport/src/AccessToken.php(145): Laravel\\Passport\\AccessToken->getToken()
#3 /var/www/vendor/laravel/passport/src/AccessToken.php(87): Laravel\\Passport\\AccessToken->__get()
#4 /var/www/app/Domains/Profile/Jobs/RevokeTokenJob.php(13): Laravel\\Passport\\AccessToken->revoke()
```