### PR TITLE
[13.x] Fix Exception Caused by Missing `AccessToken` Attributes

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -60,7 +60,12 @@ class AccessToken implements ScopeAuthorizable, Arrayable, Jsonable, JsonSeriali
      */
     public function can(string $scope): bool
     {
-        return in_array('*', $this->oauth_scopes) || $this->scopeExistsIn($scope, $this->oauth_scopes);
+        if (empty($this->attributes['oauth_scopes'])) {
+            return false;
+        }
+
+        return in_array('*', $this->attributes['oauth_scopes'])
+            || $this->scopeExistsIn($scope, $this->attributes['oauth_scopes']);
     }
 
     /**

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -84,7 +84,15 @@ class AccessToken implements ScopeAuthorizable, Arrayable, Jsonable, JsonSeriali
      */
     public function revoke(): bool
     {
-        return (bool) Passport::token()->newQuery()->whereKey($this->oauth_access_token_id)->update(['revoked' => true]);
+        if ($this->token) {
+            return $this->token->revoke();
+        }
+
+        if (isset($this->attributes['oauth_access_token_id'])) {
+            return (bool) Passport::token()->newQuery()->whereKey($this->attributes['oauth_access_token_id'])->update(['revoked' => true]);
+        }
+
+        return false;
     }
 
     /**
@@ -92,7 +100,15 @@ class AccessToken implements ScopeAuthorizable, Arrayable, Jsonable, JsonSeriali
      */
     protected function getToken(): ?Token
     {
-        return $this->token ??= Passport::token()->newQuery()->find($this->oauth_access_token_id);
+        if ($this->token) {
+            return $this->token;
+        }
+
+        if (isset($this->attributes['oauth_access_token_id'])) {
+            return $this->token = Passport::token()->newQuery()->find($this->attributes['oauth_access_token_id']);
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Fixes #1827
Closes #1828 

This PR fixes an issue where missing `AccessToken`'s attributes may cause exceptions when calling its methods.