### PR TITLE
added migration file check before publish passport-migration

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -4,6 +4,8 @@ namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
 use Laravel\Passport\Passport;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'passport:install')]

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -4,8 +4,6 @@ namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
 use Laravel\Passport\Passport;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'passport:install')]

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -35,7 +35,14 @@ class InstallCommand extends Command
     {
         $this->call('passport:keys', ['--force' => $this->option('force'), '--length' => $this->option('length')]);
 
-        $this->call('vendor:publish', ['--tag' => 'passport-migrations']);
+        //  Check if Passport migrations are already exist
+        $migrationFilesExist = collect(glob(database_path('migrations/*_create_oauth_*.php')))->isNotEmpty();
+
+        if (! $migrationFilesExist) {
+            $this->call('vendor:publish', ['--tag' => 'passport-migrations']);
+        } else {
+            $this->components->info('Passport migration files already exist. Skipping publishing...');
+        }
 
         if ($this->option('uuids')) {
             $this->configureUuids();

--- a/tests/Feature/Console/InstallCommand.php
+++ b/tests/Feature/Console/InstallCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature\Console;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Passport\Tests\Feature\PassportTestCase;
+
+class InstallCommandTest extends PassportTestCase
+{
+    public function test_migrations_are_published_if_they_do_not_exist()
+    {
+        File::shouldReceive('glob')
+            ->once()
+            ->with(database_path('migrations/*_create_oauth_*.php'))
+            ->andReturn([]);
+
+        // Run the passport:install command
+        $this->artisan('passport:install --no-interaction --force')
+            ->assertExitCode(0);
+    }
+
+    public function test_migrations_are_skipped_if_already_exist()
+    {
+        File::shouldReceive('glob')
+            ->once()
+            ->with(database_path('migrations/*_create_oauth_*.php'))
+            ->andReturn([
+                database_path('migrations/2025_01_01_000000_create_oauth_clients_table.php'),
+            ]);
+
+        $this->artisan('passport:install --no-interaction --force')
+            ->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
# Laravel Passport: Prevent Duplicate Migration Files

## ✨ Summary

This pull request improves the behavior of the `passport:install` command by adding a check to avoid re-publishing Passport migration files if they already exist in the `database/migrations` directory.

---

## 🥉 Problem

When running `php artisan passport:install` on a fresh Laravel setup using Laragon's Cmder terminal, the following error occurred:

```
LogicException
Choice question must have at least 1 choice available.
```

After troubleshooting, Attempting to rerun the command after partial execution led to **duplicate migration files** and migration errors.

---

## ✅ Solution

This PR introduces a pre-check before publishing Passport migration files. It ensures the command:

```php
$this->call('vendor:publish', ['--tag' => 'passport-migrations']);
```

...is only executed **if** the Passport migration files don't already exist.

### Migration Check Logic

```php
$migrationFilesExist = collect(glob(database_path('migrations/*_create_oauth_*.php')))->isNotEmpty();

if (! $migrationFilesExist) {
    $this->call('vendor:publish', ['--tag' => 'passport-migrations']);
} else {
    $this->components->info('Passport migration files already exist. Skipping publishing...');
}
```
## 🧹 Code Clean-up

- Removed unused imports (`DB` and `Schema`) for cleaner code and to pass static analysis.
---

## 🎯 Benefits

- ✅ Prevents accidental duplication of migration files
- ✅ Ensures safer and more predictable CLI execution
- ✅ Avoids migration class name conflicts
- ✅ Improves developer experience (DX) by being idempotent
- ✅ Aligns with Laravel's philosophy of intuitive tooling

---

## 🌟 Notes

This enhancement is fully backward compatible. Existing users of `passport:install` will now benefit from an extra safeguard against duplicate migrations without needing to change their workflow.

---

Thanks for reviewing this PR! Looking forward to your feedback and suggestions.