### PR TITLE
[13.x] Fix broken token relation when auth identifier is not PK

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -47,7 +47,7 @@ trait HasApiTokens
      */
     public function tokens(): HasMany
     {
-        return $this->hasMany(Passport::tokenModel(), 'user_id')
+        return $this->hasMany(Passport::tokenModel(), 'user_id', $this->getAuthIdentifierName())
             ->where(function (Builder $query): void {
                 $query->whereHas('client', function (Builder $query): void {
                     $query->where(function (Builder $query): void {


### PR DESCRIPTION
Passport refers to users through their auth identifier, similarly to guards and session handlers found in the framework itself. Normally this is also the user's primary key, but if a developer opts to use a different column as the auth identifier Passport will break, because while it stores the user's auth identifier it tries to look up tokens through the user's primary key.

This PR fixes this by making the `tokens()` relation use the auth identifier.

Passport already uses the auth identifier in most places, but it seems it isn't doing it consistently:
- https://github.com/laravel/passport/blob/951fe86b260adeb2485cfc251cbfa2fc9d7fe45a/src/Token.php#L83
- https://github.com/laravel/passport/blob/951fe86b260adeb2485cfc251cbfa2fc9d7fe45a/src/Passport.php#L352

This should **not** be a breaking change because the auth identifier is set to the primary key by default. If the developer was already using a different key Passport would already not work.

Related PR:
- https://github.com/laravel/passport/pull/1134