### PR TITLE
REFACTOR: Standardize all routes with the pattern `passport.<resource>{*}.<action>`

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -5,7 +5,7 @@ use Laravel\Passport\Passport;
 
 Route::post('/token', [
     'uses' => 'AccessTokenController@issueToken',
-    'as' => 'token',
+    'as' => 'token.issue',
     'middleware' => 'throttle',
 ]);
 


### PR DESCRIPTION
The route `passport.tokens` was the only one not complying with the naming pattern adopted on the rest of the project's routes. Also it can mislead to the interpretation that if the name omitted the action, it might be a getter.

In order to let this organized in the same standard, I am suggesting this refactor. 

<img width="1220" height="81" alt="image" src="https://github.com/user-attachments/assets/5e0ce3fe-30ec-45fd-9a83-eed306d49918" />