### PR TITLE
[13.x] Add an option to disable device code grant

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,7 +32,13 @@ All the authorization view's rendering logic may be customized using the appropr
 
     public function boot(): void
     {
+        // By providing the view names...
         Passport::authorizationView('auth.oauth.authorize');
+        Passport::deviceUserCodeView('auth.oauth.device.user-code');
+        Passport::deviceAuthorizationView('auth.oauth.device.authorize');
+
+        // Or using conventional names under the given prefix...
+        Passport::viewPrefix('auth.oauth');
     }
 
 ### Identify Clients by UUIDs

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,17 +15,19 @@ Route::get('/authorize', [
     'middleware' => 'web',
 ]);
 
-Route::get('/device', [
-    'uses' => 'DeviceUserCodeController',
-    'as' => 'device',
-    'middleware' => 'web',
-]);
+if (Passport::$deviceCodeGrantEnabled) {
+    Route::get('/device', [
+        'uses' => 'DeviceUserCodeController',
+        'as' => 'device',
+        'middleware' => 'web',
+    ]);
 
-Route::post('/device/code', [
-    'uses' => 'DeviceCodeController',
-    'as' => 'device.code',
-    'middleware' => 'throttle',
-]);
+    Route::post('/device/code', [
+        'uses' => 'DeviceCodeController',
+        'as' => 'device.code',
+        'middleware' => 'throttle',
+    ]);
+}
 
 $guard = config('passport.guard', null);
 
@@ -45,20 +47,22 @@ Route::middleware(['web', $guard ? 'auth:'.$guard : 'auth'])->group(function () 
         'as' => 'authorizations.deny',
     ]);
 
-    Route::get('/device/authorize', [
-        'uses' => 'DeviceAuthorizationController',
-        'as' => 'device.authorizations.authorize',
-    ]);
+    if (Passport::$deviceCodeGrantEnabled) {
+        Route::get('/device/authorize', [
+            'uses' => 'DeviceAuthorizationController',
+            'as' => 'device.authorizations.authorize',
+        ]);
 
-    Route::post('/device/authorize', [
-        'uses' => 'ApproveDeviceAuthorizationController',
-        'as' => 'device.authorizations.approve',
-    ]);
+        Route::post('/device/authorize', [
+            'uses' => 'ApproveDeviceAuthorizationController',
+            'as' => 'device.authorizations.approve',
+        ]);
 
-    Route::delete('/device/authorize', [
-        'uses' => 'DenyDeviceAuthorizationController',
-        'as' => 'device.authorizations.deny',
-    ]);
+        Route::delete('/device/authorize', [
+            'uses' => 'DenyDeviceAuthorizationController',
+            'as' => 'device.authorizations.deny',
+        ]);
+    }
 
     if (Passport::$registersJsonApiRoutes) {
         Route::get('/tokens', [

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -31,6 +31,11 @@ class Passport
     public static bool $revokeRefreshTokenAfterUse = true;
 
     /**
+     * Indicates if the device authorization grant type is enabled.
+     */
+    public static bool $deviceCodeGrantEnabled = true;
+
+    /**
      * Indicates if the implicit grant type is enabled.
      */
     public static bool $implicitGrantEnabled = false;

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -167,7 +167,7 @@ class PassportServiceProvider extends ServiceProvider
                     );
                 }
 
-                if (Route::has('passport.device')) {
+                if (Passport::$deviceCodeGrantEnabled && Route::has('passport.device')) {
                     $server->enableGrantType(
                         $this->makeDeviceCodeGrant(), Passport::tokensExpireIn()
                     );


### PR DESCRIPTION
Fixes #1836 

This PR adds an option property to the `Passport` class that allows disabling the "Device Code" grant. This is useful in applications where the grant is not needed, allowing you to avoid registering its routes, views, and enabling the grant unnecessarily.

You may disable this grant by adding the following line to the `boot` method of your application's `AppServiceProvider` class:

```php
Passport::$deviceCodeGrantEnabled = false;
```