### PR TITLE
 Fix viewPrefix Method to Match Documentation Example

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -598,9 +598,9 @@ class Passport
      */
     public static function viewPrefix(string $prefix): void
     {
-        static::authorizationView($prefix.'authorize');
-        static::deviceAuthorizationView($prefix.'device.authorize');
-        static::deviceUserCodeView($prefix.'device.user-code');
+        static::authorizationView($prefix.'.authorize');
+        static::deviceAuthorizationView($prefix.'.device.authorize');
+        static::deviceUserCodeView($prefix.'.device.user-code');
     }
 
     /**

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -598,6 +598,8 @@ class Passport
      */
     public static function viewPrefix(string $prefix): void
     {
+        $prefix = rtrim($prefix, '.');
+
         static::authorizationView($prefix.'.authorize');
         static::deviceAuthorizationView($prefix.'.device.authorize');
         static::deviceUserCodeView($prefix.'.device.user-code');


### PR DESCRIPTION
In the upgrade.md guide, there’s an example showing how to set the view prefix using:

```php
// Or using conventional names under the given prefix...
Passport::viewPrefix('auth.oauth');
 ```
 
However, in practice, this does not work as intended unless the prefix includes a trailing dot, like so:
```php
Passport::viewPrefix('auth.oauth.');
```
To address this inconsistency, this PR updates the viewPrefix method to automatically handle the trailing dot, making it consistent with the documentation. This avoids requiring users to remember to add the dot manually and ensures the example in the upgrade guide works out of the box.

Alternatively, we would have to update the documentation — but this fix ensures a better developer experience.