### PR TITLE
Added device code grant exception to purge command

### DIFF
--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -46,7 +46,9 @@ class PurgeCommand extends Command
         Passport::token()->newQuery()->where($constraint)->delete();
         Passport::authCode()->newQuery()->where($constraint)->delete();
         Passport::refreshToken()->newQuery()->where($constraint)->delete();
-        Passport::deviceCode()->newQuery()->where($constraint)->delete();
+        if (Passport::$deviceCodeGrantEnabled) {
+            Passport::deviceCode()->newQuery()->where($constraint)->delete();
+        }
 
         $this->components->info(sprintf('Purged %s.', implode(' and ', array_filter([
             $revoked ? 'revoked items' : null,


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
After updating Passport from 12 to 13 I noticed an error log where it failed to purge the not existing `oauth_device_codes` table. So in addition to https://github.com/laravel/passport/pull/1842 I thought this exception could/ should be added to the purge command as well.