### PR TITLE
[13.x] Added option to set device code token expire date

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -75,6 +75,11 @@ class Passport
     public static ?DateInterval $personalAccessTokensExpireIn = null;
 
     /**
+     * The date when device code tokens expire.
+     */
+    public static ?DateInterval $deviceCodeTokensExpireIn = null;
+
+    /**
      * The name for API token cookies.
      */
     public static string $cookie = 'laravel_token';
@@ -320,6 +325,20 @@ class Passport
         }
 
         return static::$personalAccessTokensExpireIn = $date instanceof DateTimeInterface
+            ? Date::now()->diff($date)
+            : $date;
+    }
+
+    /**
+     * Get or set when device code tokens expire.
+     */
+    public static function deviceCodeTokensExpireIn(DateTimeInterface|DateInterval|null $date = null): DateInterval
+    {
+        if (is_null($date)) {
+            return static::$deviceCodeTokensExpireIn ??= new DateInterval('P1Y');
+        }
+
+        return static::$deviceCodeTokensExpireIn = $date instanceof DateTimeInterface
             ? Date::now()->diff($date)
             : $date;
     }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -169,7 +169,7 @@ class PassportServiceProvider extends ServiceProvider
 
                 if (Passport::$deviceCodeGrantEnabled && Route::has('passport.device')) {
                     $server->enableGrantType(
-                        $this->makeDeviceCodeGrant(), Passport::tokensExpireIn()
+                        $this->makeDeviceCodeGrant(), Passport::deviceCodeTokensExpireIn() ?? Passport::tokensExpireIn()
                     );
                 }
             })


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds an option to set a custom expiry date for device code tokens. This implementation is similar to that of `tokensExpireIn` method. The registration of the device code grant has also been updated to add the new option or fallback to the `tokensExpireIn` if not set.

The reason for creating this PR is so that I can set a custom expiry date for the device code grant that I plan to use for my first party CLI tool. Currently my `tokensExpireIn` in is set to 8 hours which would lead to a bad developer experience for anyone wanting to use my CLI tool on a daily basis.