### PR TITLE
Update Client Model

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -209,7 +209,7 @@ class Client extends Model
      */
     public function confidential(): bool
     {
-        return ! empty($this->secret);
+        return ! empty($this->getAttributes()['secret'] ?? null);
     }
 
     /**


### PR DESCRIPTION
On generating personal access token **createToken()** throws error which is
"Personal access client not found for '$provider' user provider. Please create one."

It occurs due to **confidential()** in Client model returns false as the secret attribute is hidden, but getAttributes() does the job.

**Note: I tested passport along with mongodb package.**
