### PR TITLE
[13.x] Fix issuing PAT with configured trusted hosts

### DIFF
--- a/src/PersonalAccessTokenFactory.php
+++ b/src/PersonalAccessTokenFactory.php
@@ -39,7 +39,7 @@ class PersonalAccessTokenFactory
      */
     protected function createRequest(string|int $userId, string $name, array $scopes, string $provider): ServerRequestInterface
     {
-        return (new PsrHttpFactory)->createRequest(Request::create('', 'POST', [
+        return (new PsrHttpFactory)->createRequest(Request::create(config('app.url'), 'POST', [
             'grant_type' => 'personal_access',
             'provider' => $provider,
             'user_id' => $userId,

--- a/tests/Feature/PersonalAccessGrantWithTrustedHostsTest.php
+++ b/tests/Feature/PersonalAccessGrantWithTrustedHostsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature;
+
+use Illuminate\Http\Request;
+use Laravel\Passport\Database\Factories\ClientFactory;
+use Laravel\Passport\PersonalAccessTokenResult;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
+use Workbench\Database\Factories\UserFactory;
+
+class PersonalAccessGrantWithTrustedHostsTest extends PassportTestCase
+{
+    use WithLaravelMigrations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['config']->set('app.url', 'https://laravel.test');
+
+        Request::setTrustedHosts(['laravel.test']);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->app['config']->set('app.url', 'http://localhost');
+
+        Request::setTrustedHosts([]);
+
+        parent::tearDown();
+    }
+
+    public function testIssueToken()
+    {
+        $user = UserFactory::new()->create();
+
+        ClientFactory::new()->asPersonalAccessTokenClient()->create();
+
+        $result = $user->createToken('test');
+
+        $this->assertInstanceOf(PersonalAccessTokenResult::class, $result);
+        $this->assertArrayHasKey('accessToken', $result->toArray());
+    }
+}


### PR DESCRIPTION
Fixes #1851 

The request created in `\Laravel\Passport\PersonalAccessTokenFactory` is a dummy, and its URI is not important. However, when trusted hosts are configured, `\Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory::createRequest()` calls `\Symfony\Component\HttpFoundation\Request::getHost()`, which validates the trusted hosts and causes an exception to be thrown.

This PR resolves the exception thrown when issuing Personal Access Tokens with configured trusted hosts.