### PR TITLE
[13.x] Test Improvements

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -139,7 +139,9 @@ If you prefer to use the new structure, you may create a migration to apply the 
 
 ```php
 Schema::table('oauth_clients', function (Blueprint $table) {
-    $table->nullableMorphs('owner')->after('user_id');
+    $table->after('user_id', function (Blueprint $table) {
+        $table->nullableMorphs('owner');
+    });
 
     $table->after('provider', function (Blueprint $table) {
         $table->text('redirect_uris');

--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport\Console;
 use Illuminate\Console\Command;
 use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Passport;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'passport:client')]
@@ -149,7 +150,8 @@ class ClientCommand extends Command
             ? ! $this->option('public')
             : $this->components->confirm('Would you like to make this client confidential?', true);
 
-        $enableDeviceFlow = $this->confirm('Would you like to enable the device authorization flow for this client?');
+        $enableDeviceFlow = Passport::$deviceCodeGrantEnabled &&
+            $this->confirm('Would you like to enable the device authorization flow for this client?');
 
         return $clients->createAuthorizationCodeGrantClient(
             $this->option('name'), explode(',', $redirect), $confidential, null, $enableDeviceFlow

--- a/tests/Feature/AccessTokenControllerTest.php
+++ b/tests/Feature/AccessTokenControllerTest.php
@@ -49,8 +49,7 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertArrayHasKey('expires_in', $decodedResponse);
         $this->assertArrayHasKey('access_token', $decodedResponse);
         $this->assertSame('Bearer', $decodedResponse['token_type']);
-        $expiresInSeconds = 31536000;
-        $this->assertEqualsWithDelta($expiresInSeconds, $decodedResponse['expires_in'], 5);
+        $this->assertEqualsWithDelta(31536000, $decodedResponse['expires_in'], 2);
     }
 
     public function testGettingAccessTokenWithClientCredentialsGrantInvalidClientSecret()
@@ -131,8 +130,7 @@ class AccessTokenControllerTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $decodedResponse);
         $this->assertArrayHasKey('refresh_token', $decodedResponse);
         $this->assertSame('Bearer', $decodedResponse['token_type']);
-        $expiresInSeconds = 31536000;
-        $this->assertEqualsWithDelta($expiresInSeconds, $decodedResponse['expires_in'], 5);
+        $this->assertEqualsWithDelta(31536000, $decodedResponse['expires_in'], 2);
     }
 
     public function testGettingAccessTokenWithPasswordGrantWithInvalidPassword()

--- a/tests/Feature/AuthorizationCodeGrantTest.php
+++ b/tests/Feature/AuthorizationCodeGrantTest.php
@@ -76,7 +76,7 @@ class AuthorizationCodeGrantTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $json);
         $this->assertArrayHasKey('refresh_token', $json);
         $this->assertSame('Bearer', $json['token_type']);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $json['expires_in'], 2);
 
         Route::get('/foo', fn (Request $request) => $request->user()->currentAccessToken()->toJson())
             ->middleware('auth:api');

--- a/tests/Feature/AuthorizationCodeGrantWithPkceTest.php
+++ b/tests/Feature/AuthorizationCodeGrantWithPkceTest.php
@@ -81,7 +81,7 @@ class AuthorizationCodeGrantWithPkceTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $json);
         $this->assertArrayHasKey('refresh_token', $json);
         $this->assertSame('Bearer', $json['token_type']);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $json['expires_in'], 2);
 
         $refreshToken = $json['refresh_token'];
 
@@ -103,7 +103,7 @@ class AuthorizationCodeGrantWithPkceTest extends PassportTestCase
 
         $this->assertArrayHasKey('access_token', $newToken);
         $this->assertArrayHasKey('refresh_token', $newToken);
-        $this->assertSame(31536000, $newToken['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $newToken['expires_in'], 2);
         $this->assertSame('Bearer', $newToken['token_type']);
     }
 

--- a/tests/Feature/ClientCredentialsGrantTest.php
+++ b/tests/Feature/ClientCredentialsGrantTest.php
@@ -40,7 +40,7 @@ class ClientCredentialsGrantTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $json);
         $this->assertArrayNotHasKey('refresh_token', $json);
         $this->assertSame('Bearer', $json['token_type']);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $json['expires_in'], 2);
 
         Route::get('/foo', fn (Request $request) => response('response'))
             ->middleware([EnsureClientIsResourceOwner::using(['create', 'delete'])]);
@@ -70,7 +70,7 @@ class ClientCredentialsGrantTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $json);
         $this->assertArrayNotHasKey('refresh_token', $json);
         $this->assertSame('Bearer', $json['token_type']);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $json['expires_in'], 2);
 
         Route::get('/foo', fn (Request $request) => response('response'))
             ->middleware([EnsureClientIsResourceOwner::using(['create', 'delete'])]);

--- a/tests/Feature/DeviceAuthorizationGrantTest.php
+++ b/tests/Feature/DeviceAuthorizationGrantTest.php
@@ -175,7 +175,7 @@ class DeviceAuthorizationGrantTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $json);
         $this->assertArrayHasKey('refresh_token', $json);
         $this->assertSame('Bearer', $json['token_type']);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $json['expires_in'], 2);
 
         Route::get('/foo', fn (Request $request) => $request->user()->currentAccessToken()->toJson())
             ->middleware('auth:api');
@@ -254,7 +254,7 @@ class DeviceAuthorizationGrantTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $json);
         $this->assertArrayHasKey('refresh_token', $json);
         $this->assertSame('Bearer', $json['token_type']);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $json['expires_in'], 2);
     }
 
     public function testUnauthorizedClient()

--- a/tests/Feature/ImplicitGrantTest.php
+++ b/tests/Feature/ImplicitGrantTest.php
@@ -65,7 +65,7 @@ class ImplicitGrantTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $params);
         $this->assertArrayNotHasKey('refresh_token', $params);
         $this->assertSame('Bearer', $params['token_type']);
-        $this->assertSame('31536000', $params['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $params['expires_in'], 2);
 
         Route::get('/foo', fn (Request $request) => $request->user()->currentAccessToken()->toJson())
             ->middleware('auth:api');
@@ -145,7 +145,7 @@ class ImplicitGrantTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $params);
         $this->assertArrayNotHasKey('refresh_token', $params);
         $this->assertSame('Bearer', $params['token_type']);
-        $this->assertSame('31536000', $params['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $params['expires_in'], 2);
     }
 
     public function testValidateAuthorizationRequest()

--- a/tests/Feature/PasswordGrantTest.php
+++ b/tests/Feature/PasswordGrantTest.php
@@ -48,7 +48,7 @@ class PasswordGrantTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $json);
         $this->assertArrayHasKey('refresh_token', $json);
         $this->assertSame('Bearer', $json['token_type']);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $json['expires_in'], 2);
 
         Route::get('/foo', fn (Request $request) => $request->user()->currentAccessToken()->toJson())
             ->middleware('auth:api');
@@ -77,7 +77,7 @@ class PasswordGrantTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $json);
         $this->assertArrayHasKey('refresh_token', $json);
         $this->assertSame('Bearer', $json['token_type']);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $json['expires_in'], 2);
 
         Route::get('/foo', fn (Request $request) => $request->user()->currentAccessToken()->toJson())
             ->middleware('auth:api');
@@ -167,7 +167,7 @@ class PasswordGrantTest extends PassportTestCase
         $this->assertArrayHasKey('access_token', $json);
         $this->assertArrayHasKey('refresh_token', $json);
         $this->assertSame('Bearer', $json['token_type']);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $json['expires_in'], 2);
     }
 
     public function testUnauthorizedClient()

--- a/tests/Feature/PersonalAccessGrantTest.php
+++ b/tests/Feature/PersonalAccessGrantTest.php
@@ -38,7 +38,7 @@ class PersonalAccessGrantTest extends PassportTestCase
         $this->assertArrayHasKey('accessToken', $result->toArray());
         $this->assertSame($token->getKey(), $result->accessTokenId);
         $this->assertSame('Bearer', $result->tokenType);
-        $this->assertSame(31536000, $result->expiresIn);
+        $this->assertEqualsWithDelta(31536000, $result->expiresIn, 2);
         $this->assertSame($client->getKey(), $token->client_id);
         $this->assertSame($user->getAuthIdentifier(), $token->user_id);
         $this->assertSame(['bar'], $token->scopes);

--- a/tests/Feature/RefreshTokenGrantTest.php
+++ b/tests/Feature/RefreshTokenGrantTest.php
@@ -46,7 +46,7 @@ class RefreshTokenGrantTest extends PassportTestCase
 
         $this->assertArrayHasKey('access_token', $newToken);
         $this->assertArrayHasKey('refresh_token', $newToken);
-        $this->assertSame(31536000, $newToken['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $newToken['expires_in'], 2);
         $this->assertSame('Bearer', $newToken['token_type']);
 
         Route::get('/foo', fn (Request $request) => $request->user()->currentAccessToken()->toJson())
@@ -92,7 +92,7 @@ class RefreshTokenGrantTest extends PassportTestCase
 
         $this->assertArrayHasKey('access_token', $newToken);
         $this->assertArrayHasKey('refresh_token', $newToken);
-        $this->assertSame(31536000, $newToken['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $newToken['expires_in'], 2);
         $this->assertSame('Bearer', $newToken['token_type']);
 
         Route::get('/foo', fn (Request $request) => $request->user()->currentAccessToken()->toJson())
@@ -117,7 +117,7 @@ class RefreshTokenGrantTest extends PassportTestCase
 
         $this->assertArrayHasKey('access_token', $json);
         $this->assertArrayHasKey('refresh_token', $json);
-        $this->assertSame(31536000, $json['expires_in']);
+        $this->assertEqualsWithDelta(31536000, $json['expires_in'], 2);
         $this->assertSame('Bearer', $json['token_type']);
     }
 


### PR DESCRIPTION
* Related to https://github.com/laravel/passport/pull/1843#issuecomment-3265090535
   * Fix the upgrade guide code, since calling `after` modifier is not supported on `nullableMorphs`.
* Related to #1842
   * Check if Device code grant is enabled before prompting the user on `passport:client` Artisan command.
* Test Improvements
   * Tests are intermittently failing because the expire time is being rounded to 31,535,999 instead of 31,536,000.