### PR TITLE
[13.x] Prevent duplicate Passport migrations by skipping existing files in passport:install

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -35,7 +35,36 @@ class InstallCommand extends Command
         ]);
 
         $this->call('vendor:publish', ['--tag' => 'passport-config']);
-        $this->call('vendor:publish', ['--tag' => 'passport-migrations']);
+                
+        // Selectively publish Passport migrations (plain PHP)
+        $migrationPath = database_path('migrations');
+        $passportMigrationPath = base_path('vendor/laravel/passport/database/migrations');
+
+        // Build a list of all migration stubs in the package
+        $stubFiles = glob($passportMigrationPath . '/*.php');
+
+        $this->components->info('Checking Passport migrations…');
+
+        foreach ($stubFiles as $stubPath) {
+            // Strip the timestamp from the stub filename
+            $stubFilename = basename($stubPath);
+            $baseName = preg_replace('/^\d+_\d+_\d+_\d+_/', '_', $stubFilename);
+
+            // Check if a migration with this base name already exists
+            $existing = glob($migrationPath . '/*' . $baseName);
+
+            if (empty($existing)) {
+                // No migration yet → copy it with a new timestamp
+                $newName = date('Y_m_d_His') . $baseName;
+                $target = $migrationPath . '/' . $newName;
+                copy($stubPath, $target);
+
+                $this->components->info("Published Passport migration: {$newName}");
+                usleep(100000); // small delay so timestamps differ
+            } else {
+                $this->components->warn("Skipped existing Passport migration: {$baseName}");
+            }
+        }
 
         if ($this->components->confirm('Would you like to run all pending database migrations?', true)) {
             $this->call('migrate');

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -56,7 +56,7 @@ class InstallCommand extends Command
             if (empty($existing)) {
                 // No migration yet → copy it with a new timestamp
                 $newName = date('Y_m_d_His').$baseName;
-+               $target = $migrationPath.'/'.$newName;
+                $target = $migrationPath.'/'.$newName;
                 copy($stubPath, $target);
 
                 $this->components->info("Published Passport migration: {$newName}");

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -56,7 +56,7 @@ class InstallCommand extends Command
             if (empty($existing)) {
                 // No migration yet → copy it with a new timestamp
                 $newName = date('Y_m_d_His').$baseName;
-+                $target = $migrationPath.'/'.$newName;
++               $target = $migrationPath.'/'.$newName;
                 copy($stubPath, $target);
 
                 $this->components->info("Published Passport migration: {$newName}");

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -35,13 +35,13 @@ class InstallCommand extends Command
         ]);
 
         $this->call('vendor:publish', ['--tag' => 'passport-config']);
-                
+
         // Selectively publish Passport migrations (plain PHP)
         $migrationPath = database_path('migrations');
         $passportMigrationPath = base_path('vendor/laravel/passport/database/migrations');
 
         // Build a list of all migration stubs in the package
-        $stubFiles = glob($passportMigrationPath . '/*.php');
+        $stubFiles = glob($passportMigrationPath.'/*.php');
 
         $this->components->info('Checking Passport migrations…');
 
@@ -51,12 +51,12 @@ class InstallCommand extends Command
             $baseName = preg_replace('/^\d+_\d+_\d+_\d+_/', '_', $stubFilename);
 
             // Check if a migration with this base name already exists
-            $existing = glob($migrationPath . '/*' . $baseName);
+            $existing = glob($migrationPath.'/*'.$baseName);
 
             if (empty($existing)) {
                 // No migration yet → copy it with a new timestamp
-                $newName = date('Y_m_d_His') . $baseName;
-                $target = $migrationPath . '/' . $newName;
+                $newName = date('Y_m_d_His').$baseName;
++                $target = $migrationPath.'/'.$newName;
                 copy($stubPath, $target);
 
                 $this->components->info("Published Passport migration: {$newName}");


### PR DESCRIPTION
**Description:**
The `passport:install` command currently republishes all Passport migration stubs on every run. Each new copy gets a fresh timestamp, which leads to duplicate migration files and database errors when running `migrate`.

This is a **serious problem** for projects running Passport in production or multiple environments.

This commit updates `InstallCommand` to:

• Check for existing Passport migration files in the app’s `database/migrations` directory.
• Skip publishing a stub if its base name already exists.
• Publish only missing migrations with a new timestamp.
• Log clear messages for published and skipped migrations.

**Example output:**

```
Published Passport migration: 2025_09_24_120000_create_oauth_auth_codes_table.php
Skipped existing Passport migration: _create_oauth_access_tokens_table.php
```

This makes the command idempotent and safe to run multiple times, while retaining the default behaviour for first-time installs.

**Tested on:** Laravel 12.x

---

**Note:**
@laravel – this issue can cause duplicate tables and migration errors in real projects. Fixing this will prevent developers from encountering database conflicts when running `passport:install` multiple times.