### PR TITLE
Enable JWKS-based JWT verification via `kid` header

### DIFF
--- a/src/Bridge/AccessToken.php
+++ b/src/Bridge/AccessToken.php
@@ -2,11 +2,15 @@
 
 namespace Laravel\Passport\Bridge;
 
+use DateTimeImmutable;
+use Laravel\Passport\Passport;
+use Lcobucci\JWT\Token;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
 use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
+use RuntimeException;
 
 class AccessToken implements AccessTokenEntityInterface
 {
@@ -29,5 +33,86 @@ class AccessToken implements AccessTokenEntityInterface
         }
 
         $this->setClient($client);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function convertToJWT(): Token
+    {
+        $this->initJwtConfiguration();
+
+        return $this->jwtConfiguration->builder()
+            ->withHeader('kid', $this->determineKid())
+            ->permittedFor($this->getClient()->getIdentifier())
+            ->identifiedBy($this->getIdentifier())
+            ->issuedAt(new DateTimeImmutable())
+            ->canOnlyBeUsedAfter(new DateTimeImmutable())
+            ->expiresAt($this->getExpiryDateTime())
+            ->relatedTo($this->getSubjectIdentifier())
+            ->withClaim('scopes', $this->getScopes())
+            ->getToken($this->jwtConfiguration->signer(), $this->jwtConfiguration->signingKey());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toString(): string
+    {
+        return $this->convertToJWT()->toString();
+    }
+
+    /**
+     * Determine the 'kid' (key ID) for the JWT header, based on the public key's JWK thumbprint.
+     * See RFC 7638: https://tools.ietf.org/html/rfc7638.
+     */
+    protected function determineKid(): string
+    {
+        $pem = $this->getPublicKeyMaterial();
+
+        $res = openssl_pkey_get_public($pem);
+        if ($res === false) {
+            throw new RuntimeException('Invalid public key material');
+        }
+
+        $details = openssl_pkey_get_details($res);
+        if ($details === false || $details['type'] !== OPENSSL_KEYTYPE_RSA) {
+            throw new RuntimeException('Only RSA public keys are supported');
+        }
+
+        // Base64url helpers
+        $b64url = fn (string $bin) => rtrim(strtr(base64_encode($bin), '+/', '-_'), '=');
+
+        // Build minimal JWK (kty, n, e)
+        $jwk = [
+            'e' => $b64url($details['rsa']['e']),
+            'kty' => 'RSA',
+            'n' => $b64url($details['rsa']['n']),
+        ];
+
+        // Canonical JSON: keys sorted, no spaces or escapes that change semantics
+        ksort($jwk);
+        $json = json_encode($jwk, JSON_UNESCAPED_SLASHES);
+
+        // RFC 7638 thumbprint = SHA-256 over canonical JSON, base64url-encoded
+        $thumb = hash('sha256', $json, true);
+
+        return $b64url($thumb);
+    }
+
+    /**
+     * Find the public key material from config or file.
+     */
+    private function getPublicKeyMaterial(): string
+    {
+        if ($keyMaterial = config('passport.public_key')) {
+            return $keyMaterial;
+        }
+
+        if (file_exists($publicKey = Passport::keyPath('oauth-public.key'))) {
+            return file_get_contents($publicKey);
+        }
+
+        throw new RuntimeException('No public key available');
     }
 }


### PR DESCRIPTION
# Add support for `kid` header in JWTs

Hi everyone! 👋

This is my first contribution to the Laravel ecosystem, and I’m excited to propose a feature that I believe will be helpful for many developers.

### Motivation

This PR adds support for the [`kid` header as defined in RFC 7515, section 4.1.4](https://www.rfc-editor.org/rfc/rfc7515#section-4.1.4).

By including the `kid` header, third-party applications can leverage JWKS (JSON Web Key Sets) published by the standard discovery endpoint (`/.well-known/oauth-authorization-server`) to validate JWTs issued by Passport.

### Benefits

* **Key rotation support**: Applications can seamlessly validate tokens signed with both old and new keys during a rotation.
* **Better interoperability**: Third-party services can consume JWKS endpoints, ensuring more standardized JWT verification.

### How the `kid` is generated

The `kid` is automatically derived from the **public key** using the [JWK Thumbprint (RFC 7638)](https://www.rfc-editor.org/rfc/rfc7638) standard:

* The RSA key parameters (`n`, `e`) are extracted.
* A minimal JWK is built and hashed with SHA-256.
* The result is base64url-encoded to form the `kid`.

This means every public key always produces the same `kid`. When you rotate keys, the new one will get a different `kid`, allowing clients to select the right key from your JWKS automatically.

### Example

An OAuth discovery document may expose a JWKS URI:

```json
{
  "jwks_uri": "https://example.com/.well-known/jwks.json"
}
```

Fetching `https://example.com/.well-known/jwks.json` could return something like:

```json
{
  "keys": [
    {
      "kty": "RSA",
      "n": "...",
      "e": "AQAB",
      "alg": "RS256",
      "kid": "...",
      "use": "sig"
    }
  ]
}
```

A third-party application can then use these keys to verify tokens issued by Passport:

```php
$keys = JWK::parseKeySet(Cache::remember('jwks', Carbon::now()->addHour(), function () {
    $resp = file_get_contents('https://example.com/.well-known/jwks.json');
    return json_decode($resp, true);
}));

$decoded = (new JWT())->decode($request->bearerToken(), $keys);
```

### Open Questions

* Would `getPublicKeyMaterial()` be better placed elsewhere in the codebase?
* Should Passport middlewares also include built-in JWKS checks to benefit directly from this functionality?