### PR TITLE
[13.x] Support Token Revocation RFC7009 and Token Introspection RFC7662

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,19 @@
         "illuminate/encryption": "^11.35|^12.0",
         "illuminate/http": "^11.35|^12.0",
         "illuminate/support": "^11.35|^12.0",
-        "league/oauth2-server": "^9.2",
+        "league/oauth2-server": "dev-master-token-revocation-introspection",
         "php-http/discovery": "^1.20",
         "phpseclib/phpseclib": "^3.0",
         "psr/http-factory-implementation": "*",
         "symfony/console": "^7.1",
         "symfony/psr-http-message-bridge": "^7.1"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/hafezdivandari/oauth2-server"
+        }
+    ],
     "require-dev": {
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^9.9|^10.0",

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,14 @@ if (Passport::$deviceCodeGrantEnabled) {
     ]);
 }
 
+if (Passport::$tokenRevocationEnabled) {
+    Route::post('/revoke', [
+        'uses' => 'RevokeTokenController',
+        'as' => 'revoke',
+        'middleware' => 'throttle',
+    ]);
+}
+
 $guard = config('passport.guard', null);
 
 Route::middleware(['web', $guard ? 'auth:'.$guard : 'auth'])->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,6 +37,14 @@ if (Passport::$tokenRevocationEnabled) {
     ]);
 }
 
+if (Passport::$tokenIntrospectionEnabled) {
+    Route::post('/introspect', [
+        'uses' => 'IntrospectTokenController',
+        'as' => 'introspect',
+        'middleware' => 'throttle',
+    ]);
+}
+
 $guard = config('passport.guard', null);
 
 Route::middleware(['web', $guard ? 'auth:'.$guard : 'auth'])->group(function () {

--- a/src/Http/Controllers/IntrospectTokenController.php
+++ b/src/Http/Controllers/IntrospectTokenController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Laravel\Passport\Http\Controllers;
+
+use League\OAuth2\Server\TokenServer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class IntrospectTokenController
+{
+    use ConvertsPsrResponses, HandlesOAuthErrors;
+
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct(
+        protected TokenServer $server,
+    ) {
+    }
+
+    /**
+     * Introspect a token.
+     */
+    public function __invoke(ServerRequestInterface $psrRequest, ResponseInterface $psrResponse): Response
+    {
+        return $this->withErrorHandling(
+            fn () => $this->convertResponse(
+                $this->server->respondToTokenIntrospectionRequest($psrRequest, $psrResponse)
+            )
+        );
+    }
+}

--- a/src/Http/Controllers/RevokeTokenController.php
+++ b/src/Http/Controllers/RevokeTokenController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Laravel\Passport\Http\Controllers;
+
+use League\OAuth2\Server\TokenServer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class RevokeTokenController
+{
+    use ConvertsPsrResponses, HandlesOAuthErrors;
+
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct(
+        protected TokenServer $server,
+    ) {
+    }
+
+    /**
+     * Revoke a token.
+     */
+    public function __invoke(ServerRequestInterface $psrRequest, ResponseInterface $psrResponse): Response
+    {
+        return $this->withErrorHandling(
+            fn () => $this->convertResponse(
+                $this->server->respondToTokenRevocationRequest($psrRequest, $psrResponse)
+            )
+        );
+    }
+}

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -48,12 +48,12 @@ class Passport
     /**
      * Indicates if the token introspection is enabled.
      */
-    public static bool $tokenIntrospectionEnabled = true;
+    public static bool $tokenIntrospectionEnabled = false;
 
     /**
      * Indicates if the token revocation is enabled.
      */
-    public static bool $tokenRevocationEnabled = true;
+    public static bool $tokenRevocationEnabled = false;
 
     /**
      * The default scope.
@@ -199,6 +199,22 @@ class Passport
     public static function enablePasswordGrant(): void
     {
         static::$passwordGrantEnabled = true;
+    }
+
+    /**
+     * Enable the token introspection.
+     */
+    public static function enableTokenIntrospection(): void
+    {
+        static::$tokenIntrospectionEnabled = true;
+    }
+
+    /**
+     * Enable the token revocation.
+     */
+    public static function enableTokenRevocation(): void
+    {
+        static::$tokenRevocationEnabled = true;
     }
 
     /**

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -46,6 +46,11 @@ class Passport
     public static bool $passwordGrantEnabled = false;
 
     /**
+     * Indicates if the token revocation is enabled.
+     */
+    public static bool $tokenRevocationEnabled = true;
+
+    /**
      * The default scope.
      */
     public static string $defaultScope = '';

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -46,6 +46,11 @@ class Passport
     public static bool $passwordGrantEnabled = false;
 
     /**
+     * Indicates if the token introspection is enabled.
+     */
+    public static bool $tokenIntrospectionEnabled = true;
+
+    /**
      * Indicates if the token revocation is enabled.
      */
     public static bool $tokenRevocationEnabled = true;

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -32,6 +32,7 @@ use League\OAuth2\Server\Grant\PasswordGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use League\OAuth2\Server\ResourceServer;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use League\OAuth2\Server\TokenServer;
 
 class PassportServiceProvider extends ServiceProvider
 {
@@ -116,6 +117,7 @@ class PassportServiceProvider extends ServiceProvider
         $this->registerResponseBindings();
         $this->registerAuthorizationServer();
         $this->registerResourceServer();
+        $this->registerTokenServer();
         $this->registerGuard();
     }
 
@@ -275,6 +277,20 @@ class PassportServiceProvider extends ServiceProvider
         $this->app->singleton(ResourceServer::class, fn ($container) => new ResourceServer(
             $container->make(Bridge\AccessTokenRepository::class),
             $this->makeCryptKey('public')
+        ));
+    }
+
+    /**
+     * Register the token server.
+     */
+    protected function registerTokenServer(): void
+    {
+        $this->app->singleton(TokenServer::class, fn ($container) => new TokenServer(
+            $container->make(Bridge\ClientRepository::class),
+            $container->make(Bridge\AccessTokenRepository::class),
+            $container->make(Bridge\RefreshTokenRepository::class),
+            $this->makeCryptKey('public'),
+            Passport::tokenEncryptionKey($container->make('encrypter'))
         ));
     }
 

--- a/tests/Feature/TokenIntrospectionTest.php
+++ b/tests/Feature/TokenIntrospectionTest.php
@@ -17,6 +17,8 @@ class TokenIntrospectionTest extends PassportTestCase
 
     protected function setUp(): void
     {
+        Passport::enableTokenIntrospection();
+
         parent::setUp();
 
         Passport::tokensCan([

--- a/tests/Feature/TokenIntrospectionTest.php
+++ b/tests/Feature/TokenIntrospectionTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature;
+
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Laravel\Passport\Client;
+use Laravel\Passport\Database\Factories\ClientFactory;
+use Laravel\Passport\Passport;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
+use Workbench\Database\Factories\UserFactory;
+
+class TokenIntrospectionTest extends PassportTestCase
+{
+    use WithLaravelMigrations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Passport::tokensCan([
+            'create' => 'Create',
+            'read' => 'Read',
+            'update' => 'Update',
+            'delete' => 'Delete',
+        ]);
+
+        Passport::authorizationView(fn ($params) => $params);
+    }
+
+    public function testIntrospectToken()
+    {
+        $client = ClientFactory::new()->create();
+        $user = UserFactory::new()->create();
+
+        $token = $this->requestToken($user, $client);
+
+        $json = $this->post('/oauth/introspect', [
+            'token' => $token['access_token'],
+            'client_id' => $client->getKey(),
+            'client_secret' => $client->plainSecret,
+        ])->assertOk()->json();
+
+        $jwt = JWT::decode($token['access_token'], new Key(file_get_contents(self::PUBLIC_KEY), 'RS256'));
+
+        $this->assertTrue($json['active']);
+        $this->assertSame('create read delete', $json['scope']);
+        $this->assertSame($client->getKey(), $json['client_id']);
+        $this->assertSame('Bearer', $json['token_type']);
+        $this->assertEquals($user->getAuthIdentifier(), $json['sub']);
+        $this->assertArrayHasKey('aud', $json);
+        $this->assertSame($jwt->jti, $json['jti']);
+        $this->assertSame((int) $jwt->exp, $json['exp']);
+        $this->assertSame((int) $jwt->iat, $json['iat']);
+        $this->assertSame((int) $jwt->nbf, $json['nbf']);
+
+        $json = $this->post('/oauth/introspect', [
+            'token' => $token['refresh_token'],
+            'client_id' => $client->getKey(),
+            'client_secret' => $client->plainSecret,
+        ])->assertOk()->json();
+
+        $this->assertTrue($json['active']);
+        $this->assertSame('create read delete', $json['scope']);
+        $this->assertSame($client->getKey(), $json['client_id']);
+        $this->assertEquals($user->getAuthIdentifier(), $json['sub']);
+        $this->assertArrayHasKey('jti', $json);
+        $this->assertEqualsWithDelta(31536000, $json['exp'] - time(), 5);
+    }
+
+    public function testInvalidClient(): void
+    {
+        $client1 = ClientFactory::new()->create();
+        $client2 = ClientFactory::new()->create();
+        $user = UserFactory::new()->create();
+
+        $token = $this->requestToken($user, $client1);
+
+        $this->assertFalse($this->post('/oauth/introspect', [
+            'token' => $token['access_token'],
+            'client_id' => $client2->getKey(),
+            'client_secret' => $client2->plainSecret,
+        ])->assertOk()->json('active'));
+
+        $this->assertTrue($this->post('/oauth/introspect', [
+            'token' => $token['access_token'],
+            'client_id' => $client1->getKey(),
+            'client_secret' => $client1->plainSecret,
+        ])->assertOk()->json('active'));
+
+        $this->assertFalse($this->post('/oauth/introspect', [
+            'token' => $token['refresh_token'],
+            'client_id' => $client2->getKey(),
+            'client_secret' => $client2->plainSecret,
+        ])->assertOk()->json('active'));
+
+        $this->assertTrue($this->post('/oauth/introspect', [
+            'token' => $token['refresh_token'],
+            'client_id' => $client1->getKey(),
+            'client_secret' => $client1->plainSecret,
+        ])->assertOk()->json('active'));
+    }
+
+    private function requestToken(Authenticatable $user, Client $client)
+    {
+        $this->actingAs($user, 'web');
+
+        $authToken = $this->get('/oauth/authorize?'.http_build_query([
+            'client_id' => $client->getKey(),
+            'redirect_uri' => $redirect = $client->redirect_uris[0],
+            'response_type' => 'code',
+            'scope' => 'create read delete',
+        ]))->assertOk()->json('authToken');
+
+        $redirectUrl = $this->post('/oauth/authorize', ['auth_token' => $authToken])->headers->get('Location');
+        parse_str(parse_url($redirectUrl, PHP_URL_QUERY), $params);
+
+        return $this->post('/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'client_id' => $client->getKey(),
+            'client_secret' => $client->plainSecret,
+            'redirect_uri' => $redirect,
+            'code' => $params['code'],
+        ])->assertOK()->json();
+    }
+}

--- a/tests/Feature/TokenRevocationTest.php
+++ b/tests/Feature/TokenRevocationTest.php
@@ -14,6 +14,9 @@ class TokenRevocationTest extends PassportTestCase
 
     protected function setUp(): void
     {
+        Passport::enableTokenRevocation();
+        Passport::enableTokenIntrospection();
+
         parent::setUp();
 
         Passport::tokensCan([

--- a/tests/Feature/TokenRevocationTest.php
+++ b/tests/Feature/TokenRevocationTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature;
+
+use Laravel\Passport\Client;
+use Laravel\Passport\Database\Factories\ClientFactory;
+use Laravel\Passport\Passport;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
+use Workbench\Database\Factories\UserFactory;
+
+class TokenRevocationTest extends PassportTestCase
+{
+    use WithLaravelMigrations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Passport::tokensCan([
+            'create' => 'Create',
+            'read' => 'Read',
+            'update' => 'Update',
+            'delete' => 'Delete',
+        ]);
+
+        Passport::authorizationView(fn ($params) => $params);
+    }
+
+    public function testRevokeAccessToken()
+    {
+        $client = ClientFactory::new()->create();
+
+        $token = $this->requestToken($client);
+
+        $requestData = [
+            'token' => $token['access_token'],
+            'client_id' => $client->getKey(),
+            'client_secret' => $client->plainSecret,
+        ];
+
+        $this->assertTrue($this->post('/oauth/introspect', $requestData)->assertOk()->json('active'));
+
+        $this->post('/oauth/revoke', $requestData)->assertOk();
+
+        $this->assertFalse($this->post('/oauth/introspect', $requestData)->assertOk()->json('active'));
+
+        $requestData['token'] = $token['refresh_token'];
+
+        $this->assertTrue($this->post('/oauth/introspect', $requestData)->assertOk()->json('active'));
+    }
+
+    public function testRevokeRefreshToken()
+    {
+        $client = ClientFactory::new()->create();
+
+        $token = $this->requestToken($client);
+
+        $requestData = [
+            'token' => $token['refresh_token'],
+            'client_id' => $client->getKey(),
+            'client_secret' => $client->plainSecret,
+        ];
+
+        $this->assertTrue($this->post('/oauth/introspect', $requestData)->assertOk()->json('active'));
+
+        $this->post('/oauth/revoke', $requestData)->assertOk();
+
+        $this->assertFalse($this->post('/oauth/introspect', $requestData)->assertOk()->json('active'));
+
+        $requestData['token'] = $token['access_token'];
+
+        $this->assertFalse($this->post('/oauth/introspect', $requestData)->assertOk()->json('active'));
+    }
+
+    public function testInvalidClient(): void
+    {
+        $client1 = ClientFactory::new()->create();
+        $client2 = ClientFactory::new()->create();
+
+        $token = $this->requestToken($client1);
+
+        $this->post('/oauth/revoke', [
+            'token' => $token['access_token'],
+            'client_id' => $client2->getKey(),
+            'client_secret' => $client2->plainSecret,
+        ])->assertOk();
+
+        $this->post('/oauth/revoke', [
+            'token' => $token['refresh_token'],
+            'client_id' => $client2->getKey(),
+            'client_secret' => $client2->plainSecret,
+        ])->assertOk();
+
+        $this->assertTrue($this->post('/oauth/introspect', [
+            'token' => $token['access_token'],
+            'client_id' => $client1->getKey(),
+            'client_secret' => $client1->plainSecret,
+        ])->assertOk()->json('active'));
+
+        $this->assertTrue($this->post('/oauth/introspect', [
+            'token' => $token['refresh_token'],
+            'client_id' => $client1->getKey(),
+            'client_secret' => $client1->plainSecret,
+        ])->assertOk()->json('active'));
+    }
+
+    private function requestToken(Client $client)
+    {
+        $this->actingAs(UserFactory::new()->create(), 'web');
+
+        $authToken = $this->get('/oauth/authorize?'.http_build_query([
+            'client_id' => $client->getKey(),
+            'redirect_uri' => $redirect = $client->redirect_uris[0],
+            'response_type' => 'code',
+            'scope' => 'create read delete',
+        ]))->assertOk()->json('authToken');
+
+        $redirectUrl = $this->post('/oauth/authorize', ['auth_token' => $authToken])->headers->get('Location');
+        parse_str(parse_url($redirectUrl, PHP_URL_QUERY), $params);
+
+        return $this->post('/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'client_id' => $client->getKey(),
+            'client_secret' => $client->plainSecret,
+            'redirect_uri' => $redirect,
+            'code' => $params['code'],
+        ])->assertOK()->json();
+    }
+}


### PR DESCRIPTION
* thephpleague/oauth2-server#1473

## Token Revocation

[Token Revocation RFC7009](https://datatracker.ietf.org/doc/html/rfc7009)

First, enable the token revocation by calling the `Passport::enableTokenRevocation` method in the boot method of your application's `App\Providers\AppServiceProvider` class:

```php
Passport::enableTokenRevocation();
```

Then, the consuming application should make a `POST` request to your application's `/oauth/revoke` route:

```php
Http::asForm()->post('https://laravel.test/oauth/revoke', [
    'client_id' => 'your-client-id',
    'client_secret' => 'your-client-secret', // Required for confidential clients only...
    'token' => 'your-token-here',            // Either an access token or a refresh token to revoke...
    'token_type_hint' => 'access_token',     // Optional, to help the server optimize the token lookup. 'access_token' or 'refresh_token'...
]);
```

This will return an empty `200` response.

## Token Introspection

[Token Introspection RFC7662](https://datatracker.ietf.org/doc/html/rfc7662)

First, enable the token introspection by calling the `Passport::enableTokenIntrospection` method in the boot method of your application's `App\Providers\AppServiceProvider` class:

```php
Passport::enableTokenIntrospection();
```

Then, the consuming application should make a `POST` request to your application's `/oauth/introspect` route:

```php
Http::asForm()->post('https://laravel.test/oauth/introspect', [
    'client_id' => 'your-client-id',
    'client_secret' => 'your-client-secret', // Required for confidential clients only...
    'token' => 'your-token-here',            // Either an access token or a refresh token to introspect...
    'token_type_hint' => 'access_token',     // Optional, to help the server optimize the token lookup. 'access_token' or 'refresh_token'...
]);
```

This will return a JSON response containing `active` attribute that indicates whether or not the presented token is currently active.