### PR TITLE
Fix »OAuth Client Table Changes« migration snippet in the upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -151,7 +151,7 @@ foreach (Passport::client()->cursor() as $client) {
     Model::withoutTimestamps(fn () => $client->forceFill([
         'owner_id' => $client->user_id,
         'owner_type' => $client->user_id
-            ? config('auth.providers.'.$client->provider.'.model', \App\Models\User::class)
+            ? config('auth.providers.'.($client->provider ?: config('auth.guards.api.provider')).'.model')
             : null,
         'redirect_uris' => $client->redirect_uris,
         'grant_types' => $client->grant_types,

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -159,8 +159,6 @@ foreach (Passport::client()->cursor() as $client) {
 }
 
 Schema::table('oauth_clients', function (Blueprint $table) {
-    $table->text('grant_types')->nullable(false)->change();
-
     $table->dropColumn(['user_id', 'redirect', 'personal_access_client', 'password_client']);
 });
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -143,7 +143,7 @@ Schema::table('oauth_clients', function (Blueprint $table) {
 
     $table->after('provider', function (Blueprint $table) {
         $table->text('redirect_uris');
-        $table->text('grant_types');
+        $table->text('grant_types')->nullable();
     });
 });
 
@@ -157,6 +157,8 @@ foreach (Passport::client()->cursor() as $client) {
 }
 
 Schema::table('oauth_clients', function (Blueprint $table) {
+    $table->text('grant_types')->nullable(false)->change();
+
     $table->dropColumn(['user_id', 'redirect', 'personal_access_client', 'password_client']);
 });
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -139,9 +139,7 @@ If you prefer to use the new structure, you may create a migration to apply the 
 
 ```php
 Schema::table('oauth_clients', function (Blueprint $table) {
-    $table->after('user_id', function (Blueprint $table) {
-        $table->nullableMorphs('owner');
-    });
+    $table->nullableMorphs('owner', after: 'user_id');
 
     $table->after('provider', function (Blueprint $table) {
         $table->text('redirect_uris');

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -150,7 +150,9 @@ Schema::table('oauth_clients', function (Blueprint $table) {
 foreach (Passport::client()->cursor() as $client) {
     Model::withoutTimestamps(fn () => $client->forceFill([
         'owner_id' => $client->user_id,
-        'owner_type' => $client->user_id ? config('auth.providers.'.$client->provider.'.model') : null,
+        'owner_type' => $client->user_id
+            ? config('auth.providers.'.$client->provider.'.model', \App\Models\User::class)
+            : null,
         'redirect_uris' => $client->redirect_uris,
         'grant_types' => $client->grant_types,
     ])->save());


### PR DESCRIPTION
The migration code snippet of the v13 upgrade guide immediately crashed on me.
I had to apply several fixes.

Please see commit descriptions for more details.

Using `\App\Models\User::class` even though old apps might still use `\App\User::class` does not seem to be that big of an issue. The IDE should immediately highlight the missing class. (eefdb76730de8bc8ed5b031ecfb2435f28a81a72)