### PR TITLE
Fix ClientController::store() breaking change introduced via #1745

### DIFF
--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -38,7 +38,7 @@ class ClientController
     /**
      * Store a new client.
      */
-    public function store(Request $request): Client
+    public function store(Request $request): array
     {
         $this->validation->make($request->all(), [
             'name' => ['required', 'string', 'max:255'],
@@ -53,9 +53,7 @@ class ClientController
             $request->user(),
         );
 
-        $client->secret = $client->plainSecret;
-
-        return $client->makeVisible('secret');
+        return ['plainSecret' => $client->plainSecret] + $client->toArray();
     }
 
     /**

--- a/tests/Unit/ClientControllerTest.php
+++ b/tests/Unit/ClientControllerTest.php
@@ -51,7 +51,7 @@ class ClientControllerTest extends TestCase
         $clients->shouldReceive('createAuthorizationCodeGrantClient')
             ->once()
             ->with('client name', ['http://localhost'], true, $user)
-            ->andReturn($client = new Client);
+            ->andReturn($client = new Client(['name' => 'client']));
 
         $redirectRule = m::mock(RedirectRule::class);
 
@@ -70,7 +70,10 @@ class ClientControllerTest extends TestCase
             $clients, $validator, $redirectRule
         );
 
-        $this->assertEquals($client, $controller->store($request));
+        $this->assertEquals([
+            'name' => $client->name,
+            'plainSecret' => $client->plainSecret,
+        ], $controller->store($request));
     }
 
     public function test_public_clients_can_be_stored()
@@ -89,7 +92,7 @@ class ClientControllerTest extends TestCase
         $clients->shouldReceive('createAuthorizationCodeGrantClient')
             ->once()
             ->with('client name', ['http://localhost'], false, $user)
-            ->andReturn($client = new Client);
+            ->andReturn($client = new Client(['name' => 'client']));
 
         $redirectRule = m::mock(RedirectRule::class);
 
@@ -109,7 +112,10 @@ class ClientControllerTest extends TestCase
             $clients, $validator, $redirectRule
         );
 
-        $this->assertEquals($client, $controller->store($request));
+        $this->assertEquals([
+            'name' => $client->name,
+            'plainSecret' => $client->plainSecret,
+        ], $controller->store($request));
     }
 
     public function test_clients_can_be_updated()


### PR DESCRIPTION
Fixes `ClientController::store()` breaking change introduced via #1745

```php
// \Laravel\Passport\Http\Controllers\ClientController::store

- if (Passport::$hashesClientSecrets) {
-     return ['plainSecret' => $client->plainSecret] + $client->toArray();
- }
+ $client->secret = $client->plainSecret;

return $client->makeVisible('secret');
```

This change obviously breaks usages that previously relied on the return type array with the additional `plainSecret` data. E.g., the old Vue components used `plainSecret` to present that to the user so that he could save it, etc. Since hashing is now mandatory, I restored the previous behavior without the now obsolete `Passport::$hashesClientSecrets` check:

```php
return ['plainSecret' => $client->plainSecret] + $client->toArray();
```

I also updated the tests. I know it looks a bit fishy but I had not much choice since it's a unit test … (didn't want to make too big of a change out of this … it's deprecated anyways …)