### PR TITLE
[13.x] Fix accessing the plain secret after creating a new confidential client via deprecated `ClientController::store`

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -135,6 +135,16 @@ class Client extends Model
     }
 
     /**
+     * Interact with the client's plain secret.
+     */
+    protected function plainSecret(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): ?string => $this->plainSecret
+        );
+    }
+
+    /**
      * Interact with the client's redirect URIs.
      */
     protected function redirectUris(): Attribute

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -38,7 +38,7 @@ class ClientController
     /**
      * Store a new client.
      */
-    public function store(Request $request): Client
+    public function store(Request $request): array
     {
         $this->validation->make($request->all(), [
             'name' => ['required', 'string', 'max:255'],
@@ -53,9 +53,7 @@ class ClientController
             $request->user(),
         );
 
-        $client->secret = $client->plainSecret;
-
-        return $client->makeVisible('secret');
+        return ['plainSecret' => $client->plainSecret] + $client->toArray();
     }
 
     /**

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -53,7 +53,7 @@ class ClientController
             $request->user(),
         );
 
-        return $confidential ? $client->mergeAppends(['plain_secret']) : $client;
+        return $confidential ? $client->append(['plain_secret']) : $client;
     }
 
     /**

--- a/src/Http/Controllers/ClientController.php
+++ b/src/Http/Controllers/ClientController.php
@@ -38,7 +38,7 @@ class ClientController
     /**
      * Store a new client.
      */
-    public function store(Request $request): array
+    public function store(Request $request): Client
     {
         $this->validation->make($request->all(), [
             'name' => ['required', 'string', 'max:255'],
@@ -49,11 +49,11 @@ class ClientController
         $client = $this->clients->createAuthorizationCodeGrantClient(
             $request->name,
             explode(',', $request->redirect),
-            (bool) $request->input('confidential', true),
+            $confidential = (bool) $request->input('confidential', true),
             $request->user(),
         );
 
-        return ['plainSecret' => $client->plainSecret] + $client->toArray();
+        return $confidential ? $client->mergeAppends(['plain_secret']) : $client;
     }
 
     /**

--- a/tests/Unit/ClientControllerTest.php
+++ b/tests/Unit/ClientControllerTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Passport\Tests\Unit;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Http\Controllers\ClientController;
@@ -41,6 +42,9 @@ class ClientControllerTest extends TestCase
 
     public function test_clients_can_be_stored()
     {
+        Hash::expects('isHashed')->once()->with('secret')->andReturn(false);
+        Hash::expects('make')->once()->with('secret')->andReturn('hashed_secret');
+
         $clients = m::mock(ClientRepository::class);
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
@@ -51,7 +55,11 @@ class ClientControllerTest extends TestCase
         $clients->shouldReceive('createAuthorizationCodeGrantClient')
             ->once()
             ->with('client name', ['http://localhost'], true, $user)
-            ->andReturn($client = new Client(['name' => 'client']));
+            ->andReturn($client = new Client([
+                'name' => 'client name',
+                'redirect' => 'http://localhost',
+                'secret' => 'secret',
+            ]));
 
         $redirectRule = m::mock(RedirectRule::class);
 
@@ -70,10 +78,13 @@ class ClientControllerTest extends TestCase
             $clients, $validator, $redirectRule
         );
 
-        $this->assertEquals([
-            'name' => $client->name,
-            'plainSecret' => $client->plainSecret,
-        ], $controller->store($request));
+        $this->assertEquals($client, $controller->store($request));
+        $this->assertSame('hashed_secret', $client->secret);
+        $this->assertSame([
+            'name' => 'client name',
+            'redirect' => 'http://localhost',
+            'plain_secret' => 'secret',
+        ], $client->toArray());
     }
 
     public function test_public_clients_can_be_stored()
@@ -92,7 +103,11 @@ class ClientControllerTest extends TestCase
         $clients->shouldReceive('createAuthorizationCodeGrantClient')
             ->once()
             ->with('client name', ['http://localhost'], false, $user)
-            ->andReturn($client = new Client(['name' => 'client']));
+            ->andReturn($client = new Client([
+                'name' => 'client name',
+                'redirect' => 'http://localhost',
+                'secret' => null,
+            ]));
 
         $redirectRule = m::mock(RedirectRule::class);
 
@@ -112,10 +127,12 @@ class ClientControllerTest extends TestCase
             $clients, $validator, $redirectRule
         );
 
-        $this->assertEquals([
-            'name' => $client->name,
-            'plainSecret' => $client->plainSecret,
-        ], $controller->store($request));
+        $this->assertEquals($client, $controller->store($request));
+        $this->assertNull($client->secret);
+        $this->assertSame([
+            'name' => 'client name',
+            'redirect' => 'http://localhost',
+        ], $client->toArray());
     }
 
     public function test_clients_can_be_updated()

--- a/tests/Unit/ClientControllerTest.php
+++ b/tests/Unit/ClientControllerTest.php
@@ -51,7 +51,7 @@ class ClientControllerTest extends TestCase
         $clients->shouldReceive('createAuthorizationCodeGrantClient')
             ->once()
             ->with('client name', ['http://localhost'], true, $user)
-            ->andReturn($client = new Client);
+            ->andReturn($client = new Client(['name' => 'client']));
 
         $redirectRule = m::mock(RedirectRule::class);
 
@@ -70,7 +70,10 @@ class ClientControllerTest extends TestCase
             $clients, $validator, $redirectRule
         );
 
-        $this->assertEquals($client, $controller->store($request));
+        $this->assertEquals([
+            'name' => $client->name,
+            'plainSecret' => $client->plainSecret,
+        ], $controller->store($request));
     }
 
     public function test_public_clients_can_be_stored()
@@ -89,7 +92,7 @@ class ClientControllerTest extends TestCase
         $clients->shouldReceive('createAuthorizationCodeGrantClient')
             ->once()
             ->with('client name', ['http://localhost'], false, $user)
-            ->andReturn($client = new Client);
+            ->andReturn($client = new Client(['name' => 'client']));
 
         $redirectRule = m::mock(RedirectRule::class);
 
@@ -109,7 +112,10 @@ class ClientControllerTest extends TestCase
             $clients, $validator, $redirectRule
         );
 
-        $this->assertEquals($client, $controller->store($request));
+        $this->assertEquals([
+            'name' => $client->name,
+            'plainSecret' => $client->plainSecret,
+        ], $controller->store($request));
     }
 
     public function test_clients_can_be_updated()


### PR DESCRIPTION
Closes #1860

This PR fixes an issue where the plain secret was not accessible after creating a new confidential client in `ClientController::store`, by appending the `plain_secret` attribute.

@hettiger Thanks!