### PR TITLE
ActingAsClient should be that same as how client credientals actual work

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -383,7 +383,7 @@ class Passport
             fn (ServerRequestInterface $request) => $request
                 ->withAttribute('oauth_client_id', $client->getKey())
                 ->withAttribute('oauth_scopes', $scopes)
-                ->withAttribute('oauth_user_id', null)
+                ->withAttribute('oauth_user_id', $client->getKey())
         );
 
         app()->instance(ResourceServer::class, $mock);


### PR DESCRIPTION
League Oauth server is confirming to the RFC standard there should always be a sub field in JWT token. And sub field is mapped to client identifier as fallback if the user is not present. This happens with all client_crediential grants.

related to:
https://github.com/thephpleague/oauth2-server/issues/1456

