### PR TITLE
chore(UPGRADE): v13, update oauth_clients table schema changes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -142,7 +142,7 @@ Schema::table('oauth_clients', function (Blueprint $table) {
     $table->nullableMorphs('owner', after: 'user_id');
 
     $table->after('provider', function (Blueprint $table) {
-        $table->text('redirect_uris');
+        $table->text('redirect_uris')->nullable();
         $table->text('grant_types')->nullable();
     });
 });
@@ -160,6 +160,8 @@ foreach (Passport::client()->cursor() as $client) {
 
 Schema::table('oauth_clients', function (Blueprint $table) {
     $table->dropColumn(['user_id', 'redirect', 'personal_access_client', 'password_client']);
+    $table->text('redirect_uris')->nullable(false)->change();
+    $table->text('grant_types')->nullable(false)->change();
 });
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -160,6 +160,7 @@ foreach (Passport::client()->cursor() as $client) {
 
 Schema::table('oauth_clients', function (Blueprint $table) {
     $table->dropColumn(['user_id', 'redirect', 'personal_access_client', 'password_client']);
+
     $table->text('redirect_uris')->nullable(false)->change();
     $table->text('grant_types')->nullable(false)->change();
 });


### PR DESCRIPTION
This pull request is intended to fix the migration of Passport clients. Specifically, not adding `->nullable()` to the `redirect_uris` column causes issues when there is existing data in the database, which is the case during a migration.

The `->change()` lines are meant to remove the nullable setting, **applied after migrating the existing data**, to stay consistent with the original migration: [create_oauth_clients_table.php](https://github.com/laravel/passport/blob/13.x/database/migrations/2016_06_01_000004_create_oauth_clients_table.php).

This ensures migrations run correctly without breaking existing data or causing unexpected errors.