### PR TITLE
feat: Allow `findForPassport` to optionally receive the OAuth client

### DIFF
--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -6,8 +6,8 @@ use Illuminate\Contracts\Hashing\Hasher;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\UserEntityInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
-use RuntimeException;
 use ReflectionMethod;
+use RuntimeException;
 
 class UserRepository implements UserRepositoryInterface
 {

--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -44,7 +44,7 @@ class UserRepository implements UserRepositoryInterface
             $method = new ReflectionMethod($instance, 'findForPassport');
             $args = [$username];
             if ($method->getNumberOfParameters() >= 2) {
-                $args[] = $client;
+                $args[] = $clientEntity;
             }
             $user = $method->invokeArgs($instance, $args);
         } else {

--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Hashing\Hasher;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\UserEntityInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
-use ReflectionMethod;
 use RuntimeException;
 
 class UserRepository implements UserRepositoryInterface
@@ -35,7 +34,7 @@ class UserRepository implements UserRepositoryInterface
         }
 
         if (method_exists($model, 'findAndValidateForPassport')) {
-            $user = (new $model)->findAndValidateForPassport($username, $password);
+            $user = (new $model)->findAndValidateForPassport($username, $password, $clientEntity);
 
             return $user ? new User($user->getAuthIdentifier()) : null;
         }

--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -40,17 +40,9 @@ class UserRepository implements UserRepositoryInterface
             return $user ? new User($user->getAuthIdentifier()) : null;
         }
 
-        $instance = new $model;
-        if (method_exists($instance, 'findForPassport')) {
-            $method = new ReflectionMethod($instance, 'findForPassport');
-            $args = [$username];
-            if ($method->getNumberOfParameters() >= 2) {
-                $args[] = $clientEntity;
-            }
-            $user = $method->invokeArgs($instance, $args);
-        } else {
-            $user = $instance->where('email', $username)->first();
-        }
+        $user = method_exists($model, 'findForPassport')
+            ? (new $model)->findForPassport($username, $clientEntity)
+            : (new $model)->where('email', $username)->first();
 
         if (! $user) {
             return null;

--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -39,9 +39,17 @@ class UserRepository implements UserRepositoryInterface
             return $user ? new User($user->getAuthIdentifier()) : null;
         }
 
-        $user = method_exists($model, 'findForPassport')
-            ? (new $model)->findForPassport($username)
-            : (new $model)->where('email', $username)->first();
+        $instance = new $model;
+        if (method_exists($instance, 'findForPassport')) {
+            $method = new ReflectionMethod($instance, 'findForPassport');
+            $args = [$username];
+            if ($method->getNumberOfParameters() >= 2) {
+                $args[] = $client;
+            }
+            $user = $method->invokeArgs($instance, $args);
+        } else {
+            $user = $instance->where('email', $username)->first();
+        }
 
         if (! $user) {
             return null;

--- a/src/Bridge/UserRepository.php
+++ b/src/Bridge/UserRepository.php
@@ -7,6 +7,7 @@ use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\UserEntityInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use RuntimeException;
+use ReflectionMethod;
 
 class UserRepository implements UserRepositoryInterface
 {


### PR DESCRIPTION
Currently, Laravel Passport uses the `findForPassport(string $username)` method to retrieve the user during password grant authentication. This method only receives the username, which limits cases where we might want to filter users based on the OAuth client.

This PR introduces the possibility to define `findForPassport` with a **second optional parameter**, a `ClientEntityInterface $client`, allowing:

* Filtering users based on the OAuth client if needed.
* Maintaining compatibility with existing methods that only accept one parameter.

Example usage:

```php
use Laravel\Passport\Bridge\Client;

public function findForPassport(string $username, Client $client)
{
    return $this->where('email', $username)
        ->whereHas('clients', function ($q) use ($client) {
            $q->where('id', $client->getIdentifier());
        })->first();
}
```

This is **not a breaking change**: existing methods with a single parameter will continue to work.

📖 I also prepared a PR for the documentation to explain this new possibility: https://github.com/laravel/docs/pull/10880