### PR TITLE
[13.x] Add static setter for authorizationServerResponseType

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -454,6 +454,14 @@ class Passport
     }
 
     /**
+     * Set the default ResponseType that should be used by the Authorization Server.
+     */
+    public static function useAuthorizationServerResponseType(?ResponseTypeInterface $authorizationServerResponseType): void
+    {
+        static::$authorizationServerResponseType = $authorizationServerResponseType;
+    }
+
+    /**
      * Set the device code model class name.
      *
      * @param  class-string<\Laravel\Passport\DeviceCode>  $deviceCodeModel

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -454,7 +454,7 @@ class Passport
     }
 
     /**
-     * Set the default ResponseType that should be used by the Authorization Server.
+     * Set the default ResponseType that should be used by the authorization server.
      */
     public static function useAuthorizationServerResponseType(?ResponseTypeInterface $authorizationServerResponseType): void
     {


### PR DESCRIPTION
This PR adds a static setter for `$authorizationServerResponseType` in `Passport.php` to match other setters like `useDeviceCodeModel()`.

This makes it more readable when wanting to override the default `ResponseType`, because it is in line with other setters.. i.e.;

```php
$responseType = new BearerTokenResponseWithExtras();

// Only way currently
Passport::$authorizationServerResponseType = $responseType;

// New way
Passport::useAuthorizationServerResponseType($responseType);
```

This also makes it clearer that the `ResponseType` actually can be set and 'overwritten'.