### PR TITLE
[13.x] Fix possible 500 error when retrieving user on token guard

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -131,7 +131,7 @@ class ClientCommand extends Command
     {
         $confidential = $this->hasOption('public')
             ? ! $this->option('public')
-            : $this->confirm('Would you like to make this client confidential?', true);
+            : $this->components->confirm('Would you like to make this client confidential?', true);
 
         return $clients->createDeviceAuthorizationGrantClient($this->option('name'), $confidential);
     }
@@ -151,7 +151,7 @@ class ClientCommand extends Command
             : $this->components->confirm('Would you like to make this client confidential?', true);
 
         $enableDeviceFlow = Passport::$deviceCodeGrantEnabled &&
-            $this->confirm('Would you like to enable the device authorization flow for this client?');
+            $this->components->confirm('Would you like to enable the device authorization flow for this client?');
 
         return $clients->createAuthorizationCodeGrantClient(
             $this->option('name'), explode(',', $redirect), $confidential, null, $enableDeviceFlow

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -144,18 +144,18 @@ class TokenGuard implements Guard
         // If the access token is valid we will retrieve the user according to the user ID
         // associated with the token. We will use the provider implementation which may
         // be used to retrieve users from Eloquent. Next, we'll be ready to continue.
-        $user = $this->provider->retrieveById(
-            $psr->getAttribute('oauth_user_id') ?: null
-        );
-
-        if (! $user) {
+        try {
+            $user = $this->provider->retrieveById(
+                $psr->getAttribute('oauth_user_id') ?: null
+            );
+        } catch (Exception) {
             return null;
         }
 
         // Next, we will assign a token instance to this user which the developers may use
         // to determine if the token has a given scope, etc. This will be useful during
         // authorization such as within the developer's Laravel model policy classes.
-        return $user->withAccessToken(AccessToken::fromPsrRequest($psr));
+        return $user?->withAccessToken(AccessToken::fromPsrRequest($psr));
     }
 
     /**
@@ -193,11 +193,13 @@ class TokenGuard implements Guard
         // If this user exists, we will return this user and attach a "transient" token to
         // the user model. The transient token assumes it has all scopes since the user
         // is physically logged into the application via the application's interface.
-        if ($user = $this->provider->retrieveById($token['sub'])) {
-            return $user->withAccessToken(new TransientToken);
+        try {
+            $user = $this->provider->retrieveById($token['sub']);
+        } catch (Exception) {
+            return null;
         }
 
-        return null;
+        return $user?->withAccessToken(new TransientToken);
     }
 
     /**

--- a/src/Http/Controllers/HandlesOAuthErrors.php
+++ b/src/Http/Controllers/HandlesOAuthErrors.php
@@ -13,7 +13,7 @@ trait HandlesOAuthErrors
      *
      * @template TResult
      *
-     * @param  \Closure(): TResult  $callback
+     * @param  (\Closure(): TResult)  $callback
      * @return TResult
      *
      * @throws \Laravel\Passport\Exceptions\OAuthServerException

--- a/src/Http/Middleware/CreateFreshApiToken.php
+++ b/src/Http/Middleware/CreateFreshApiToken.php
@@ -38,7 +38,7 @@ class CreateFreshApiToken
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  (\Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response))  $next
      */
     public function handle(Request $request, Closure $next, ?string $guard = null): BaseResponse
     {

--- a/src/Http/Middleware/ValidateToken.php
+++ b/src/Http/Middleware/ValidateToken.php
@@ -39,7 +39,7 @@ abstract class ValidateToken
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  (\Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response))  $next
      */
     public function handle(Request $request, Closure $next, string ...$params): Response
     {


### PR DESCRIPTION
Fixes #1868

This PR fixes an issue where using a valid client-credentials token on an `auth:api` guarded endpoint accidentally may triggers a database type mismatch, causing a 500 error instead of the expected 401.

This PR also fixes a few PHPDoc types.