### PR TITLE
Fix unhandled possible redirect_uris field usage in Client Model

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -153,6 +153,7 @@ class Client extends Model
             get: fn (?string $value, array $attributes): array => match (true) {
                 ! empty($value) => $this->fromJson($value),
                 ! empty($attributes['redirect']) => explode(',', $attributes['redirect']),
+                ! empty($attributes['redirect_uris']) => $this->fromJson($attributes['redirect_uris']),
                 default => [],
             },
         );


### PR DESCRIPTION
This Bugfix adds consideration of the newly added redirect_uris field in Oauth Clients Table. This new field was introduced with Passport 13. If you decided to switch to new oauth_clients table fields you will stumble over the described problem.

### Behaviour without fix:

If you are using the Oauth Register Route in Laravel MCP to register a new Client you send the request:

**The Register Request:**

POST oauth/register

Body:
{"client_name":"Test","redirect_uris":["https://test1.com", "https://test2.com"]}

**Response:**
{
    "client_id": "51",
    "grant_types": [
        "authorization_code",
        "implicit",
        "refresh_token",
        "urn:ietf:params:oauth:grant-type:device_code"
    ],
    "response_types": [
        "code"
    ],
    "redirect_uris": [],
    "scope": "mcp:use",
    "token_endpoint_auth_method": "none"
}


**Problem:** redirect_uris are empty because of the missing consideration of a potential redirect_uris field (instead of the old redirect field).

### Behaviour with fix:

**The Register Request:**

POST oauth/register

Body:
{"client_name":"Test","redirect_uris":["https://test1.com", "https://test2.com"]}

**Response:**
{
    "client_id": "51",
    "grant_types": [
        "authorization_code",
        "implicit",
        "refresh_token",
        "urn:ietf:params:oauth:grant-type:device_code"
    ],
    "response_types": [
        "code"
    ],
    "redirect_uris": [
        "https://test1.com",
        "https://test2.com"
    ],
    "scope": "mcp:use",
    "token_endpoint_auth_method": "none"
}

The Redirect URIs are now correctly returned!


### Side Effects of the Bug

This Bug currently does lead to non working MCP Oauth Workflow with Anthropic Claude. OpenAI instead seems to have no problems with the missing redirect_uris in the response.
