### PR TITLE
Remove the usage of deprecated `$request->get()`

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -50,12 +50,12 @@ class AuthorizationController
         );
 
         if ($this->guard->guest()) {
-            $request->get('prompt') === 'none'
+            $request->input('prompt') === 'none'
                 ? throw OAuthServerException::loginRequired($authRequest)
                 : $this->promptForLogin($request);
         }
 
-        if ($request->get('prompt') === 'login' &&
+        if ($request->input('prompt') === 'login' &&
             ! $request->session()->get('promptedForLogin', false)) {
             $this->guard->logout();
             $request->session()->invalidate();
@@ -72,12 +72,12 @@ class AuthorizationController
         $scopes = $this->parseScopes($authRequest);
         $client = $this->clients->find($authRequest->getClient()->getIdentifier());
 
-        if ($request->get('prompt') !== 'consent' &&
+        if ($request->input('prompt') !== 'consent' &&
             ($client->skipsAuthorization($user, $scopes) || $this->hasGrantedScopes($user, $client, $scopes))) {
             return $this->approveRequest($authRequest, $psrResponse);
         }
 
-        if ($request->get('prompt') === 'none') {
+        if ($request->input('prompt') === 'none') {
             throw OAuthServerException::consentRequired($authRequest);
         }
 

--- a/src/Http/Controllers/RetrievesAuthRequestFromSession.php
+++ b/src/Http/Controllers/RetrievesAuthRequestFromSession.php
@@ -18,7 +18,7 @@ trait RetrievesAuthRequestFromSession
     protected function getAuthRequestFromSession(Request $request): AuthorizationRequestInterface
     {
         if ($request->isNotFilled('auth_token') ||
-            $request->session()->pull('authToken') !== $request->get('auth_token')) {
+            $request->session()->pull('authToken') !== $request->input('auth_token')) {
             $request->session()->forget(['authToken', 'authRequest']);
 
             throw InvalidAuthTokenException::different();

--- a/src/Http/Controllers/RetrievesDeviceCodeFromSession.php
+++ b/src/Http/Controllers/RetrievesDeviceCodeFromSession.php
@@ -18,7 +18,7 @@ trait RetrievesDeviceCodeFromSession
     protected function getDeviceCodeFromSession(Request $request): DeviceCodeEntityInterface
     {
         if ($request->isNotFilled('auth_token') ||
-            $request->session()->pull('authToken') !== $request->get('auth_token')) {
+            $request->session()->pull('authToken') !== $request->input('auth_token')) {
             $request->session()->forget(['authToken', 'deviceCode']);
 
             throw InvalidAuthTokenException::different();

--- a/tests/Unit/ApproveAuthorizationControllerTest.php
+++ b/tests/Unit/ApproveAuthorizationControllerTest.php
@@ -26,7 +26,7 @@ class ApproveAuthorizationControllerTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $request->shouldReceive('isNotFilled')->with('auth_token')->andReturn(false);
-        $request->shouldReceive('get')->with('auth_token')->andReturn('foo');
+        $request->shouldReceive('input')->with('auth_token')->andReturn('foo');
 
         $session->shouldReceive('pull')->once()->with('authToken')->andReturn('foo');
         $session->shouldReceive('pull')

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -51,7 +51,7 @@ class AuthorizationControllerTest extends TestCase
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
         $session->shouldReceive('put')->with('authRequest', $authRequest);
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
-        $request->shouldReceive('get')->with('prompt')->andReturn(null);
+        $request->shouldReceive('input')->with('prompt')->andReturn(null);
 
         $authRequest->shouldReceive('getClient->getIdentifier')->andReturn(1);
         $authRequest->shouldReceive('getScopes')->andReturn([new Scope('scope-1')]);
@@ -134,7 +134,7 @@ class AuthorizationControllerTest extends TestCase
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldNotReceive('session');
-        $request->shouldReceive('get')->with('prompt')->andReturn(null);
+        $request->shouldReceive('input')->with('prompt')->andReturn(null);
 
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
         $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
@@ -182,7 +182,7 @@ class AuthorizationControllerTest extends TestCase
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
         $request->shouldNotReceive('session');
-        $request->shouldReceive('get')->with('prompt')->andReturn(null);
+        $request->shouldReceive('input')->with('prompt')->andReturn(null);
 
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
         $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
@@ -226,7 +226,7 @@ class AuthorizationControllerTest extends TestCase
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
         $session->shouldReceive('put')->with('authRequest', $authRequest);
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
-        $request->shouldReceive('get')->with('prompt')->andReturn('consent');
+        $request->shouldReceive('input')->with('prompt')->andReturn('consent');
 
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
         $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
@@ -275,7 +275,7 @@ class AuthorizationControllerTest extends TestCase
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
-        $request->shouldReceive('get')->with('prompt')->andReturn('none');
+        $request->shouldReceive('input')->with('prompt')->andReturn('none');
 
         $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
         $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
@@ -326,7 +326,7 @@ class AuthorizationControllerTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldNotReceive('user');
-        $request->shouldReceive('get')->with('prompt')->andReturn('none');
+        $request->shouldReceive('input')->with('prompt')->andReturn('none');
 
         $authRequest->shouldNotReceive('setUser');
         $authRequest->shouldReceive('setAuthorizationApproved')->with(false);
@@ -378,7 +378,7 @@ class AuthorizationControllerTest extends TestCase
         $session->shouldReceive('get')->with('promptedForLogin', false)->once()->andReturn(false);
         $session->shouldReceive('put')->with('promptedForLogin', true)->once();
         $session->shouldNotReceive('forget')->with('promptedForLogin');
-        $request->shouldReceive('get')->with('prompt')->andReturn('login');
+        $request->shouldReceive('input')->with('prompt')->andReturn('login');
 
         $clients = m::mock(ClientRepository::class);
 
@@ -408,7 +408,7 @@ class AuthorizationControllerTest extends TestCase
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('put')->with('promptedForLogin', true)->once();
         $session->shouldNotReceive('forget')->with('promptedForLogin');
-        $request->shouldReceive('get')->with('prompt')->andReturn(null);
+        $request->shouldReceive('input')->with('prompt')->andReturn(null);
 
         $clients = m::mock(ClientRepository::class);
 

--- a/tests/Unit/DenyAuthorizationControllerTest.php
+++ b/tests/Unit/DenyAuthorizationControllerTest.php
@@ -28,7 +28,7 @@ class DenyAuthorizationControllerTest extends TestCase
 
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $request->shouldReceive('isNotFilled')->with('auth_token')->andReturn(false);
-        $request->shouldReceive('get')->with('auth_token')->andReturn('foo');
+        $request->shouldReceive('input')->with('auth_token')->andReturn('foo');
 
         $session->shouldReceive('pull')->once()->with('authToken')->andReturn('foo');
         $session->shouldReceive('pull')
@@ -68,7 +68,7 @@ class DenyAuthorizationControllerTest extends TestCase
         $request->shouldReceive('user')->never();
         $request->shouldReceive('input')->never();
         $request->shouldReceive('isNotFilled')->with('auth_token')->andReturn(false);
-        $request->shouldReceive('get')->with('auth_token')->andReturn('foo');
+        $request->shouldReceive('input')->with('auth_token')->andReturn('foo');
 
         $session->shouldReceive('pull')->once()->with('authToken')->andReturn('foo');
         $session->shouldReceive('pull')->once()->with('authRequest')->andReturnNull();


### PR DESCRIPTION
`$request->get()` is Symfony's method which has been deprecated since version 7.4:

https://github.com/symfony/http-foundation/blob/bd1af1e425811d6f077db240c3a588bdb405cd27/Request.php#L746

This PR replaces Symfony's deprecated `$request->get()` with Laravel's `$request->input()`.