### PR TITLE
[13.x] Allow setting the client with `Passport::actingAs()`

### DIFF
--- a/src/Passport.php
+++ b/src/Passport.php
@@ -351,9 +351,14 @@ class Passport
      * @param  string[]  $scopes
      * @return \Laravel\Passport\Contracts\OAuthenticatable
      */
-    public static function actingAs(Authenticatable $user, array $scopes = [], ?string $guard = 'api'): Authenticatable
-    {
+    public static function actingAs(
+        Authenticatable $user,
+        array $scopes = [],
+        ?string $guard = 'api',
+        ?Client $client = null,
+    ): Authenticatable {
         $token = new AccessToken([
+            'oauth_client_id' => $client?->getKey(),
             'oauth_user_id' => $user->getAuthIdentifier(),
             'oauth_scopes' => $scopes,
         ]);

--- a/tests/Feature/ActingAsTest.php
+++ b/tests/Feature/ActingAsTest.php
@@ -3,7 +3,9 @@
 namespace Laravel\Passport\Tests\Feature;
 
 use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Laravel\Passport\Client;
 use Laravel\Passport\Http\Middleware\CheckToken;
 use Laravel\Passport\Http\Middleware\CheckTokenForAnyScope;
 use Laravel\Passport\Passport;
@@ -18,11 +20,18 @@ class ActingAsTest extends PassportTestCase
         /** @var Registrar $router */
         $router = $this->app->make(Registrar::class);
 
-        $router->get('/foo', function () {
+        $router->get('/foo', function (Request $request) {
+            $this->assertSame('client-1234', $request->user()->token()->oauth_client_id);
+            $this->assertSame(1234, $request->user()->token()->oauth_user_id);
+            $this->assertSame(['admin'], $request->user()->token()->oauth_scopes);
+
             return 'bar';
         })->middleware('auth:api');
 
-        Passport::actingAs(new User());
+        $client = new Client(['id' => 'client-1234']);
+        $user = (new User())->forceFill(['id' => 1234]);
+
+        Passport::actingAs($user, ['admin'], client: $client);
 
         $response = $this->get('/foo');
         $response->assertSuccessful();


### PR DESCRIPTION
Currently it is not possible to set the client that the token belongs to when using `Passport::actingAs(...)`, this PR changes that. Also added extra assertions to check that the mocked token contains the expected properties.

These changes should be fully backwards compatible