### PR TITLE
Add dedicated token lifetime for client credentials grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased](https://github.com/laravel/passport/compare/v13.4.4...13.x)
 
-* [13.x] Add dedicated token lifetime for client credentials grant by [@sajanp](https://github.com/sajanp) in https://github.com/laravel/passport/pull/1880
-
 ## [v13.4.4](https://github.com/laravel/passport/compare/v13.4.3...v13.4.4) - 2026-02-09
 
 * [13.x] Supports Laravel 13 by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/passport/pull/1885

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/laravel/passport/compare/v13.4.4...13.x)
 
+* [13.x] Add dedicated token lifetime for client credentials grant by [@sajanp](https://github.com/sajanp) in https://github.com/laravel/passport/pull/1880
+
 ## [v13.4.4](https://github.com/laravel/passport/compare/v13.4.3...v13.4.4) - 2026-02-09
 
 * [13.x] Supports Laravel 13 by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/passport/pull/1885

--- a/src/Passport.php
+++ b/src/Passport.php
@@ -75,6 +75,11 @@ class Passport
     public static ?DateInterval $personalAccessTokensExpireIn = null;
 
     /**
+     * The interval when client credentials tokens expire.
+     */
+    public static ?DateInterval $clientCredentialsTokensExpireIn = null;
+
+    /**
      * The name for API token cookies.
      */
     public static string $cookie = 'laravel_token';
@@ -320,6 +325,20 @@ class Passport
         }
 
         return static::$personalAccessTokensExpireIn = $date instanceof DateTimeInterface
+            ? Date::now()->diff($date)
+            : $date;
+    }
+
+    /**
+     * Get or set when client credentials grant tokens expire.
+     */
+    public static function clientCredentialsTokensExpireIn(DateTimeInterface|DateInterval|null $date = null): ?DateInterval
+    {
+        if (is_null($date)) {
+            return static::$clientCredentialsTokensExpireIn;
+        }
+
+        return static::$clientCredentialsTokensExpireIn = $date instanceof DateTimeInterface
             ? Date::now()->diff($date)
             : $date;
     }

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -158,7 +158,7 @@ class PassportServiceProvider extends ServiceProvider
                 }
 
                 $server->enableGrantType(
-                    new ClientCredentialsGrant, Passport::tokensExpireIn()
+                    new ClientCredentialsGrant, Passport::clientCredentialsTokensExpireIn() ?? Passport::tokensExpireIn()
                 );
 
                 if (Passport::$implicitGrantEnabled) {

--- a/tests/Feature/ClientCredentialsGrantTest.php
+++ b/tests/Feature/ClientCredentialsGrantTest.php
@@ -16,6 +16,8 @@ class ClientCredentialsGrantTest extends PassportTestCase
 
     protected function setUp(): void
     {
+        Passport::$clientCredentialsTokensExpireIn = null;
+
         parent::setUp();
 
         Passport::tokensCan([
@@ -113,5 +115,21 @@ class ClientCredentialsGrantTest extends PassportTestCase
             'The authenticated client is not authorized to use this authorization grant type.',
             $json['error_description']
         );
+    }
+
+    public function testCustomClientCredentialsTokenExpiration()
+    {
+        Passport::clientCredentialsTokensExpireIn(new \DateInterval('P7D'));
+
+        $client = ClientFactory::new()->asClientCredentials()->create();
+
+        $json = $this->post('/oauth/token', [
+            'grant_type' => 'client_credentials',
+            'client_id' => $client->getKey(),
+            'client_secret' => $client->plainSecret,
+        ])->assertOk()->json();
+
+        // 7 days = 604800 seconds
+        $this->assertEqualsWithDelta(604800, $json['expires_in'], 2);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a `Passport::clientCredentialsTokensExpireIn()` method for configuring token lifetimes specifically for the client credentials grant, mirroring the existing `personalAccessTokensExpireIn()` pattern.

This is a non-breaking change. When not explicitly configured, client credentials tokens continue to use `Passport::tokensExpireIn()` as before.

## Motivation

The client credentials grant is designed for autonomous machine-to-machine interactions where tokens are regenerated automatically. Currently there is no way to configure token lifetime specifically for this grant type without affecting all other grants.

Many developers using Laravel Passport may not be familiar with the security implications of long-lived tokens or the nuances between OAuth 2.0 grant types. Providing a dedicated configuration method helps guide them toward better security practices.

### Industry Guidance

- **[RFC 9700 - OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/rfc9700/)** (January 2025): "Access tokens should be restricted to the minimum required... helps reduce the impact of access token leakage."
- **[OWASP OAuth2 Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/OAuth2_Cheat_Sheet.html)**: "The validity of an access token should be between 5 and 15 minutes, depending on the sensitivity of the resources."
- **[Google API Security Guidelines](https://cloud.google.com/apigee/docs/api-platform/antipatterns/oauth-long-expiration)**: Explicitly calls out long token expiration as an antipattern, recommending 30 minutes as a starting point.

## Usage

```php
use DateInterval;
use Laravel\Passport\Passport;

public function boot(): void
{
    Passport::clientCredentialsTokensExpireIn(new DateInterval('PT1H'));
}
```

## Changes

- Added `Passport::$clientCredentialsTokensExpireIn` property and `Passport::clientCredentialsTokensExpireIn()` method
- Service provider uses `clientCredentialsTokensExpireIn() ?? tokensExpireIn()` for backwards compatibility
- Added test for custom client credentials token expiration