### PR TITLE
Add mixin annotation for `Token` model in `AccessToken`

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -13,6 +13,8 @@ use Psr\Http\Message\ServerRequestInterface;
  * @template TValue
  *
  * @implements \Illuminate\Contracts\Support\Arrayable<string, TValue>
+ * 
+ * @mixin \Laravel\Passport\Token
  *
  * @property string $oauth_access_token_id
  * @property string $oauth_client_id

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * @template TValue
  *
  * @implements \Illuminate\Contracts\Support\Arrayable<string, TValue>
+ *
  * @mixin \Laravel\Passport\Token
  *
  * @property string $oauth_access_token_id

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -13,7 +13,6 @@ use Psr\Http\Message\ServerRequestInterface;
  * @template TValue
  *
  * @implements \Illuminate\Contracts\Support\Arrayable<string, TValue>
- * 
  * @mixin \Laravel\Passport\Token
  *
  * @property string $oauth_access_token_id


### PR DESCRIPTION
AccessToken uses the underlying Token instance, but PHPStan can't infer that statically. Without @mixin Token, PHPStan reports errors like "method X not found on AccessToken" or "property Y not found on AccessToken" whenever someone accesses a Token method or property through an AccessToken instance.

The @mixin annotation tells PHPStan that this class also exposes the API surface of Token