### PR TITLE
Add missing `OAuthenticatable` interface step to upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -70,6 +70,23 @@ PR: https://github.com/laravel/passport/pull/1755
 
 When authenticating users via bearer tokens, the `User` model's `token` method now returns an instance of `Laravel\Passport\AccessToken` class instead of `Laravel\Passport\Token`.
 
+### User Model Interface
+
+PR: https://github.com/laravel/passport/pull/1797
+
+Passport 13 introduces the `Laravel\Passport\Contracts\OAuthenticatable` interface, which must now be
+implemented by your `App\Models\User` model alongside the existing `HasApiTokens` trait:
+
+```php
+use Laravel\Passport\Contracts\OAuthenticatable;
+use Laravel\Passport\HasApiTokens;
+
+class User extends Authenticatable implements OAuthenticatable
+{
+    use HasApiTokens;
+}
+```
+
 ### Renamed Middlewares
 
 PR: https://github.com/laravel/passport/pull/1792, https://github.com/laravel/passport/pull/1794

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,23 @@ All the authorization view's rendering logic may be customized using the appropr
         Passport::viewPrefix('auth.oauth');
     }
 
+### User Model Interface
+
+PR: https://github.com/laravel/passport/pull/1797
+
+Passport 13 introduces the `Laravel\Passport\Contracts\OAuthenticatable` interface, which must now be
+implemented by your `App\Models\User` model alongside the existing `HasApiTokens` trait:
+
+```php
+use Laravel\Passport\Contracts\OAuthenticatable;
+use Laravel\Passport\HasApiTokens;
+
+class User extends Authenticatable implements OAuthenticatable
+{
+    use HasApiTokens;
+}
+```
+
 ### Identify Clients by UUIDs
 
 PR: https://github.com/laravel/passport/pull/1764
@@ -69,23 +86,6 @@ In light of this change, the `Passport::$hashesClientSecrets` property and `Pass
 PR: https://github.com/laravel/passport/pull/1755
 
 When authenticating users via bearer tokens, the `User` model's `token` method now returns an instance of `Laravel\Passport\AccessToken` class instead of `Laravel\Passport\Token`.
-
-### User Model Interface
-
-PR: https://github.com/laravel/passport/pull/1797
-
-Passport 13 introduces the `Laravel\Passport\Contracts\OAuthenticatable` interface, which must now be
-implemented by your `App\Models\User` model alongside the existing `HasApiTokens` trait:
-
-```php
-use Laravel\Passport\Contracts\OAuthenticatable;
-use Laravel\Passport\HasApiTokens;
-
-class User extends Authenticatable implements OAuthenticatable
-{
-    use HasApiTokens;
-}
-```
 
 ### Renamed Middlewares
 


### PR DESCRIPTION
The upgrade guide was missing a step instructing users to add the `Laravel\Passport\Contracts\OAuthenticatable` interface to their `App\Models\User` model. This interface was introduced in Passport 13. Prior versions only required the `HasApiTokens` trait. Without this, upgrading users will have no indication they need to add it.

## Changes

Added a new entry to `UPGRADE.md` under the "Upgrading To 13.0 From 12.x" section documenting the required `User` model change, consistent with what the installation docs already state.
