### PR TITLE
Fix session serialization for auth request and device code

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -82,7 +82,7 @@ class AuthorizationController
         }
 
         $request->session()->put('authToken', $authToken = Str::random());
-        $request->session()->put('authRequest', $authRequest);
+        $request->session()->put('authRequest', serialize($authRequest));
 
         return $viewResponse->withParameters([
             'client' => $client,

--- a/src/Http/Controllers/DeviceAuthorizationController.php
+++ b/src/Http/Controllers/DeviceAuthorizationController.php
@@ -55,7 +55,7 @@ class DeviceAuthorizationController
         $client = $this->clients->find($deviceCode->getClient()->getIdentifier());
 
         $request->session()->put('authToken', $authToken = Str::random());
-        $request->session()->put('deviceCode', $deviceCode);
+        $request->session()->put('deviceCode', serialize($deviceCode));
 
         return $viewResponse->withParameters([
             'client' => $client,

--- a/src/Http/Controllers/RetrievesAuthRequestFromSession.php
+++ b/src/Http/Controllers/RetrievesAuthRequestFromSession.php
@@ -24,7 +24,13 @@ trait RetrievesAuthRequestFromSession
             throw InvalidAuthTokenException::different();
         }
 
-        return $request->session()->pull('authRequest')
+        $authRequest = $request->session()->pull('authRequest')
             ?? throw new Exception('Authorization request was not present in the session.');
+
+        if (is_string($authRequest)) {
+            $authRequest = unserialize($authRequest);
+        }
+
+        return $authRequest;
     }
 }

--- a/src/Http/Controllers/RetrievesDeviceCodeFromSession.php
+++ b/src/Http/Controllers/RetrievesDeviceCodeFromSession.php
@@ -24,7 +24,13 @@ trait RetrievesDeviceCodeFromSession
             throw InvalidAuthTokenException::different();
         }
 
-        return $request->session()->pull('deviceCode')
+        $deviceCode = $request->session()->pull('deviceCode')
             ?? throw new Exception('Device code was not present in the session.');
+
+        if (is_string($deviceCode)) {
+            $deviceCode = unserialize($deviceCode);
+        }
+
+        return $deviceCode;
     }
 }

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -41,7 +41,12 @@ class AuthorizationControllerTest extends TestCase
 
         $guard->shouldReceive('guest')->andReturn(false);
         $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
-        $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest = m::mock(AuthorizationRequestInterface::class));
+
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setClient(new \Laravel\Passport\Bridge\Client('1', 'Test Client'));
+        $authRequest->setScopes([new Scope('scope-1')]);
+
+        $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest);
 
         $psrRequest = m::mock(ServerRequestInterface::class);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
@@ -49,16 +54,12 @@ class AuthorizationControllerTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
-        $session->shouldReceive('put')->with('authRequest', $authRequest);
+        $session->shouldReceive('put')->with('authRequest', m::on(fn ($value) => is_string($value)))->once();
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $request->shouldReceive('input')->with('prompt')->andReturn(null);
 
-        $authRequest->shouldReceive('getClient->getIdentifier')->andReturn(1);
-        $authRequest->shouldReceive('getScopes')->andReturn([new Scope('scope-1')]);
-        $authRequest->shouldReceive('setUser')->once();
-
         $clients = m::mock(ClientRepository::class);
-        $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
+        $clients->shouldReceive('find')->with('1')->andReturn($client = m::mock(Client::class));
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
         $client->shouldReceive('tokens->where->pluck')->andReturn(collect());
 
@@ -213,8 +214,13 @@ class AuthorizationControllerTest extends TestCase
         $guard->shouldReceive('guest')->andReturn(false);
         $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
+
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setClient(new \Laravel\Passport\Bridge\Client('1', 'Test Client'));
+        $authRequest->setScopes([new Scope('scope-1')]);
+
         $server->shouldReceive('validateAuthorizationRequest')
-            ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
+            ->andReturn($authRequest);
 
         $psrRequest = m::mock(ServerRequestInterface::class);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
@@ -224,16 +230,12 @@ class AuthorizationControllerTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
-        $session->shouldReceive('put')->with('authRequest', $authRequest);
+        $session->shouldReceive('put')->with('authRequest', m::on(fn ($value) => is_string($value)))->once();
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $request->shouldReceive('input')->with('prompt')->andReturn('consent');
 
-        $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
-        $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
-        $authRequest->shouldReceive('setUser')->once()->andReturnNull();
-
         $clients = m::mock(ClientRepository::class);
-        $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
+        $clients->shouldReceive('find')->with('1')->andReturn($client = m::mock(Client::class));
         $client->shouldReceive('skipsAuthorization')->andReturn(false);
 
         $response->shouldReceive('withParameters')->once()->andReturnUsing(function ($data) use ($client, $user, $request, $response) {


### PR DESCRIPTION
## Summary
- Laravel 13 defaults to JSON session serialization, which cannot properly serialize/deserialize League OAuth2 objects (`AuthorizationRequestInterface`, `DeviceCodeEntityInterface`)
- When retrieved from a JSON-serialized session, these objects are returned as arrays instead of their original class instances, causing `ApproveAuthorizationController::getAuthRequestFromSession()` to fail with "Return value must be of type AuthorizationRequestInterface, array returned"
- This fix explicitly `serialize()`s these objects to strings before storing them in the session, and `unserialize()`s them when retrieved
- The `is_string()` check provides backward compatibility with existing sessions that may still contain objects from the native PHP session serializer

Fixes #1894

## Test plan
- [x] Updated unit tests to use real `AuthorizationRequest` objects to verify serialization works correctly
- [x] All 101 unit tests pass
- [x] Backward compatible: `is_string()` check handles both serialized strings and legacy object values

🤖 Generated with [Claude Code](https://claude.com/claude-code)