### PR TITLE
[13.x] Add  middleware attribute

### DIFF
--- a/src/Attributes/AuthorizeToken.php
+++ b/src/Attributes/AuthorizeToken.php
@@ -11,9 +11,9 @@ use Laravel\Passport\Http\Middleware\CheckTokenForAnyScope;
 class AuthorizeToken extends Middleware
 {
     /**
-     * @param array<string>|string $scopes
-     * @param array<string>|null $only
-     * @param array<string>|null $except
+     * @param  array<string>|string  $scopes
+     * @param  array<string>|null  $only
+     * @param  array<string>|null  $except
      */
     public function __construct(
         array|string $scopes,

--- a/src/Attributes/AuthorizeToken.php
+++ b/src/Attributes/AuthorizeToken.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Passport\Attributes;
+
+use Attribute;
+use Illuminate\Routing\Attributes\Controllers\Middleware;
+use Laravel\Passport\Http\Middleware\CheckToken;
+use Laravel\Passport\Http\Middleware\CheckTokenForAnyScope;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class AuthorizeToken extends Middleware
+{
+    /**
+     * @param array<string>|string $scopes
+     * @param array<string>|null $only
+     * @param array<string>|null $except
+     */
+    public function __construct(
+        array|string $scopes,
+        bool $anyScope = false,
+        ?array $only = null,
+        ?array $except = null,
+    ) {
+        parent::__construct(
+            $anyScope ? CheckTokenForAnyScope::using($scopes) : CheckToken::using($scopes),
+            $only, $except,
+        );
+    }
+}

--- a/tests/Feature/Attributes/AuthorizeTokenTest.php
+++ b/tests/Feature/Attributes/AuthorizeTokenTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Laravel\Passport\Tests\Feature\Attributes;
+
+use Illuminate\Support\Facades\Route;
+use Laravel\Passport\Attributes\AuthorizeToken;
+use Orchestra\Testbench\Attributes\RequiresLaravel;
+use Orchestra\Testbench\TestCase;
+
+#[RequiresLaravel('13.0.0')]
+class AuthorizeTokenTest extends TestCase
+{
+    public function testItAppliesCheckTokenMiddleware(): void
+    {
+        $route = Route::get('/test', [AuthorizeTokenControllerTest::class, 'index']);
+
+        $this->assertSame([
+            'Laravel\Passport\Http\Middleware\CheckToken:all',
+            'Laravel\Passport\Http\Middleware\CheckToken:only-index',
+            'Laravel\Passport\Http\Middleware\CheckToken:also-index',
+        ], $route->controllerMiddleware());
+
+        $route = Route::get('/test', [AuthorizeTokenControllerTest::class, 'show']);
+
+        $this->assertSame([
+            'Laravel\Passport\Http\Middleware\CheckToken:all',
+            'Laravel\Passport\Http\Middleware\CheckToken:except-index',
+        ], $route->controllerMiddleware());
+    }
+
+    public function testItAppliesCheckTokenForAnyScopeMiddleware(): void
+    {
+        $route = Route::get('/test', [AuthorizeTokenControllerTest::class, 'store']);
+
+        $this->assertSame([
+            'Laravel\Passport\Http\Middleware\CheckToken:all',
+            'Laravel\Passport\Http\Middleware\CheckToken:except-index',
+            'Laravel\Passport\Http\Middleware\CheckTokenForAnyScope:only-store,something-else',
+        ], $route->controllerMiddleware());
+    }
+}
+
+#[AuthorizeToken('all')]
+#[AuthorizeToken('only-index', only: ['index'])]
+#[AuthorizeToken('except-index', except: ['index'])]
+class AuthorizeTokenControllerTest
+{
+    #[AuthorizeToken('also-index')]
+    public function index(): void
+    {
+    }
+
+    public function show(): void
+    {
+    }
+
+    #[AuthorizeToken(['only-store', 'something-else'], anyScope: true)]
+    public function store(): void
+    {
+    }
+}


### PR DESCRIPTION
Inspired by https://github.com/laravel/framework/pull/59048

This PR adds a new attribute that allows developers to easily set token scopes in their controllers, example usage:

```php
class MyController
{
    #[TokenCan('read')]
    public function index() { /* ... */ }

    #[TokenCan('write')]
    public function store() { /* ... */ }
}
```

Note: I opted not to name it `Scope` because that would conflict with an existing Eloquent attribute