### PR TITLE
[13.x] Parse prompt parameter as a space-delimited list per OIDC spec

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -49,13 +49,16 @@ class AuthorizationController
             ($psrRequest->getQueryParams()['response_type'] ?? null) === 'token'
         );
 
+        $prompt = $request->input('prompt');
+        $promptValues = $prompt ? explode(' ', $prompt) : [];
+
         if ($this->guard->guest()) {
-            $request->input('prompt') === 'none'
+            in_array('none', $promptValues)
                 ? throw OAuthServerException::loginRequired($authRequest)
                 : $this->promptForLogin($request);
         }
 
-        if ($request->input('prompt') === 'login' &&
+        if (in_array('login', $promptValues) &&
             ! $request->session()->get('promptedForLogin', false)) {
             $this->guard->logout();
             $request->session()->invalidate();
@@ -72,12 +75,12 @@ class AuthorizationController
         $scopes = $this->parseScopes($authRequest);
         $client = $this->clients->find($authRequest->getClient()->getIdentifier());
 
-        if ($request->input('prompt') !== 'consent' &&
+        if (! in_array('consent', $promptValues) &&
             ($client->skipsAuthorization($user, $scopes) || $this->hasGrantedScopes($user, $client, $scopes))) {
             return $this->approveRequest($authRequest, $psrResponse);
         }
 
-        if ($request->input('prompt') === 'none') {
+        if (in_array('none', $promptValues)) {
             throw OAuthServerException::consentRequired($authRequest);
         }
 

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -387,6 +387,90 @@ class AuthorizationControllerTest extends TestCase
         $controller->authorize($psrRequest, $request, $psrResponse, $response);
     }
 
+    public function test_logout_and_prompt_login_if_request_has_prompt_with_login_and_consent()
+    {
+        $this->expectException(AuthenticationException::class);
+
+        $server = m::mock(AuthorizationServer::class);
+        $response = m::mock(AuthorizationViewResponse::class);
+        $guard = m::mock(StatefulGuard::class);
+
+        $guard->shouldReceive('guest')->andReturn(false);
+        $server->shouldReceive('validateAuthorizationRequest')->once();
+        $guard->shouldReceive('logout')->once();
+
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+
+        $psrResponse = m::mock(ResponseInterface::class);
+
+        $request = m::mock(Request::class);
+        $request->shouldReceive('session')->andReturn($session = m::mock());
+        $session->shouldReceive('invalidate')->once();
+        $session->shouldReceive('regenerateToken')->once();
+        $session->shouldReceive('get')->with('promptedForLogin', false)->once()->andReturn(false);
+        $session->shouldReceive('put')->with('promptedForLogin', true)->once();
+        $session->shouldNotReceive('forget')->with('promptedForLogin');
+        $request->shouldReceive('input')->with('prompt')->andReturn('login consent');
+
+        $clients = m::mock(ClientRepository::class);
+
+        $controller = new AuthorizationController($server, $guard, $clients);
+
+        $controller->authorize($psrRequest, $request, $psrResponse, $response);
+    }
+
+    public function test_authorization_view_is_presented_if_request_has_prompt_with_login_and_consent_after_login()
+    {
+        Passport::tokensCan([
+            'scope-1' => 'description',
+        ]);
+
+        $server = m::mock(AuthorizationServer::class);
+        $response = m::mock(AuthorizationViewResponse::class);
+        $guard = m::mock(StatefulGuard::class);
+
+        $guard->shouldReceive('guest')->andReturn(false);
+        $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
+        $server->shouldReceive('validateAuthorizationRequest')
+            ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
+
+        $psrRequest = m::mock(ServerRequestInterface::class);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+
+        $psrResponse = m::mock(ResponseInterface::class);
+
+        $request = m::mock(Request::class);
+        $request->shouldReceive('session')->andReturn($session = m::mock());
+        $session->shouldReceive('get')->with('promptedForLogin', false)->andReturn(true);
+        $session->shouldReceive('forget')->with('promptedForLogin')->once();
+        $session->shouldReceive('put')->withSomeOfArgs('authToken');
+        $session->shouldReceive('put')->with('authRequest', $authRequest);
+        $request->shouldReceive('input')->with('prompt')->andReturn('login consent');
+
+        $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
+        $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
+        $authRequest->shouldReceive('setUser')->once()->andReturnNull();
+
+        $clients = m::mock(ClientRepository::class);
+        $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
+        $client->shouldReceive('skipsAuthorization')->andReturn(true);
+
+        $response->shouldReceive('withParameters')->once()->andReturnUsing(function ($data) use ($client, $user, $request, $response) {
+            $this->assertEquals($client, $data['client']);
+            $this->assertEquals($user, $data['user']);
+            $this->assertEquals($request, $data['request']);
+            $this->assertSame('description', $data['scopes'][0]->description);
+
+            return $response;
+        });
+
+        $controller = new AuthorizationController($server, $guard, $clients);
+
+        $this->assertSame($response, $controller->authorize($psrRequest, $request, $psrResponse, $response));
+    }
+
     public function test_user_should_be_authenticated()
     {
         $this->expectException(AuthenticationException::class);


### PR DESCRIPTION
The OIDC Core 1.0 spec ([Section 3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)) defines `prompt` as:

> OPTIONAL. Space-delimited, case-sensitive list of ASCII string values that specifies whether the Authorization Server prompts the End-User for reauthentication and consent.

Currently, Passport checks the `prompt` parameter using strict string equality, so a request like `prompt=login consent` silently matches none of the checks.

This PR parses `prompt` into an array via `explode()` and replaces the four equality checks with `in_array()`. Single-value requests like `prompt=login` continue to work identically.