### PR TITLE
Prevent user impersonation via client credentials token

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -141,13 +141,17 @@ class TokenGuard implements Guard
 
         $this->setClient($client);
 
+        $oauthUserId = $psr->getAttribute('oauth_user_id');
+
+        if (empty($oauthUserId) || $oauthUserId === $psr->getAttribute('oauth_client_id')) {
+            return null;
+        }
+
         // If the access token is valid we will retrieve the user according to the user ID
         // associated with the token. We will use the provider implementation which may
         // be used to retrieve users from Eloquent. Next, we'll be ready to continue.
         try {
-            $user = $this->provider->retrieveById(
-                $psr->getAttribute('oauth_user_id') ?: null
-            );
+            $user = $this->provider->retrieveById($oauthUserId);
         } catch (Exception) {
             return null;
         }

--- a/tests/Unit/TokenGuardTest.php
+++ b/tests/Unit/TokenGuardTest.php
@@ -47,17 +47,17 @@ class TokenGuardTest extends TestCase
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttributes')->andReturn([
             'oauth_user_id' => 1,
-            'oauth_client_id' => 1,
+            'oauth_client_id' => 2,
             'oauth_access_token_id' => 'token',
             'oauth_scopes' => [],
         ]);
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
-        $clients->shouldReceive('findActive')->with(1)->andReturn(new TokenGuardTestClient);
+        $clients->shouldReceive('findActive')->with(2)->andReturn(new TokenGuardTestClient);
 
         $user = $guard->user();
 
@@ -79,17 +79,17 @@ class TokenGuardTest extends TestCase
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttributes')->andReturn([
             'oauth_user_id' => 1,
-            'oauth_client_id' => 1,
+            'oauth_client_id' => 2,
             'oauth_access_token_id' => 'token',
             'oauth_scopes' => [],
         ]);
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
-        $clients->shouldReceive('findActive')->with(1)->andReturn(new TokenGuardTestClient);
+        $clients->shouldReceive('findActive')->with(2)->andReturn(new TokenGuardTestClient);
 
         $user = $guard->user();
 
@@ -137,7 +137,7 @@ class TokenGuardTest extends TestCase
         $encrypter = m::mock(Encrypter::class);
 
         $clients->shouldReceive('findActive')
-            ->with(1)
+            ->with(2)
             ->andReturn(new TokenGuardTestClient);
 
         $request = Request::create('/');
@@ -147,9 +147,36 @@ class TokenGuardTest extends TestCase
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(null);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
+
+        $this->assertNull($guard->user());
+    }
+
+    public function test_null_is_returned_for_client_credentials_token()
+    {
+        $resourceServer = m::mock(ResourceServer::class);
+        $userProvider = m::mock(PassportUserProvider::class);
+        $clients = m::mock(ClientRepository::class);
+        $encrypter = m::mock(Encrypter::class);
+
+        $clientId = '019c9d23-9763-7303-9bdb-3a0a6bf0ef90';
+
+        $clients->shouldReceive('findActive')
+            ->with($clientId)
+            ->andReturn(new TokenGuardTestClient);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
+
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
+        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn($clientId);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn($clientId);
+        $userProvider->shouldReceive('getProviderName')->andReturn(null);
+        $userProvider->shouldReceive('retrieveById')->never();
 
         $this->assertNull($guard->user());
     }


### PR DESCRIPTION
For `client_credentials` tokens, League's `AccessTokenTrait::getSubjectIdentifier()` falls back to the client UUID when no user exists. The `BearerTokenValidator` maps this into `oauth_user_id`, causing `TokenGuard` to call `retrieveById()` with the client UUID. On MySQL with integer primary keys, implicit type casting can match an unrelated user row.

Fixes #1900
