### PR TITLE
[13.X] fix: resolve user as null when user ID matches client ID on integer key setups

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -143,7 +143,7 @@ class TokenGuard implements Guard
 
         $oauthUserId = $psr->getAttribute('oauth_user_id');
 
-        if (empty($oauthUserId) || $oauthUserId === $psr->getAttribute('oauth_client_id')) {
+        if (empty($oauthUserId)) {
             return null;
         }
 

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -143,7 +143,7 @@ class TokenGuard implements Guard
 
         $oauthUserId = $psr->getAttribute('oauth_user_id');
 
-        if (empty($oauthUserId)) {
+        if (empty($oauthUserId) || ($oauthUserId === $psr->getAttribute('oauth_client_id') && $client->hasGrantType('client_credentials'))) {
             return null;
         }
 

--- a/tests/Unit/TokenGuardTest.php
+++ b/tests/Unit/TokenGuardTest.php
@@ -176,9 +176,44 @@ class TokenGuardTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn($clientId);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn($clientId);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
-        $userProvider->shouldReceive('retrieveById')->never();
+        $userProvider->shouldReceive('retrieveById')->with($clientId)->andReturn(null);
 
         $this->assertNull($guard->user());
+    }
+
+    public function test_user_is_resolved_when_user_id_matches_client_id()
+    {
+        $resourceServer = m::mock(ResourceServer::class);
+        $userProvider = m::mock(PassportUserProvider::class);
+        $clients = m::mock(ClientRepository::class);
+        $encrypter = m::mock(Encrypter::class);
+
+        $clients->shouldReceive('findActive')
+            ->with(1)
+            ->andReturn(new TokenGuardTestClient);
+
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer token');
+
+        $guard = new TokenGuard($resourceServer, $userProvider, $clients, $encrypter, $request);
+
+        $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
+        $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
+        $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
+        $psr->shouldReceive('getAttributes')->andReturn([
+            'oauth_user_id' => 1,
+            'oauth_client_id' => 1,
+            'oauth_access_token_id' => 'token',
+            'oauth_scopes' => [],
+        ]);
+        $userProvider->shouldReceive('getProviderName')->andReturn(null);
+        $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(new TokenGuardTestUser);
+
+        $user = $guard->user();
+
+        $this->assertInstanceOf(TokenGuardTestUser::class, $user);
+        $this->assertEquals(AccessToken::fromPsrRequest($psr), $user->currentAccessToken());
     }
 
     public function test_users_may_be_retrieved_from_cookies_with_csrf_token_header()

--- a/tests/Unit/TokenGuardTest.php
+++ b/tests/Unit/TokenGuardTest.php
@@ -47,17 +47,17 @@ class TokenGuardTest extends TestCase
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttributes')->andReturn([
             'oauth_user_id' => 1,
-            'oauth_client_id' => 2,
+            'oauth_client_id' => 1,
             'oauth_access_token_id' => 'token',
             'oauth_scopes' => [],
         ]);
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
-        $clients->shouldReceive('findActive')->with(2)->andReturn(new TokenGuardTestClient);
+        $clients->shouldReceive('findActive')->with(1)->andReturn(new TokenGuardTestClient);
 
         $user = $guard->user();
 
@@ -79,17 +79,17 @@ class TokenGuardTest extends TestCase
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $psr->shouldReceive('getAttribute')->with('oauth_access_token_id')->andReturn('token');
         $psr->shouldReceive('getAttributes')->andReturn([
             'oauth_user_id' => 1,
-            'oauth_client_id' => 2,
+            'oauth_client_id' => 1,
             'oauth_access_token_id' => 'token',
             'oauth_scopes' => [],
         ]);
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(new TokenGuardTestUser);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
-        $clients->shouldReceive('findActive')->with(2)->andReturn(new TokenGuardTestClient);
+        $clients->shouldReceive('findActive')->with(1)->andReturn(new TokenGuardTestClient);
 
         $user = $guard->user();
 
@@ -137,7 +137,7 @@ class TokenGuardTest extends TestCase
         $encrypter = m::mock(Encrypter::class);
 
         $clients->shouldReceive('findActive')
-            ->with(2)
+            ->with(1)
             ->andReturn(new TokenGuardTestClient);
 
         $request = Request::create('/');
@@ -147,7 +147,7 @@ class TokenGuardTest extends TestCase
 
         $resourceServer->shouldReceive('validateAuthenticatedRequest')->andReturn($psr = m::mock(ServerRequestInterface::class));
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn(1);
-        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(2);
+        $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn(1);
         $userProvider->shouldReceive('retrieveById')->with(1)->andReturn(null);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
 
@@ -163,9 +163,12 @@ class TokenGuardTest extends TestCase
 
         $clientId = '019c9d23-9763-7303-9bdb-3a0a6bf0ef90';
 
+        $client = new TokenGuardTestClient;
+        $client->grant_types = ['client_credentials'];
+
         $clients->shouldReceive('findActive')
             ->with($clientId)
-            ->andReturn(new TokenGuardTestClient);
+            ->andReturn($client);
 
         $request = Request::create('/');
         $request->headers->set('Authorization', 'Bearer token');
@@ -176,7 +179,7 @@ class TokenGuardTest extends TestCase
         $psr->shouldReceive('getAttribute')->with('oauth_user_id')->andReturn($clientId);
         $psr->shouldReceive('getAttribute')->with('oauth_client_id')->andReturn($clientId);
         $userProvider->shouldReceive('getProviderName')->andReturn(null);
-        $userProvider->shouldReceive('retrieveById')->with($clientId)->andReturn(null);
+        $userProvider->shouldReceive('retrieveById')->never();
 
         $this->assertNull($guard->user());
     }


### PR DESCRIPTION
## Problem

When using integer (non-UUID) primary keys, if a user's ID happens to equal the ID of the password grant client, `TokenGuard::authenticateViaBearerToken()` incorrectly returns `null` and the user cannot be authenticated.

The faulty check in `TokenGuard.php`:

```php
if (empty($oauthUserId) || $oauthUserId === $psr->getAttribute('oauth_client_id')) {
    return null;
}
```

This condition was intended to detect `client_credentials `grant tokens (which have no associated user). However, when integer IDs are used, a legitimate password grant token for user ID `2` will be rejected if the client ID is also `2`, because the strict equality check `$oauthUserId === $psr->getAttribute('oauth_client_id')` evaluates to `true`.

## Root Cause

The `UPGRADE.md` for v13 documents UUID migration as optional. Applications that continue using integer IDs are vulnerable to this ID collision.

The `=== oauth_client_id check` alone is too broad — it rejects any token where the user ID matches the client ID, regardless of grant type. The fix scopes this check to only apply when the client actually uses the `client_credentials` grant type.

Reproduction Steps

1.     Use integer (non-UUID) primary keys for both `users` and `oauth_clients` tables.
2.     Seed a password grant client — ensure its auto-incremented ID ends up as `N`.
3.     Create a user with ID `N`. 
4.     Obtain an `access token` for that user via the `password grant`.
5.     Make an authenticated request — the guard returns `null` and the request is rejected with a 401 Unauthorized response.