### PR TITLE
[13.x] Fix session JSON serialization

### DIFF
--- a/src/Http/Controllers/AuthorizationController.php
+++ b/src/Http/Controllers/AuthorizationController.php
@@ -82,7 +82,7 @@ class AuthorizationController
         }
 
         $request->session()->put('authToken', $authToken = Str::random());
-        $request->session()->put('authRequest', $authRequest);
+        $request->session()->put('authRequest', serialize($authRequest));
 
         return $viewResponse->withParameters([
             'client' => $client,

--- a/src/Http/Controllers/DeviceAuthorizationController.php
+++ b/src/Http/Controllers/DeviceAuthorizationController.php
@@ -55,7 +55,7 @@ class DeviceAuthorizationController
         $client = $this->clients->find($deviceCode->getClient()->getIdentifier());
 
         $request->session()->put('authToken', $authToken = Str::random());
-        $request->session()->put('deviceCode', $deviceCode);
+        $request->session()->put('deviceCode', serialize($deviceCode));
 
         return $viewResponse->withParameters([
             'client' => $client,

--- a/src/Http/Controllers/RetrievesAuthRequestFromSession.php
+++ b/src/Http/Controllers/RetrievesAuthRequestFromSession.php
@@ -24,7 +24,14 @@ trait RetrievesAuthRequestFromSession
             throw InvalidAuthTokenException::different();
         }
 
-        return $request->session()->pull('authRequest')
+        $authRequest = $request->session()->pull('authRequest')
             ?? throw new Exception('Authorization request was not present in the session.');
+
+        return unserialize($authRequest, ['allowed_classes' => [
+            \League\OAuth2\Server\RequestTypes\AuthorizationRequest::class,
+            \Laravel\Passport\Bridge\Client::class,
+            \Laravel\Passport\Bridge\Scope::class,
+            \Laravel\Passport\Bridge\User::class,
+        ]]);
     }
 }

--- a/src/Http/Controllers/RetrievesDeviceCodeFromSession.php
+++ b/src/Http/Controllers/RetrievesDeviceCodeFromSession.php
@@ -24,7 +24,14 @@ trait RetrievesDeviceCodeFromSession
             throw InvalidAuthTokenException::different();
         }
 
-        return $request->session()->pull('deviceCode')
+        $deviceCode = $request->session()->pull('deviceCode')
             ?? throw new Exception('Device code was not present in the session.');
+
+        return unserialize($deviceCode, ['allowed_classes' => [
+            \Laravel\Passport\Bridge\DeviceCode::class,
+            \Laravel\Passport\Bridge\Client::class,
+            \Laravel\Passport\Bridge\Scope::class,
+            \DateTimeImmutable::class,
+        ]]);
     }
 }

--- a/tests/Feature/AuthorizationCodeGrantTest.php
+++ b/tests/Feature/AuthorizationCodeGrantTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Laravel\Passport\Database\Factories\ClientFactory;
 use Laravel\Passport\Passport;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Workbench\Database\Factories\UserFactory;
 
@@ -252,6 +253,35 @@ class AuthorizationCodeGrantTest extends PassportTestCase
         $json = $response->json();
         $this->assertEqualsCanonicalizing(['client', 'user', 'scopes', 'request', 'authToken'], array_keys($json));
         $this->assertSame(collect(Passport::scopesFor(['create', 'update']))->toArray(), $json['scopes']);
+    }
+
+    #[WithConfig('session.serialization', 'json')]
+    public function testAuthRequestSerialization()
+    {
+        $client = ClientFactory::new()->create();
+
+        $query = http_build_query([
+            'client_id' => $client->getKey(),
+            'redirect_uri' => $client->redirect_uris[0],
+            'response_type' => 'code',
+            'scope' => 'create read',
+            'state' => Str::random(40),
+        ]);
+
+        $this->actingAs(UserFactory::new()->create(), 'web');
+
+        $json = $this->get('/oauth/authorize?'.$query)
+            ->assertOk()
+            ->assertSessionHas('authRequest')
+            ->assertSessionHas('authToken')
+            ->json();
+
+        $this->assertEqualsCanonicalizing(['client', 'user', 'scopes', 'request', 'authToken'], array_keys($json));
+        $this->assertSame(collect(Passport::scopesFor(['create', 'read']))->toArray(), $json['scopes']);
+
+        $this->post('/oauth/authorize', ['auth_token' => $json['authToken']])
+            ->assertRedirect()
+            ->assertSessionMissing(['authRequest', 'authToken']);
     }
 
     public function testValidateAuthorizationRequest()

--- a/tests/Feature/DeviceAuthorizationGrantTest.php
+++ b/tests/Feature/DeviceAuthorizationGrantTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Laravel\Passport\Database\Factories\ClientFactory;
 use Laravel\Passport\Passport;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Workbench\Database\Factories\UserFactory;
 
@@ -224,6 +225,33 @@ class DeviceAuthorizationGrantTest extends PassportTestCase
         $this->assertArrayHasKey('error', $json);
         $this->assertArrayHasKey('error_description', $json);
         $this->assertSame('access_denied', $json['error']);
+    }
+
+    #[WithConfig('session.serialization', 'json')]
+    public function testDeviceCodeSerialization()
+    {
+        $client = ClientFactory::new()->asDeviceCodeClient()->create();
+
+        ['user_code' => $userCode] = $this->post('/oauth/device/code', [
+            'client_id' => $client->getKey(),
+            'scope' => 'create read',
+        ])->assertOk()->json();
+
+        $user = UserFactory::new()->create();
+        $this->actingAs($user, 'web');
+
+        $json = $this->get('/oauth/device/authorize?user_code='.$userCode)
+            ->assertOk()
+            ->assertSessionHas('deviceCode')
+            ->assertSessionHas('authToken')
+            ->json();
+        $this->assertEqualsCanonicalizing(['client', 'user', 'scopes', 'request', 'authToken'], array_keys($json));
+        $this->assertSame(collect(Passport::scopesFor(['create', 'read']))->toArray(), $json['scopes']);
+
+        $this->post('/oauth/device/authorize', ['auth_token' => $json['authToken']])
+            ->assertRedirectToRoute('passport.device')
+            ->assertSessionHas('status', 'authorization-approved')
+            ->assertSessionMissing(['deviceCode', 'authToken']);
     }
 
     public function testPublicClient()

--- a/tests/Unit/ApproveAuthorizationControllerTest.php
+++ b/tests/Unit/ApproveAuthorizationControllerTest.php
@@ -28,22 +28,25 @@ class ApproveAuthorizationControllerTest extends TestCase
         $request->shouldReceive('isNotFilled')->with('auth_token')->andReturn(false);
         $request->shouldReceive('input')->with('auth_token')->andReturn('foo');
 
+        $authRequest = new AuthorizationRequest;
+        $authRequest->setGrantTypeId('authorization_code');
+
         $session->shouldReceive('pull')->once()->with('authToken')->andReturn('foo');
         $session->shouldReceive('pull')
             ->once()
             ->with('authRequest')
-            ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
+            ->andReturn(serialize($authRequest));
 
         $request->shouldReceive('user')->andReturn(new ApproveAuthorizationControllerFakeUser);
-
-        $authRequest->shouldReceive('getGrantTypeId')->once()->andReturn('authorization_code');
-        $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(true);
 
         $psrResponse = (new PsrHttpFactory)->createResponse(new Response);
         $psrResponse->getBody()->write('response');
 
         $server->shouldReceive('completeAuthorizationRequest')
-            ->with($authRequest, m::type(ResponseInterface::class))
+            ->with(
+                m::on(fn (AuthorizationRequest $request) => $request->isAuthorizationApproved()),
+                m::type(ResponseInterface::class)
+            )
             ->andReturn($psrResponse);
 
         $this->assertSame('response', $controller->approve($request, $psrResponse)->getContent());

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -16,7 +16,6 @@ use Laravel\Passport\Passport;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException as LeagueException;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
-use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -39,9 +38,13 @@ class AuthorizationControllerTest extends TestCase
         $response = m::mock(AuthorizationViewResponse::class);
         $guard = m::mock(StatefulGuard::class);
 
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setClient(new \Laravel\Passport\Bridge\Client('1', 'Test Client'));
+        $authRequest->setScopes([new Scope('scope-1')]);
+
         $guard->shouldReceive('guest')->andReturn(false);
         $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
-        $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest = m::mock(AuthorizationRequestInterface::class));
+        $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest);
 
         $psrRequest = m::mock(ServerRequestInterface::class);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
@@ -49,13 +52,9 @@ class AuthorizationControllerTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
-        $session->shouldReceive('put')->with('authRequest', $authRequest);
+        $session->shouldReceive('put')->with('authRequest', m::on(fn ($value) => is_string($value)))->once();
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $request->shouldReceive('input')->with('prompt')->andReturn(null);
-
-        $authRequest->shouldReceive('getClient->getIdentifier')->andReturn(1);
-        $authRequest->shouldReceive('getScopes')->andReturn([new Scope('scope-1')]);
-        $authRequest->shouldReceive('setUser')->once();
 
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));
@@ -210,11 +209,14 @@ class AuthorizationControllerTest extends TestCase
         $response = m::mock(AuthorizationViewResponse::class);
         $guard = m::mock(StatefulGuard::class);
 
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setClient(new \Laravel\Passport\Bridge\Client('1', 'Test Client'));
+        $authRequest->setScopes([new Scope('scope-1')]);
+
         $guard->shouldReceive('guest')->andReturn(false);
         $guard->shouldReceive('user')->andReturn($user = m::mock(Authenticatable::class));
         $user->shouldReceive('getAuthIdentifier')->andReturn(1);
-        $server->shouldReceive('validateAuthorizationRequest')
-            ->andReturn($authRequest = m::mock(AuthorizationRequest::class));
+        $server->shouldReceive('validateAuthorizationRequest')->andReturn($authRequest);
 
         $psrRequest = m::mock(ServerRequestInterface::class);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
@@ -224,13 +226,9 @@ class AuthorizationControllerTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session = m::mock());
         $session->shouldReceive('put')->withSomeOfArgs('authToken');
-        $session->shouldReceive('put')->with('authRequest', $authRequest);
+        $session->shouldReceive('put')->with('authRequest', m::on(fn ($value) => is_string($value)))->once();
         $session->shouldReceive('forget')->with('promptedForLogin')->once();
         $request->shouldReceive('input')->with('prompt')->andReturn('consent');
-
-        $authRequest->shouldReceive('getClient->getIdentifier')->once()->andReturn(1);
-        $authRequest->shouldReceive('getScopes')->once()->andReturn([new Scope('scope-1')]);
-        $authRequest->shouldReceive('setUser')->once()->andReturnNull();
 
         $clients = m::mock(ClientRepository::class);
         $clients->shouldReceive('find')->with(1)->andReturn($client = m::mock(Client::class));

--- a/tests/Unit/AuthorizationControllerTest.php
+++ b/tests/Unit/AuthorizationControllerTest.php
@@ -38,7 +38,7 @@ class AuthorizationControllerTest extends TestCase
         $response = m::mock(AuthorizationViewResponse::class);
         $guard = m::mock(StatefulGuard::class);
 
-        $authRequest = new AuthorizationRequest();
+        $authRequest = new AuthorizationRequest;
         $authRequest->setClient(new \Laravel\Passport\Bridge\Client('1', 'Test Client'));
         $authRequest->setScopes([new Scope('scope-1')]);
 
@@ -209,7 +209,7 @@ class AuthorizationControllerTest extends TestCase
         $response = m::mock(AuthorizationViewResponse::class);
         $guard = m::mock(StatefulGuard::class);
 
-        $authRequest = new AuthorizationRequest();
+        $authRequest = new AuthorizationRequest;
         $authRequest->setClient(new \Laravel\Passport\Bridge\Client('1', 'Test Client'));
         $authRequest->setScopes([new Scope('scope-1')]);
 

--- a/tests/Unit/DenyAuthorizationControllerTest.php
+++ b/tests/Unit/DenyAuthorizationControllerTest.php
@@ -30,22 +30,23 @@ class DenyAuthorizationControllerTest extends TestCase
         $request->shouldReceive('isNotFilled')->with('auth_token')->andReturn(false);
         $request->shouldReceive('input')->with('auth_token')->andReturn('foo');
 
+        $authRequest = new AuthorizationRequest;
+        $authRequest->setGrantTypeId('authorization_code');
+
         $session->shouldReceive('pull')->once()->with('authToken')->andReturn('foo');
         $session->shouldReceive('pull')
             ->once()
             ->with('authRequest')
-            ->andReturn($authRequest = m::mock(
-                AuthorizationRequest::class
-            ));
-
-        $authRequest->shouldReceive('getGrantTypeId')->once()->andReturn('authorization_code');
-        $authRequest->shouldReceive('setAuthorizationApproved')->once()->with(false);
+            ->andReturn(serialize($authRequest));
 
         $psrResponse = m::mock(ResponseInterface::class);
         app()->instance(ResponseInterface::class, (new PsrHttpFactory)->createResponse(new Response));
 
         $server->shouldReceive('completeAuthorizationRequest')
-            ->with($authRequest, m::type(ResponseInterface::class))
+            ->with(
+                m::on(fn (AuthorizationRequest $request) => ! $request->isAuthorizationApproved()),
+                m::type(ResponseInterface::class)
+            )
             ->andReturnUsing(function () {
                 throw new \League\OAuth2\Server\Exception\OAuthServerException('', 0, '');
             });
@@ -78,15 +79,5 @@ class DenyAuthorizationControllerTest extends TestCase
         $server->shouldReceive('completeAuthorizationRequest')->never();
 
         $controller->deny($request, $psrResponse);
-    }
-}
-
-class DenyAuthorizationControllerFakeUser
-{
-    public $id = 1;
-
-    public function getAuthIdentifier()
-    {
-        return $this->id;
     }
 }


### PR DESCRIPTION
Fixes #1894 

This PR fixes an issue where an exception is thrown when `session.serialization` is set to `json`.
