### PR TITLE
Add notice of invalid tokens when user and client id match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## [v13.7.2](https://github.com/laravel/passport/compare/v13.7.1...v13.7.2) - 2026-04-02
 
 * [13.X] fix: resolve user as null when user ID matches client ID on integer key setups by [@Can-Kar](https://github.com/Can-Kar) in https://github.com/laravel/passport/pull/1902
+> This change permanently invalidates client credential tokens for any user whose user ID happens to match the client ID of the token issuer.
 
 ## [v13.7.1](https://github.com/laravel/passport/compare/v13.7.0...v13.7.1) - 2026-04-01
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -77,6 +77,10 @@ As a consequence of this change, the `'passport.client_uuids'` configuration pro
 
 > Changing the client ID in the database will invalidate all tokens previously issued for that client, as tokens are bound to the original client identifier.
 
+> The underlying [OAuth2 server](https://oauth2.thephpleague.com/database-setup/#:~:text=Please%20note%20that,the%20bearer%20token) sets the token's `sub` claim to the client's identifier for client credentials tokens. By default, Passport uses `UUID`s for clients, so this cannot collide with a user's integer primary key. However, if you have set `Passport::$clientUuids` to `false`, a client credentials token may inadvertently resolve a user whose ID matches the client's ID. In such cases, using this middleware cannot guarantee that the incoming token is a client credentials token.
+
+> Included in the upgrade is a change that permanently invalidates client credential tokens for any user whose user ID happens to match the client ID of the token issuer.
+
 ### Client Secrets Hashed by Default
 
 PR: https://github.com/laravel/passport/pull/1745


### PR DESCRIPTION
See https://github.com/laravel/passport/pull/1902#discussion_r3073086817

This PR adds a note to the documentation explaining that client credential tokens are invalidated when a user ID matches the issuing client’s ID.

This case can otherwise lead to confusion, as such tokens may appear valid but are rejected due to a potential impersonation risk.
