### PR TITLE
Clarify that running `passport:hash` is not optional

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -85,7 +85,7 @@ As a consequence of this change, the `'passport.client_uuids'` configuration pro
 
 PR: https://github.com/laravel/passport/pull/1745
 
-Passport now always hashes client secrets using Laravel's `Hash` facade. If you are currently storing your client secrets in plain text, you may invoke the `passport:hash` Artisan command to hash all of your existing client secrets:
+Passport now always hashes client secrets using Laravel's `Hash` facade. If you are currently storing your client secrets in plain text, you must invoke the `passport:hash` Artisan command to hash all of your existing client secrets:
 
 ```bash
 php artisan passport:hash


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Just a small clarification, looking at the source code of `validateClient` in `ClientRepository`:

```php
public function validateClient(string $clientIdentifier, ?string $clientSecret, ?string $grantType): bool
{
    $record = $this->clients->findActive($clientIdentifier);

    return $record && ! empty($clientSecret) && $this->hasher->check($clientSecret, $record->secret);
}
```

Hashing your secrets is no longer optional, client validation will fail if the `secret` column is not hashed. The wording in the current UPGRADE.md implies this is optional by using "MAY", which means optional as per: https://www.rfc-editor.org/rfc/rfc2119
