### PR TITLE
[13.x] Clarify grant_types migration is required for integer-based cl…

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -155,12 +155,13 @@ Alternatively, you may disable this validation entirely (not recommended) by set
 Passport::$validateKeyPermissions = false;
 ```
 
-### OAuth Client Table Changes (Optional)
+### OAuth Client Table Changes
 
 PR: https://github.com/laravel/passport/pull/1744, https://github.com/laravel/passport/pull/1797
 
+Passport 13 introduces a new schema for the `oauth_clients` table. However, these changes are **fully backward compatible**, and **no action is required** on your part.
 
-Passport 13 introduces a new schema for the `oauth_clients` table. However, These changes are **fully backward compatible**, and **no action is required** on your part.
+> **Note:** If you use integer-based client IDs (`Passport::$clientUuids = false`), running this migration is **strongly recommended**. Without it, any user whose integer ID matches a client ID will have their token requests incorrectly rejected with a 401. See [#1912](https://github.com/laravel/passport/issues/1912) for details.
 
 For reference, here are the changes on the `oauth_clients` table:
 


### PR DESCRIPTION
The UPGRADE.md entry for the oauth_clients table changes was marked as (Optional) with the note that "no action is required." While technically true for most setups, this is misleading for applications using integer-based client IDs (Passport::$clientUuids = false).

  The security fix introduced in #1901 and #1902 relies on hasGrantType('client_credentials') in TokenGuard. Without the grant_types migration, the fallback computes grant types based on client properties (confidential() && firstParty()), which causes any user whose integer ID matches a client ID to have their token
  requests incorrectly rejected with a 401.

  This PR removes (Optional) from the section title and adds a note recommending the migration for integer-based client ID setups. Related to #1912.