### PR TITLE
Fix enum support for database connection name

### DIFF
--- a/src/AuthCode.php
+++ b/src/AuthCode.php
@@ -69,6 +69,6 @@ class AuthCode extends Model
      */
     public function getConnectionName(): ?string
     {
-        return $this->connection ?? config('passport.connection');
+        return parent::getConnectionName() ?? config('passport.connection');
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -227,7 +227,7 @@ class Client extends Model
      */
     public function getConnectionName(): ?string
     {
-        return $this->connection ?? config('passport.connection');
+        return parent::getConnectionName() ?? config('passport.connection');
     }
 
     /**

--- a/src/DeviceCode.php
+++ b/src/DeviceCode.php
@@ -59,6 +59,6 @@ class DeviceCode extends Model
      */
     public function getConnectionName(): ?string
     {
-        return $this->connection ?? config('passport.connection');
+        return parent::getConnectionName() ?? config('passport.connection');
     }
 }

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -75,6 +75,6 @@ class RefreshToken extends Model
      */
     public function getConnectionName(): ?string
     {
-        return $this->connection ?? config('passport.connection');
+        return parent::getConnectionName() ?? config('passport.connection');
     }
 }

--- a/src/Token.php
+++ b/src/Token.php
@@ -119,6 +119,6 @@ class Token extends Model
      */
     public function getConnectionName(): ?string
     {
-        return $this->connection ?? config('passport.connection');
+        return parent::getConnectionName() ?? config('passport.connection');
     }
 }


### PR DESCRIPTION
Laravel by default has support for enum in the database connection, it does it by using the function `enum_value($this->connection)` in `getConnectionName()`, but this package it's `getConnectionName()` before my change was:
```php
/**
 * Get the current connection name for the model.
*/
public function getConnectionName(): ?string
{
    return $this->connection ?? config('passport.connection');
}
```

So in case of an enum, the return type is invalid.

This PR fixes it by using the `parent::getConnectionName()` as base and then fallback to the config file.

```php
/**
 * Get the current connection name for the model.
*/
public function getConnectionName(): ?string
{
    return parent::getConnectionName() ?? config('passport.connection');
}
```

This seems like a more scalable solution for the future if the base eloquent model ever changes.

Should be a simple fix.