### PR TITLE
Upgrade phpseclib to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "illuminate/support": "^11.35|^12.0|^13.0",
         "league/oauth2-server": "^9.2",
         "php-http/discovery": "^1.20",
-        "phpseclib/phpseclib": "^3.0",
+        "phpseclib/phpseclib": "^4.0",
         "psr/http-factory-implementation": "*",
         "symfony/console": "^7.1|^8.0",
         "symfony/psr-http-message-bridge": "^7.1|^8.0"

--- a/src/Console/KeysCommand.php
+++ b/src/Console/KeysCommand.php
@@ -4,7 +4,7 @@ namespace Laravel\Passport\Console;
 
 use Illuminate\Console\Command;
 use Laravel\Passport\Passport;
-use phpseclib3\Crypt\RSA;
+use phpseclib4\Crypt\RSA;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'passport:keys')]


### PR DESCRIPTION
This resolves a phpseclib package conflict I was having with the latest version of passport and socialite: #1938

Changes made:
- updated passport's phpseclib requirement from ^3.0 to ^4.0
- updated the KeysCommand to import from the new package

Ran the following validations:
- composer update --prefer-dist --no-interaction --no-progress
- composer check-platform-reqs --no-interaction
- vendor/bin/phpunit --display-deprecations --display-phpunit-deprecations
- php -d memory_limit=512M vendor/bin/phpstan analyse --no-progress --memory-limit=512M
- composer validate --strict

All passed without issues.  This can be considered a companion PR to the socialite one here: https://github.com/laravel/socialite/pull/791